### PR TITLE
Removed setForeground from Details button Fixes #25

### DIFF
--- a/src/org/opendatakit/briefcase/ui/FormTransferTable.java
+++ b/src/org/opendatakit/briefcase/ui/FormTransferTable.java
@@ -58,10 +58,8 @@ public class FormTransferTable extends JTable {
     @Override public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
       JButton button = (JButton)value;
       if (isSelected) {
-        button.setForeground(table.getSelectionForeground());
         button.setBackground(table.getSelectionBackground());
       } else {
-        button.setForeground(table.getForeground());
         button.setBackground(UIManager.getColor("Button.background"));
       }
       return button;   


### PR DESCRIPTION
Removed unnecessary setForeground call to JButton that cause button label to disappear.

**Before:**
![25_before](https://cloud.githubusercontent.com/assets/3234126/21570978/24ad54b6-cecb-11e6-8b3b-c8b5bfcd786f.png)

**After:**
![25_after](https://cloud.githubusercontent.com/assets/3234126/21570979/27658d04-cecb-11e6-928b-20ea145125b2.png)
