### PR TITLE
add eclipse project support to build.gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ local.properties
 .idea
 .DS_Store
 build
+.project
+.classpath
+.settings

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'application'
     id 'checkstyle'
     id 'de.fuerstenau.buildconfig' version '1.1.8'
+    id 'eclipse'
 }
 
 repositories {


### PR DESCRIPTION
I'm more comfortable with Eclipse than IntelliJ, and since this was a one-line change I thought it would be acceptable to give folks options?