### PR TITLE
Fixed #141: App responsiveness degrades proportionally with form hist…

### DIFF
--- a/src/org/opendatakit/briefcase/model/FormStatus.java
+++ b/src/org/opendatakit/briefcase/model/FormStatus.java
@@ -60,7 +60,6 @@ public class FormStatus {
     }
     statusHistory.append("\n");
     statusHistory.append(statusString);
-    // statusHistory.append("</p>");
     this.isSuccessful = this.isSuccessful && isSuccessful;
   }
 

--- a/src/org/opendatakit/briefcase/model/FormStatus.java
+++ b/src/org/opendatakit/briefcase/model/FormStatus.java
@@ -25,7 +25,7 @@ public class FormStatus {
   private String statusString = "";
   private final StringBuilder statusHistory = new StringBuilder();
   private boolean isSuccessful = true;
-  private int historyMaxSize = 8096;
+  private int historyMaxSize = 8192;
 
   public FormStatus(TransferType transferType, IFormDefinition form) {
     this.transferType = transferType;

--- a/src/org/opendatakit/briefcase/model/FormStatus.java
+++ b/src/org/opendatakit/briefcase/model/FormStatus.java
@@ -18,6 +18,9 @@ package org.opendatakit.briefcase.model;
 
 
 public class FormStatus {
+
+  public static final int STATUS_HISTORY_MAX_BYTES = 1024 * 1024;
+
   public enum TransferType { GATHER, UPLOAD };
   private final TransferType transferType;
   private boolean isSelected = false;
@@ -25,7 +28,6 @@ public class FormStatus {
   private String statusString = "";
   private final StringBuilder statusHistory = new StringBuilder();
   private boolean isSuccessful = true;
-  private int historyMaxSize = 8192;
 
   public FormStatus(TransferType transferType, IFormDefinition form) {
     this.transferType = transferType;
@@ -55,7 +57,7 @@ public class FormStatus {
 
   public void setStatusString(String statusString, boolean isSuccessful) {
     this.statusString = statusString;
-    if (statusHistory.length() > historyMaxSize) {
+    if (statusHistory.length() > STATUS_HISTORY_MAX_BYTES) {
       trimHistory(statusString.length());
     }
     statusHistory.append("\n");

--- a/src/org/opendatakit/briefcase/model/FormStatus.java
+++ b/src/org/opendatakit/briefcase/model/FormStatus.java
@@ -56,16 +56,20 @@ public class FormStatus {
   public void setStatusString(String statusString, boolean isSuccessful) {
     this.statusString = statusString;
     if (statusHistory.length() > historyMaxSize) {
-      statusHistory.delete(0, statusString.length() + 1);
-      int lineEnd = statusHistory.indexOf("\n");
-      if (lineEnd >= 0) {
-        statusHistory.delete(0, lineEnd+1);
-      }
+      trimHistory(statusString.length());
     }
     statusHistory.append("\n");
     statusHistory.append(statusString);
     // statusHistory.append("</p>");
     this.isSuccessful = this.isSuccessful && isSuccessful;
+  }
+
+  private void trimHistory(int len) {
+    statusHistory.delete(0, len + 1);
+    int lineEnd = statusHistory.indexOf("\n");
+    if (lineEnd >= 0) {
+      statusHistory.delete(0, lineEnd + 1);
+    }
   }
 
   public String getStatusHistory() {

--- a/src/org/opendatakit/briefcase/model/FormStatus.java
+++ b/src/org/opendatakit/briefcase/model/FormStatus.java
@@ -25,6 +25,7 @@ public class FormStatus {
   private String statusString = "";
   private final StringBuilder statusHistory = new StringBuilder();
   private boolean isSuccessful = true;
+  private int historyMaxSize = 8096;
 
   public FormStatus(TransferType transferType, IFormDefinition form) {
     this.transferType = transferType;
@@ -54,6 +55,13 @@ public class FormStatus {
 
   public void setStatusString(String statusString, boolean isSuccessful) {
     this.statusString = statusString;
+    if (statusHistory.length() > historyMaxSize) {
+      statusHistory.delete(0, statusString.length() + 1);
+      int lineEnd = statusHistory.indexOf("\n");
+      if (lineEnd >= 0) {
+        statusHistory.delete(0, lineEnd+1);
+      }
+    }
     statusHistory.append("\n");
     statusHistory.append(statusString);
     // statusHistory.append("</p>");

--- a/src/org/opendatakit/briefcase/ui/ScrollingStatusListDialog.java
+++ b/src/org/opendatakit/briefcase/ui/ScrollingStatusListDialog.java
@@ -22,6 +22,8 @@ import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.io.IOException;
+import java.io.StringReader;
 
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -128,8 +130,12 @@ public class ScrollingStatusListDialog extends JDialog implements ActionListener
   public void onEvent(FormStatusEvent event) {
     // Since there can be multiple FormStatusEvent's published concurrently,
     // we have to check if the event is meant for this dialog instance.
-    if (event.getStatus().getFormDefinition().equals(form)) {
-      editorArea.setText(event.getStatus().getStatusHistory());
+    if (isShowing() && event.getStatus().getFormDefinition().equals(form)) {
+      try {
+        editorArea.read(new StringReader(event.getStatus().getStatusHistory()), null);
+      } catch (IOException e) {
+        log.warn("failed to load history", e);
+      }
     }
   }
   

--- a/src/org/opendatakit/briefcase/ui/ScrollingStatusListDialog.java
+++ b/src/org/opendatakit/briefcase/ui/ScrollingStatusListDialog.java
@@ -128,7 +128,7 @@ public class ScrollingStatusListDialog extends JDialog implements ActionListener
   public void onEvent(FormStatusEvent event) {
     // Since there can be multiple FormStatusEvent's published concurrently,
     // we have to check if the event is meant for this dialog instance.
-    if (event.getStatus().getFormDefinition().equals(form)) {
+    if (isShowing() && event.getStatus().getFormDefinition().equals(form)) {
       try {
         Document doc = editorArea.getDocument();
         String latestStatus = "\n" + event.getStatusString();

--- a/src/org/opendatakit/briefcase/ui/ScrollingStatusListDialog.java
+++ b/src/org/opendatakit/briefcase/ui/ScrollingStatusListDialog.java
@@ -131,7 +131,7 @@ public class ScrollingStatusListDialog extends JDialog implements ActionListener
     if (event.getStatus().getFormDefinition().equals(form)) {
       try {
         Document doc = editorArea.getDocument();
-        String latestStatus = event.getStatus().getStatusString() + "\n";
+        String latestStatus = "\n" + event.getStatus().getStatusString();
         doc.insertString(doc.getLength(), latestStatus, null);
       } catch (BadLocationException e) {
         log.warn("failed to update history", e);

--- a/src/org/opendatakit/briefcase/ui/ScrollingStatusListDialog.java
+++ b/src/org/opendatakit/briefcase/ui/ScrollingStatusListDialog.java
@@ -22,8 +22,6 @@ import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.io.IOException;
-import java.io.StringReader;
 
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -130,11 +128,13 @@ public class ScrollingStatusListDialog extends JDialog implements ActionListener
   public void onEvent(FormStatusEvent event) {
     // Since there can be multiple FormStatusEvent's published concurrently,
     // we have to check if the event is meant for this dialog instance.
-    if (isShowing() && event.getStatus().getFormDefinition().equals(form)) {
+    if (event.getStatus().getFormDefinition().equals(form)) {
       try {
-        editorArea.read(new StringReader(event.getStatus().getStatusHistory()), null);
-      } catch (IOException e) {
-        log.warn("failed to load history", e);
+        Document doc = editorArea.getDocument();
+        String latestStatus = event.getStatus().getStatusString() + "\n";
+        doc.insertString(doc.getLength(), latestStatus, null);
+      } catch (BadLocationException e) {
+        log.warn("failed to update history", e);
       }
     }
   }

--- a/src/org/opendatakit/briefcase/ui/ScrollingStatusListDialog.java
+++ b/src/org/opendatakit/briefcase/ui/ScrollingStatusListDialog.java
@@ -131,7 +131,7 @@ public class ScrollingStatusListDialog extends JDialog implements ActionListener
     if (event.getStatus().getFormDefinition().equals(form)) {
       try {
         Document doc = editorArea.getDocument();
-        String latestStatus = "\n" + event.getStatus().getStatusString();
+        String latestStatus = "\n" + event.getStatusString();
         doc.insertString(doc.getLength(), latestStatus, null);
       } catch (BadLocationException e) {
         log.warn("failed to update history", e);


### PR DESCRIPTION
Improves application performance when form status history grows by bounding the history size, reducing memory allocations by using alternative `JEditorPane` API, and only updating the `JEditorPane` when it is actually showing.