### PR TITLE
Non-portable storage directories

### DIFF
--- a/src/org/opendatakit/briefcase/util/DatabaseUtils.java
+++ b/src/org/opendatakit/briefcase/util/DatabaseUtils.java
@@ -51,7 +51,7 @@ public class DatabaseUtils {
   private static final String INSERT_DML = "INSERT INTO recorded_instance (instanceId, directory) VALUES(?,?)";
   private static final String DELETE_DML = "DELETE FROM recorded_instance WHERE instanceId = ?";
 
-
+  final private File formDir;
   private Connection connection;
 
   private boolean hasRecordedInstanceTable = false;
@@ -59,8 +59,15 @@ public class DatabaseUtils {
   private PreparedStatement insertRecordedInstanceQuery = null;
   private PreparedStatement deleteRecordedInstanceQuery = null;
 
-  public DatabaseUtils(Connection connection) {
-    this.connection = connection;
+  public DatabaseUtils(File formDir) throws FileSystemException, SQLException {
+    this.formDir = formDir;
+    connect();
+  }
+
+  public void connect() throws FileSystemException, SQLException {
+    if (connection == null) {
+      connection = getConnection(getFormDatabaseUrl(formDir));
+    }
   }
 
   public void close() throws SQLException {
@@ -76,7 +83,7 @@ public class DatabaseUtils {
     try {
       connection.close();
     } finally {
-      connection =  null;
+      connection = null;
     }
   }
 
@@ -211,7 +218,7 @@ public class DatabaseUtils {
   }
 
   public static DatabaseUtils newInstance(File formDirectory) throws FileSystemException, SQLException {
-    return new DatabaseUtils(getConnection(getFormDatabaseUrl(formDirectory)));
+    return new DatabaseUtils(formDirectory);
   }
 
   static Connection getConnection(String jdbcUrl) throws SQLException {

--- a/src/org/opendatakit/briefcase/util/DatabaseUtils.java
+++ b/src/org/opendatakit/briefcase/util/DatabaseUtils.java
@@ -30,8 +30,11 @@ import java.sql.Statement;
 import java.util.Set;
 import java.util.TreeSet;
 
+import static org.opendatakit.briefcase.util.FileSystemUtils.INSTANCE_DIR;
 import static org.opendatakit.briefcase.util.FileSystemUtils.SMALLSQL_JDBC_PREFIX;
 import static org.opendatakit.briefcase.util.FileSystemUtils.getFormDatabaseUrl;
+import static org.opendatakit.briefcase.util.FileSystemUtils.isFormRelativeInstancePath;
+import static org.opendatakit.briefcase.util.FileSystemUtils.makeRelative;
 
 /**
  * This class abstracts all the functionality of the instance-tracking
@@ -45,11 +48,12 @@ public class DatabaseUtils {
   private static final Log log = LogFactory.getLog(DatabaseUtils.class);
 
   private static final String CREATE_DDL = "CREATE TABLE recorded_instance (instanceId varchar(256) primary key, directory varchar(4096))";
-  private static final String ASSERT_SQL = "SELECT instanceId FROM recorded_instance limit 1";
+  private static final String ASSERT_SQL = "SELECT instanceId, directory FROM recorded_instance limit 1";
   private static final String SELECT_ALL_SQL = "SELECT instanceId, directory FROM recorded_instance";
   private static final String SELECT_DIR_SQL = "SELECT directory FROM recorded_instance WHERE instanceId = ?";
   private static final String INSERT_DML = "INSERT INTO recorded_instance (instanceId, directory) VALUES(?,?)";
   private static final String DELETE_DML = "DELETE FROM recorded_instance WHERE instanceId = ?";
+  private static final String RELATIVE_DML = "UPDATE recorded_instance set directory = regexp_replace(directory,'.*(" + INSTANCE_DIR + ")','$1')";
 
   final private File formDir;
   private Connection connection;
@@ -89,8 +93,11 @@ public class DatabaseUtils {
 
   private void assertRecordedInstanceTable() throws SQLException {
     if (!hasRecordedInstanceTable) {
-      try (Statement stmt = connection.createStatement()) {
-        stmt.execute(ASSERT_SQL);
+      try (Statement stmt = connection.createStatement();
+           ResultSet rset = stmt.executeQuery(ASSERT_SQL)) {
+        if (rset.next() && !isFormRelativeInstancePath(rset.getString(2))) {
+          makeRecordedInstanceDirsRelative(connection);
+        }
         if (log.isDebugEnabled()) {
           dumpRecordedInstanceTable();
         }
@@ -99,6 +106,12 @@ public class DatabaseUtils {
         createRecordedInstanceTable(connection);
       }
       hasRecordedInstanceTable = true;
+    }
+  }
+
+  private void makeRecordedInstanceDirsRelative(Connection c) throws SQLException {
+    try (Statement stmt = c.createStatement()) {
+      stmt.execute(RELATIVE_DML);
     }
   }
 
@@ -120,7 +133,7 @@ public class DatabaseUtils {
   }
 
   // recorded instances have known instanceIds
-  public void putRecordedInstanceDirectory( String instanceId, File dir) {
+  public void putRecordedInstanceDirectory( String instanceId, File instanceDir) {
     try {
       assertRecordedInstanceTable();
 
@@ -130,7 +143,7 @@ public class DatabaseUtils {
       }
 
       insertRecordedInstanceQuery.setString(1, instanceId);
-      insertRecordedInstanceQuery.setString(2, dir.getAbsolutePath());
+      insertRecordedInstanceQuery.setString(2, makeRelative(formDir, instanceDir).toString());
 
       if ( 1 != insertRecordedInstanceQuery.executeUpdate() ) {
         throw new SQLException("Expected one row to be updated");
@@ -167,8 +180,7 @@ public class DatabaseUtils {
       assertRecordedInstanceTable();
 
       if ( getRecordedInstanceQuery == null ) {
-        getRecordedInstanceQuery =
-                connection.prepareStatement(SELECT_DIR_SQL);
+        getRecordedInstanceQuery = connection.prepareStatement(SELECT_DIR_SQL);
       }
 
       getRecordedInstanceQuery.setString(1, instanceId);
@@ -178,7 +190,7 @@ public class DatabaseUtils {
         if ( f != null ) {
           throw new SQLException("Duplicate entries for instanceId: " + instanceId);
         }
-        f = new File( values.getString(1) );
+        f = new File(formDir, values.getString(1));
       }
       return (f != null && f.exists() && f.isDirectory()) ? f : null;
     } catch ( SQLException e ) {
@@ -194,25 +206,23 @@ public class DatabaseUtils {
     putRecordedInstanceDirectory(instanceId, dir);
   }
 
-  public void updateInstanceLists( Set<File> instanceList ) {
-    Set<File> workingSet = new TreeSet<File>(instanceList);
-    // first, go through the database's reported set of directories
-    // removing all that aren't in the set...
-    Statement stmt = null;
-    try {
+  public void updateInstanceLists(Set<File> instanceList) {
+    Set<File> workingSet = new TreeSet<>(instanceList);
+    // scan the database's reported set of directories and remove all that are not in the set
+    try (Statement stmt = connection.createStatement()) {
       assertRecordedInstanceTable();
-      stmt = connection.createStatement();
-      ResultSet values = stmt.executeQuery(SELECT_ALL_SQL);
-      while ( values.next() ) {
-        String instanceId = values.getString(1);
-        File f = new File(values.getString(2));
-        if ( !f.exists() || !f.isDirectory() ) {
-          forgetRecordedInstance(instanceId);
-        } else {
-          workingSet.remove(f);
+      try (ResultSet values = stmt.executeQuery(SELECT_ALL_SQL)) {
+        while (values.next()) {
+          String instanceId = values.getString(1);
+          File f = new File(formDir, values.getString(2));
+          if (!f.exists() || !f.isDirectory()) {
+            forgetRecordedInstance(instanceId);
+          } else {
+            workingSet.remove(f);
+          }
         }
       }
-    } catch ( SQLException e ) {
+    } catch (SQLException e) {
       log.error("failure while pruning instance registry", e);
     }
   }

--- a/src/org/opendatakit/briefcase/util/FileSystemUtils.java
+++ b/src/org/opendatakit/briefcase/util/FileSystemUtils.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
+import java.nio.file.Path;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
@@ -66,10 +67,12 @@ public class FileSystemUtils {
   public static final String BRIEFCASE_DIR = "ODK Briefcase Storage";
   static final String README_TXT = "readme.txt";
   static final String FORMS_DIR = "forms";
+  static final String INSTANCE_DIR = "instances";
   static final String HSQLDB_DIR = "info.hsqldb";
   static final String HSQLDB_DB = "info";
   static final String SMALLSQL_DIR = "info.db";
   static final String HSQLDB_JDBC_PREFIX = "jdbc:hsqldb:file:";
+
   static final String SMALLSQL_JDBC_PREFIX = "jdbc:smallsql:";
 
   // encryption support....
@@ -354,17 +357,26 @@ public class FileSystemUtils {
   }
 
   public static File getFormInstancesDirectory(File formDirectory) throws FileSystemException {
-    File instancesDir = new File(formDirectory, "instances");
+    File instancesDir = new File(formDirectory, INSTANCE_DIR);
     if (!instancesDir.exists() && !instancesDir.mkdirs()) {
       throw new FileSystemException("unable to create directory: " + instancesDir.getAbsolutePath());
     }
     return instancesDir;
   }
 
-  public static Set<File> getFormSubmissionDirectories(File formDirectory) {
-    Set<File> files = new TreeSet<File>();
+  public static boolean isFormRelativeInstancePath(String path) {
+    return path.startsWith(INSTANCE_DIR);
+  }
 
-    File formInstancesDir = null;
+  public static Path makeRelative(File parent, File child) {
+    Path parentPath = parent.toPath(), childPath = child.toPath();
+    return parentPath.relativize(childPath);
+  }
+
+  public static Set<File> getFormSubmissionDirectories(File formDirectory) {
+    Set<File> files = new TreeSet<>();
+
+    File formInstancesDir;
     try {
       formInstancesDir = getFormInstancesDirectory(formDirectory);
     } catch (FileSystemException e) {


### PR DESCRIPTION
Fixes #149 by detecting and fixing instance tracking databases that use absolute paths. It makes them portable by using paths relative to the form directory.