### PR TITLE
On the initial launch if the user press "Cancel" on briefcase storage location selection dialog, user is end up having a disabled main window #87

### DIFF
--- a/src/org/opendatakit/briefcase/ui/BriefcaseStorageLocationDialog.java
+++ b/src/org/opendatakit/briefcase/ui/BriefcaseStorageLocationDialog.java
@@ -45,7 +45,7 @@ public class BriefcaseStorageLocationDialog extends JDialog implements ActionLis
   JEditorPane lblTheBriefcaseStorage;
   private JTextField txtBriefcaseLocation;
   private JButton btnOK;
-  private JButton btnCancel;
+  private JButton btnQuit;
   private boolean isCancelled = false;
 
   public BriefcaseStorageLocationDialog(Window app) {
@@ -102,13 +102,12 @@ public class BriefcaseStorageLocationDialog extends JDialog implements ActionLis
         }
       }});
     
-    btnCancel = new JButton("Cancel");
-    btnCancel.addActionListener(new ActionListener(){
+    btnQuit = new JButton("Quit");
+    btnQuit.addActionListener(new ActionListener(){
 
       @Override
       public void actionPerformed(ActionEvent e) {
-        isCancelled = true;
-        BriefcaseStorageLocationDialog.this.setVisible(false);
+        System.exit(0);
       }});
     
     GroupLayout groupLayout = new GroupLayout(getContentPane());
@@ -125,7 +124,7 @@ public class BriefcaseStorageLocationDialog extends JDialog implements ActionLis
             .addGroup(Alignment.TRAILING, groupLayout.createSequentialGroup()
                   .addComponent(btnOK)
                   .addPreferredGap(ComponentPlacement.RELATED)
-                  .addComponent(btnCancel))))
+                  .addComponent(btnQuit))))
         .addContainerGap()
     );
     groupLayout.setVerticalGroup(groupLayout.createSequentialGroup()
@@ -140,7 +139,7 @@ public class BriefcaseStorageLocationDialog extends JDialog implements ActionLis
           .addPreferredGap(ComponentPlacement.RELATED)
           .addGroup(groupLayout.createParallelGroup(Alignment.BASELINE)
             .addComponent(btnOK)
-            .addComponent(btnCancel))
+            .addComponent(btnQuit))
           .addContainerGap());
     getContentPane().setLayout(groupLayout);   
     pack();

--- a/src/org/opendatakit/briefcase/ui/BriefcaseStorageLocationDialog.java
+++ b/src/org/opendatakit/briefcase/ui/BriefcaseStorageLocationDialog.java
@@ -178,4 +178,15 @@ public class BriefcaseStorageLocationDialog extends JDialog implements ActionLis
       }
     }
   }
+
+  public void updateForSettingsPage() {
+	btnQuit.setText("Cancel");
+	btnQuit.removeActionListener(btnQuit.getActionListeners()[0]);
+	btnQuit.addActionListener(new ActionListener(){
+	  @Override
+	  public void actionPerformed(ActionEvent e) {
+		  isCancelled = true;
+	      BriefcaseStorageLocationDialog.this.setVisible(false);
+	  }});
+  }
 }

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -396,6 +396,12 @@ public class MainBriefcaseWindow implements WindowListener {
       // ask for new briefcase location...
       BriefcaseStorageLocationDialog fs =
           new BriefcaseStorageLocationDialog(MainBriefcaseWindow.this.frame);
+      
+      // If reset is not needed, dialog has been triggered from Settings page
+      if(!reset) {
+    	  fs.updateForSettingsPage();
+      }
+      
       fs.setVisible(true);
       if ( fs.isCancelled() ) {
         // if we need to reset the briefcase location,


### PR DESCRIPTION
Fixes #87

How to test
1. Move/Rename your briefcase storage.
2. Start ODK briefcase. You will see the folder selection dialog. 
3. Press Cancel. Application should quit. Restart the briefcase dialog. You should still see the folder selection dialog
4. This time choose a proper folder and press ok. App should be enabled. 