### PR TITLE
Re-download deleted submission file during next pull from aggregate server fixes #92

### DIFF
--- a/src/org/opendatakit/briefcase/util/ServerFetcher.java
+++ b/src/org/opendatakit/briefcase/util/ServerFetcher.java
@@ -351,7 +351,8 @@ public class ServerFetcher {
       if ( instanceFolder != null ) {
           //check if the submission file is present in the folder before skipping
           File instance = new File(instanceFolder, "submission.xml");
-          if (instance.exists()) {
+          File instanceEncrypted = new File(instanceFolder, "submission.xml.enc");
+          if (instance.exists() || instanceEncrypted.exists()) {
               logger.info("already present - skipping fetch: " + uri );
               return;
           }

--- a/src/org/opendatakit/briefcase/util/ServerFetcher.java
+++ b/src/org/opendatakit/briefcase/util/ServerFetcher.java
@@ -347,10 +347,15 @@ public class ServerFetcher {
   private void downloadSubmission(File formInstancesDir, DatabaseUtils formDatabase, BriefcaseFormDefinition lfd, FormStatus fs,
       String uri) throws Exception {
 
-    if ( formDatabase.hasRecordedInstance(uri) != null ) {
-      logger.info("already present - skipping fetch: " + uri );
-      return;
-    }
+      File instanceFolder = formDatabase.hasRecordedInstance(uri);
+      if ( instanceFolder != null ) {
+          //check if the submission file is present in the folder before skipping
+          File instance = new File(instanceFolder, "submission.xml");
+          if (instance.exists()) {
+              logger.info("already present - skipping fetch: " + uri );
+              return;
+          }
+      }
 
     String formId = lfd.getSubmissionKey(uri);
 


### PR DESCRIPTION
When the submission file is deleted from the the instance folder. During the next pull from aggregate the submission file should be re-downloaded but master doesn't re-download the submission file.
A submission file is deleted as shown here
![beforepull](https://cloud.githubusercontent.com/assets/14994500/24818572/fa0c8ea6-1bd8-11e7-84c1-bf066006e5de.png)

During the next pull it is re-downloaded as shown
![afterpull](https://cloud.githubusercontent.com/assets/14994500/24818587/12516072-1bd9-11e7-8024-f47d57643974.png)

so this pull request solves issue #92 
