### PR TITLE
util/ExportToCsv: On export, only create media folder when needed

### DIFF
--- a/src/org/opendatakit/briefcase/util/ExportToCsv.java
+++ b/src/org/opendatakit/briefcase/util/ExportToCsv.java
@@ -117,16 +117,6 @@ public class ExportToCsv implements ITransformFormAction {
       }
     }
 
-    if (exportMedia) {
-       if (!outputMediaDir.exists()) {
-         if (!outputMediaDir.mkdir()) {
-           EventBus
-               .publish(new ExportProgressEvent("Unable to create destination media directory"));
-           return false;
-         }
-       }
-    }
-
     if (!processFormDefinition()) {
       // weren't able to initialize the csv file...
       return false;
@@ -432,6 +422,13 @@ public class ExportToCsv implements ITransformFormAction {
             first = false;
           } else {
             if (exportMedia) {
+               if (!outputMediaDir.exists()) {
+                  if (!outputMediaDir.mkdir()) {
+                    EventBus.publish(new ExportProgressEvent("Unable to create destination media directory"));
+                    return false;
+                  }
+               }
+               
                int dotIndex = binaryFilename.lastIndexOf(".");
                String namePart = (dotIndex == -1) ? binaryFilename : binaryFilename.substring(0,
                    dotIndex);


### PR DESCRIPTION
Shift the code portion creating media folder to emitSubmissionCsv (to the case where binary data is being handled).

Fix #70