### PR TITLE
Changed the ScrollingStatusListDialog to live update.

### DIFF
--- a/src/org/opendatakit/briefcase/ui/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/ExportPanel.java
@@ -45,6 +45,7 @@ import org.opendatakit.briefcase.model.ExportProgressEvent;
 import org.opendatakit.briefcase.model.ExportSucceededEvent;
 import org.opendatakit.briefcase.model.ExportType;
 import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
+import org.opendatakit.briefcase.model.IFormDefinition;
 import org.opendatakit.briefcase.model.TerminationFuture;
 import org.opendatakit.briefcase.model.TransferFailedEvent;
 import org.opendatakit.briefcase.model.TransferSucceededEvent;
@@ -154,7 +155,7 @@ public class ExportPanel extends JPanel {
      */
     private static final long serialVersionUID = -5106358166776020642L;
 
-    private String formName;
+    private IFormDefinition form;
     private String dirName;
     @SuppressWarnings("unused")
     private ExportType type;
@@ -165,8 +166,7 @@ public class ExportPanel extends JPanel {
     }
 
     public void setContext() {
-      formName =
-          ((BriefcaseFormDefinition) comboBoxForm.getSelectedItem()).getFormName();
+      form = ((IFormDefinition) comboBoxForm.getSelectedItem());
       type = (ExportType) comboBoxExportType.getSelectedItem();
       File outputDir = new File(txtExportDirectory.getText());
       dirName = outputDir.getAbsolutePath();
@@ -183,7 +183,7 @@ public class ExportPanel extends JPanel {
       try {
         setEnabled(false);
         ScrollingStatusListDialog.showExportDialog(JOptionPane.getFrameForComponent(this),
-            formName, dirName, history);
+            form, dirName, history);
       } finally {
         setEnabled(true);
       }

--- a/src/org/opendatakit/briefcase/ui/FormTransferTable.java
+++ b/src/org/opendatakit/briefcase/ui/FormTransferTable.java
@@ -122,9 +122,8 @@ public class FormTransferTable extends JTable {
     public void actionPerformed(ActionEvent e) {
       try {
         final String history = status.getStatusHistory();
-        final String formName = status.getFormName();
         setEnabled(false);
-        ScrollingStatusListDialog.showDialog(JOptionPane.getFrameForComponent(this), formName, history);
+        ScrollingStatusListDialog.showDialog(JOptionPane.getFrameForComponent(this), status.getFormDefinition(), history);
       } finally {
         setEnabled(true);
       }

--- a/src/org/opendatakit/briefcase/ui/MainFormUploaderWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainFormUploaderWindow.java
@@ -264,7 +264,7 @@ public class MainFormUploaderWindow {
       public void actionPerformed(ActionEvent e) {
         if ( fs != null ) {
           ScrollingStatusListDialog.showDialog(
-            MainFormUploaderWindow.this.frame, fs.getFormName(), fs.getStatusHistory());
+            MainFormUploaderWindow.this.frame, fs.getFormDefinition(), fs.getStatusHistory());
         }
       }});
 

--- a/src/org/opendatakit/briefcase/ui/ScrollingStatusListDialog.java
+++ b/src/org/opendatakit/briefcase/ui/ScrollingStatusListDialog.java
@@ -117,8 +117,8 @@ public class ScrollingStatusListDialog extends JDialog implements ActionListener
 
   @EventSubscriber(eventClass = FormStatusEvent.class)
   public void onEvent(FormStatusEvent event) {
-    // Since there can be multiple downloads running and therefore publishing events
-    // at the same time, we have to check if the event is meant for this dialog instance.
+    // Since there can be multiple FormStatusEvent's published concurrently,
+    // we have to check if the event is meant for this dialog instance.
     if (event.getStatus().getFormDefinition().equals(form)) {
       editorArea.setText(event.getStatus().getStatusHistory());
     }

--- a/src/org/opendatakit/briefcase/ui/ScrollingStatusListDialog.java
+++ b/src/org/opendatakit/briefcase/ui/ScrollingStatusListDialog.java
@@ -32,9 +32,17 @@ import javax.swing.JEditorPane;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import javax.swing.text.JTextComponent;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.bushe.swing.event.annotation.AnnotationProcessor;
 import org.bushe.swing.event.annotation.EventSubscriber;
+import org.opendatakit.briefcase.model.ExportFailedEvent;
+import org.opendatakit.briefcase.model.ExportProgressEvent;
+import org.opendatakit.briefcase.model.ExportSucceededEvent;
 import org.opendatakit.briefcase.model.FormStatusEvent;
 import org.opendatakit.briefcase.model.IFormDefinition;
 
@@ -44,6 +52,7 @@ public class ScrollingStatusListDialog extends JDialog implements ActionListener
    * 
    */
   private static final long serialVersionUID = 3565952263140071560L;
+  private static final Log log = LogFactory.getLog(ScrollingStatusListDialog.class.getName());
 
   private final JEditorPane editorArea;
   private final IFormDefinition form;
@@ -121,6 +130,30 @@ public class ScrollingStatusListDialog extends JDialog implements ActionListener
     // we have to check if the event is meant for this dialog instance.
     if (event.getStatus().getFormDefinition().equals(form)) {
       editorArea.setText(event.getStatus().getStatusHistory());
+    }
+  }
+  
+  @EventSubscriber(eventClass = ExportProgressEvent.class)
+  public void onEvent(ExportProgressEvent event) {
+    appendToDocument(editorArea, event.getText());
+  }
+  
+  @EventSubscriber(eventClass = ExportFailedEvent.class)
+  public void onEvent(ExportFailedEvent event) {
+    appendToDocument(editorArea,"FAILED!");
+  }
+
+  @EventSubscriber(eventClass = ExportSucceededEvent.class)
+  public void onEvent(ExportSucceededEvent event) {
+    appendToDocument(editorArea,"SUCCEEDED!");
+  }
+
+  private void appendToDocument(JTextComponent component, String msg) {
+    Document doc = component.getDocument();
+    try {
+      doc.insertString(doc.getLength(), "\n" + msg, null);
+    } catch(BadLocationException e) {
+      log.error("Insertion failed: " + e.getMessage());
     }
   }
 


### PR DESCRIPTION
This PR Resolves #53.

To implement this, I had to modify the <tt>ScrollingStatusListDialog</tt> to hold an instance of the form, it displays information for. This was needed, because <tt>ScrollingStatusListDialog</tt> instances have to filter out FormStatusEvents, that are <b>concurrently</b> published for different forms (e.g. when downloading multiple forms).