### PR TITLE
This resolves #22. The last successful server setting for both push and

### DIFF
--- a/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
+++ b/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
@@ -62,14 +62,43 @@ public class BriefcasePreferences {
     return new BriefcasePreferences(node, PreferenceScope.CLASS_NAME);
   }
   
+  /**
+   * Returns the value associated with the specified key in this preference
+   * node. Returns the specified default if there is no value associated with
+   * the key, or the backing store is inaccessible.
+   * 
+   * @param key
+   *          key whose associated value is to be returned.
+   * @param defaultValue
+   *          the value to be returned in the event that this preference node
+   *          has no value associated with key.
+   * @return the value associated with key, or defaultValue if no value is associated
+   *         with key, or the backing store is inaccessible.
+   */
   public String get(String key, String defaultValue) {
     return preferences.get(key, defaultValue);
   }
   
+  /**
+   * Associates the specified value with the specified key in this preference
+   * node.
+   * 
+   * @param key
+   *          key with which the specified value is to be associated.
+   * @param value
+   *          value to be associated with the specified key.
+   */
   public void put(String key, String value) {
     preferences.put(key, value);
   }
   
+  /**
+   * Removes the value associated with the specified key in this preference
+   * node, if any.
+   * 
+   * @param key
+   *          key whose mapping is to be removed from the preference node.
+   */
   public void remove(String key) {
     preferences.remove(key);
   }

--- a/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
+++ b/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
@@ -47,14 +47,6 @@ public class BriefcasePreferences {
   }
   
   /**
-   * Factory that returns the application scoped <tt>BriefcasePreferences</tt> object.
-   * The method always return the same instance.
-   */
-  public static BriefcasePreferences applicationScoped() {
-    return Preference.APPLICATION_SCOPED;
-  }
-  
-  /**
    * Factory that creates a class scoped <tt>BriefcasePreferences</tt> object. 
    * @param node the managing class
    */
