### PR TITLE
ui/MainBriefcaseWindow: Make "f" flag more generic

### DIFF
--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -552,10 +552,10 @@ public class MainBriefcaseWindow implements WindowListener {
         .build();
 
     Option exportFilename = Option.builder("f")
-        .argName("name.csv")
+        .argName("name.format")
         .hasArg()
         .longOpt(EXPORT_FILENAME)
-        .desc("File name for exported CSV")
+        .desc("File name for exported format")
         .build();
 
     Option overwrite = Option.builder("oc")


### PR DESCRIPTION
Change "-f" (export_filename) flag from CSV specific to a more general one in CLI option

Fix #118