### PR TITLE
Fixed #155: Redirect javarosa warnings from console to log file

### DIFF
--- a/src/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -126,7 +126,7 @@ public class BaseFormParserForJavaRosa {
   private static void redirectOutput() {
     File jrLogFile = new File(FileSystemUtils.getBriefcaseFolder(), ".briefcase-javarosa.log");
     try {
-      final PrintStream jrOut = new PrintStream(jrLogFile);
+      PrintStream jrOut = new PrintStream(jrLogFile);
       Std.setOut(jrOut);
       Std.setErr(jrOut);
     } catch (FileNotFoundException e) {

--- a/src/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -129,11 +129,6 @@ public class BaseFormParserForJavaRosa {
       final PrintStream jrOut = new PrintStream(jrLogFile);
       Std.setOut(jrOut);
       Std.setErr(jrOut);
-      Runtime.getRuntime().addShutdownHook(new Thread() {
-        public void run() {
-          jrOut.close();
-        }
-      });
     } catch (FileNotFoundException e) {
       log.warn("failed to redirect javarosa output to " + jrLogFile);
     }

--- a/src/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -17,7 +17,10 @@
 
 package org.opendatakit.aggregate.parser;
 
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,6 +32,7 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.javarosa.core.io.Std;
 import org.javarosa.core.model.DataBinding;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.IDataReference;
@@ -47,6 +51,7 @@ import org.opendatakit.aggregate.constants.ParserConsts;
 import org.opendatakit.aggregate.exception.ODKIncompleteSubmissionData;
 import org.opendatakit.aggregate.exception.ODKIncompleteSubmissionData.Reason;
 import org.opendatakit.aggregate.form.XFormParameters;
+import org.opendatakit.briefcase.util.FileSystemUtils;
 import org.opendatakit.common.utils.WebUtils;
 import org.opendatakit.common.web.constants.BasicConsts;
 
@@ -111,9 +116,26 @@ public class BaseFormParserForJavaRosa {
              // new CoreModelModule().registerModule();
              // replace with direct call to PrototypeManager
              PrototypeManager.registerPrototypes(SERIALIABLE_CLASSES);
+             redirectOutput();
              new XFormsModule().registerModule();
              isJavaRosaInitialized = true;
        }
+    }
+  }
+
+  private static void redirectOutput() {
+    File jrLogFile = new File(FileSystemUtils.getBriefcaseFolder(), ".briefcase-javarosa.log");
+    try {
+      final PrintStream jrOut = new PrintStream(jrLogFile);
+      Std.setOut(jrOut);
+      Std.setErr(jrOut);
+      Runtime.getRuntime().addShutdownHook(new Thread() {
+        public void run() {
+          jrOut.close();
+        }
+      });
+    } catch (FileNotFoundException e) {
+      log.warn("failed to redirect javarosa output to " + jrLogFile);
     }
   }
 


### PR DESCRIPTION
Finishes the console logging cleanup by redirecting javarosa output to a file in the root of the briefcase storage directory (or the user's home directory per the normal storage dir default).