@@ -140,11 +132,11 @@ public class BriefcasePreferences {
   }
   
   /**
-   * Static member class, that holds the instance to the application scoped
-   * <tt>BriefcasePreferences</tt> object. Initializing the instance in this class, enables us to lazy-load the instance when
-   * {@link org.opendatakit.briefcase.model.BriefcasePreferences#applicationScoped
-   * BriefcasePreferences.applicationScoped()} is executed. The initialization is therefore not
-   * bound to the loading of the <tt>BriefcasePreferences</tt> class.
+   * Through this static nested class, we implement the Initialization-on-demand
+   * holder idiom. It enables a safe, highly concurrent lazy initialization for
+   * singletons. For more information on this idiom, please refer to <a href=
+   * "https://en.wikipedia.org/wiki/Initialization-on-demand_holder_idiom">
+   * Initialization-on-demand holder idiom</a>.
    */
   private static class Preference {
     private static final BriefcasePreferences APPLICATION_SCOPED =

--- a/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
+++ b/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
@@ -21,39 +21,104 @@ import java.util.prefs.Preferences;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
+/**
+ * This class is used to manage the applications preferences. It achieves this task, by using the standard
+ * {@link java.util.prefs.Preferences Preferences API}.
+ */
 public class BriefcasePreferences {
-
+  
   public static final String VERSION = "v1.4.9 Production";
+  public static final String USERNAME = "username";
+  public static final String TOKEN = "token";
+  public static final String AGGREGATE_1_0_URL = "url_1_0";
+  public static final String AGGREGATE_0_9_X_URL = "url_0_9_X";
+  
+  private static final String BRIEFCASE_DIR_PROPERTY = "briefcaseDir";
+  
+  static {
+    // load the security provider
+    Security.addProvider(new BouncyCastleProvider());
+  }
+
+  private final Preferences preferences;
+  
+  private BriefcasePreferences(Class<?> node, PreferenceScope scope) {
+    this.preferences = scope.preferenceFactory(node);
+  }
+  
+  /**
+   * Factory that returns the application scoped <tt>BriefcasePreferences</tt> object.
+   * The method always return the same instance.
+   */
+  public static BriefcasePreferences applicationScoped() {
+    return Preference.APPLICATION_SCOPED;
+  }
+  
+  /**
+   * Factory that creates a class scoped <tt>BriefcasePreferences</tt> object. 
+   * @param node the managing class
+   */
+  public static BriefcasePreferences forClass(Class<?> node) {
+    return new BriefcasePreferences(node, PreferenceScope.CLASS_NAME);
+  }
+  
+  public String get(String key, String defaultValue) {
+    return preferences.get(key, defaultValue);
+  }
+  
+  public void put(String key, String value) {
+    preferences.put(key, value);
+  }
+  
+  public void remove(String key) {
+    preferences.remove(key);
+  }
 
   public static void setBriefcaseDirectoryProperty(String value) {
-    if ( value == null ) {
-      getApplicationPreferences().remove(BRIEFCASE_DIR_PROPERTY);
+    if (value == null) {
+      Preference.APPLICATION_SCOPED.remove(BRIEFCASE_DIR_PROPERTY);
     } else {
-      getApplicationPreferences().put(BriefcasePreferences.BRIEFCASE_DIR_PROPERTY, value);
+      Preference.APPLICATION_SCOPED.put(BriefcasePreferences.BRIEFCASE_DIR_PROPERTY, value);
     }
   }
 
   public static String getBriefcaseDirectoryIfSet() {
-    return getApplicationPreferences().get(BriefcasePreferences.BRIEFCASE_DIR_PROPERTY,null);
+    return Preference.APPLICATION_SCOPED.get(BriefcasePreferences.BRIEFCASE_DIR_PROPERTY, null);
   }
 
   public static String getBriefcaseDirectoryProperty() {
-    return getApplicationPreferences().get(BriefcasePreferences.BRIEFCASE_DIR_PROPERTY,
+    return Preference.APPLICATION_SCOPED.get(BriefcasePreferences.BRIEFCASE_DIR_PROPERTY,
         System.getProperty("user.home"));
   }
-
-  private static final String BRIEFCASE_DIR_PROPERTY = "briefcaseDir";
-
-  private static Preferences applicationPreferences = null;
-
-  private static synchronized Preferences getApplicationPreferences() {
-    if ( applicationPreferences == null ) {
-      // as good a place as any to do one-time initialization...
-      Security.addProvider(new BouncyCastleProvider());
-      // and load the preferences...
-      applicationPreferences = Preferences.userNodeForPackage(BriefcasePreferences.class);
-    }
-    return applicationPreferences;
+  
+  /**
+   * Enum that implements the strategies, to create differently scoped preferences.
+   */
+  private enum PreferenceScope {
+    APPLICATION {
+      @Override
+      public Preferences preferenceFactory(Class<?> node) {
+        return Preferences.userNodeForPackage(node);
+      }
+    },
+    CLASS_NAME {
+      @Override
+      public Preferences preferenceFactory(Class<?> node) {
+        return Preferences.userRoot().node(node.getName());
+      }
+    };
+    public abstract Preferences preferenceFactory(Class<?> node);
   }
-
+  
+  /**
+   * Static member class, that holds the instance to the application scoped
+   * <tt>BriefcasePreferences</tt> object. Initializing the instance in this class, enables us to lazy-load the instance when
+   * {@link org.opendatakit.briefcase.model.BriefcasePreferences#applicationScoped
+   * BriefcasePreferences.applicationScoped()} is executed. The initialization is therefore not
+   * bound to the loading of the <tt>BriefcasePreferences</tt> class.
+   */
+  private static class Preference {
+    private static final BriefcasePreferences APPLICATION_SCOPED =
+        new BriefcasePreferences(BriefcasePreferences.class, PreferenceScope.APPLICATION);
+  }
 }


### PR DESCRIPTION
pull will now be saved as a preference.

I am not entirely sure, why GitHub is marking the entire files as changed. I tried every whitespace setting I could find, but nothing changes. My local diff also seems to be working fine. If reviewing the pull request like this is too much work, I will investigate a little more and hopefully find a solution. 

To implement the feature, I extended the functionality of the <tt>BriefcasePrefereces</tt> class, so that we are now able to manage preferences per class and not only application wide. 

The username and URL are saved as a preference after they have been successfully used to connect to a server. If an <b>Aggregate 0.9.x</b> server is used, the URL and token are saved. The preferences for Aggregate 1.0 and Aggregate 0.9.x servers are managed <b>separately</b> by the pull tab.

To load the preferences into the server connection dialog, I used the already supplied <tt>ServerConnectionInfo</tt> class and added the username/ token and URL on instance initialization.
The contents of the instance are then displayed by the connection dialog. 

