### PR TITLE
The text areas in the "Detailed Transfer Status for [form]" Dialog an…

### DIFF
--- a/src/org/opendatakit/briefcase/ui/ScrollingStatusListDialog.java
+++ b/src/org/opendatakit/briefcase/ui/ScrollingStatusListDialog.java
@@ -70,6 +70,7 @@ public class ScrollingStatusListDialog extends JDialog implements ActionListener
     getRootPane().setDefaultButton(cancelButton);
 
     JEditorPane editorArea = new JEditorPane("text/plain", statusHtml);
+    editorArea.setEditable(false);
   //Put the editor pane in a scroll pane.
     JScrollPane editorScrollPane = new JScrollPane(editorArea);
     editorScrollPane.setVerticalScrollBarPolicy(


### PR DESCRIPTION
…d the "Export Details for [form]" Dialog are now set to editable false.  Fix #26.

I set the <tt>isEditable</tt> flag on the <tt>JEditorPane</tt> that gets used to display the details to <tt>false</tt>.
By doing this, the editor pane can´t be edited anymore. 

The <b>problem description</b> only mentioned, that the text area in the <tt>Detailed Transfer Status for [form]</tt> Dialog was editable. The same behavior could also be observed in the <tt>Export Details for [form]</tt> Dialog.

The implemented fix also ensures, that the <tt>Export Details for [form]</tt> Dialog editor pane can´t be edited. <br><br>I believe, this is the desired behavior for both Dialogs.