### PR TITLE
#137 Add Google Analytics to Briefcase

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     compile group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.4.0'
     compile group: 'org.hsqldb', name: 'hsqldb', version: '2.4.0'
     compile files('lib/smallsql-0.21.jar')
+    compile group: 'com.brsanthu', name: 'google-analytics-java', version: '1.1.2'
 }
 
 // Required to use fileExtensions property in checkstyle file
@@ -75,6 +76,7 @@ buildConfig {
     version = getVersionName()
     clsName = 'BuildConfig'
     packageName = 'org.opendatakit.briefcase.buildconfig'
+    buildConfigField 'String', 'GOOGLE_TRACKING_ID', "UA-102618497-1"
 }
 
 mainClassName = 'org.opendatakit.briefcase.ui.MainBriefcaseWindow'

--- a/src/org/opendatakit/briefcase/model/BriefcaseAnalytics.java
+++ b/src/org/opendatakit/briefcase/model/BriefcaseAnalytics.java
@@ -1,0 +1,177 @@
+package org.opendatakit.briefcase.model;
+
+import com.brsanthu.googleanalytics.EventHit;
+import com.brsanthu.googleanalytics.GoogleAnalytics;
+import com.brsanthu.googleanalytics.GoogleAnalyticsConfig;
+import org.opendatakit.briefcase.buildconfig.BuildConfig;
+
+/**
+ *  This class is used to send usage information to ODK's Google Analytics account.
+ *
+ * <P>A library built by 'brsanthu' is utilized to streamline the
+ * process of contacting Google's Measurement Protocol API.</P>
+ * <P>This class also implements the Singleton pattern.</P>
+ *
+ * @author Joao Paulo Knox
+ * @see <a href="https://github.com/brsanthu/google-analytics-java">google-analytics-java</a>
+ */
+public class BriefcaseAnalytics {
+
+  private static final String GOOGLE_TRACKING_ID = BriefcasePreferences.GOOGLE_TRACKING_ID;
+  private static final String UNIQUE_USER_ID = BriefcasePreferences.getUniqueUserID();
+  private static final String EVENT_CATEGORY = "ODK Briefcase";
+  private static final String APPLICATION_NAME = BuildConfig.NAME;
+  private static final String APPLICATION_VERSION = BuildConfig.VERSION;
+
+  private static BriefcaseAnalytics instance;
+  private static final GoogleAnalyticsConfig config = new GoogleAnalyticsConfig();
+  private static final GoogleAnalytics googleAnalytics = new GoogleAnalytics(config, GOOGLE_TRACKING_ID);
+  private static boolean hasTrackedStartup;
+
+  /**
+   * Constructor
+   *
+   * <P>The constructor is private so as to adhere to the rules of the Singleton pattern.</P>
+   */
+  private BriefcaseAnalytics() {
+  }
+
+  /**
+   * Singleton creator.
+   *
+   * <P>This method (along with the private constructor) will ensure
+   * that only one instance of this class is instantiated.</P>
+   * @return the instantiated Singleton of {@link BriefcaseAnalytics}.
+   */
+  public static BriefcaseAnalytics getInstance() {
+    return instance == null ? (instance = new BriefcaseAnalytics()) : instance;
+  }
+
+  /**
+   *  Sends usage information to Google Analytics, only if the user has consented.
+   *  The information is modeled using an {@link EventHit} object.
+   *
+   * @param action (required) name of the event itself.
+   * @param label (optional) an open-ended label.
+   * @param value (optional) an open-ended value. Must be an integer.
+   * @return the {@link EventHit} object.
+   */
+  public EventHit trackEvent(String action, String label, Integer value) {
+    checkStateTrackingConsent();
+    EventHit eventHit = new EventHitBuilder()
+      .trackingID(GOOGLE_TRACKING_ID)
+      .clientID(UNIQUE_USER_ID)
+      .dataSource(System.getProperty("os.name"))
+      .applicationName(APPLICATION_NAME)
+      .applicationVersion(APPLICATION_VERSION)
+      .eventCategory(EVENT_CATEGORY)
+      .eventAction(action)
+      .eventLabel(label)
+      .eventValue(value)
+      .build();
+    googleAnalytics.postAsync(eventHit);
+    return eventHit;
+  }
+
+  /**
+   * Track this application's startup event.
+   *
+   * <P>This should only be run once per application execution.</P>
+   * <P>Note that the method will check to see if it has already tracked this session's startup.</P>
+   */
+  public void trackStartup() {
+    if (!hasTrackedStartup) {
+      trackEvent("Application-Startup", null, null);
+      hasTrackedStartup = true;
+    }
+  }
+
+  /**
+   * Check if the user has set or updated their consent
+   * to ODK tracking their application usage.
+   *
+   * <P>Note that this method should be executed before any event is tracked,
+   * in case the user has unticked the consent checkbox within the session.</P>
+   */
+  private void checkStateTrackingConsent() {
+    config.setGatherStats(BriefcasePreferences.getBriefcaseTrackingConsentProperty());
+  }
+
+  /**
+   * A helper class used to streamline the creation of EventHits.
+   *
+   * <P>An {@link EventHit} object is used to model the information being tracked.</P>
+   */
+  private static class EventHitBuilder {
+
+    private String trackingID;
+    private String clientID;
+    private String dataSource;
+    private String applicationName;
+    private String applicationVersion;
+    private String eventCategory;
+    private String eventAction;
+    private String eventLabel;
+    private Integer eventValue;
+
+    public EventHitBuilder trackingID(String trackingID) {
+      this.trackingID = trackingID;
+      return this;
+    }
+
+    public EventHitBuilder clientID(String clientID) {
+      this.clientID = clientID;
+      return this;
+    }
+
+    public EventHitBuilder dataSource(String dataSource) {
+      this.dataSource = dataSource;
+      return this;
+    }
+
+    public EventHitBuilder applicationName(String applicationName) {
+      this.applicationName = applicationName;
+      return this;
+    }
+
+    public EventHitBuilder applicationVersion(String applicationVersion) {
+      this.applicationVersion = applicationVersion;
+      return this;
+    }
+
+    public EventHitBuilder eventCategory(String eventCategory) {
+      this.eventCategory = eventCategory;
+      return this;
+    }
+
+    public EventHitBuilder eventAction(String eventAction) {
+      this.eventAction = eventAction;
+      return this;
+    }
+
+    public EventHitBuilder eventLabel(String eventLabel) {
+      this.eventLabel = eventLabel;
+      return this;
+    }
+
+    public EventHitBuilder eventValue(Integer eventValue) {
+      this.eventValue = eventValue;
+      return this;
+    }
+
+    public EventHit build() {
+      EventHit eventHit = new EventHit();
+      eventHit.trackingId(trackingID);
+      eventHit.clientId(clientID);
+      eventHit.dataSource(dataSource);
+      eventHit.applicationName(applicationName);
+      eventHit.applicationVersion(applicationVersion);
+      eventHit.eventCategory(eventCategory);
+      eventHit.eventAction(eventAction);
+      eventHit.eventLabel(eventLabel);
+      eventHit.eventValue(eventValue);
+      return eventHit;
+    }
+
+  }
+}

--- a/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
+++ b/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.briefcase.model;
 import java.security.Security;
+import java.util.UUID;
 import java.util.prefs.Preferences;
 
 import org.apache.http.HttpHost;
@@ -29,6 +30,7 @@ import org.opendatakit.briefcase.buildconfig.BuildConfig;
 public class BriefcasePreferences {
   
   public static final String VERSION = BuildConfig.VERSION;
+  public static final String GOOGLE_TRACKING_ID = BuildConfig.GOOGLE_TRACKING_ID;
   public static final String USERNAME = "username";
   public static final String TOKEN = "token";
   public static final String AGGREGATE_1_0_URL = "url_1_0";
@@ -38,6 +40,8 @@ public class BriefcasePreferences {
   private static final String BRIEFCASE_PROXY_HOST_PROPERTY = "briefcaseProxyHost";
   private static final String BRIEFCASE_PROXY_PORT_PROPERTY = "briefcaseProxyPort";
   private static final String BRIEFCASE_PARALLEL_PULLS_PROPERTY = "briefcaseParallelPulls";
+  private static final String BRIEFCASE_TRACKING_CONSENT_PROPERTY = "briefcaseTrackingConsent";
+  private static final String BRIEFCASE_UNIQUE_USER_ID_PROPERTY = "uniqueUserID";
   
   static {
     // load the security provider
@@ -57,7 +61,7 @@ public class BriefcasePreferences {
   public static BriefcasePreferences forClass(Class<?> node) {
     return new BriefcasePreferences(node, PreferenceScope.CLASS_NAME);
   }
-  
+
   /**
    * Returns the value associated with the specified key in this preference
    * node. Returns the specified default if there is no value associated with
@@ -180,5 +184,37 @@ public class BriefcasePreferences {
       return new HttpHost(host, port);
     }
     return null;
+  }
+
+  /**
+   * Persist the user's decision to allow/disallow their behaviour being tracked.
+   * @param value (required) the boolean value representing the user's decision.
+   */
+  public static void setBriefcaseTrackingConsentProperty(boolean value) {
+      Preference.APPLICATION_SCOPED.put(BriefcasePreferences.BRIEFCASE_TRACKING_CONSENT_PROPERTY, Boolean.valueOf(value).toString());
+  }
+
+  /**
+   * Get the user's persisted decision regarding their consent to being tracked.
+   * @return the boolean representation of the user's consent to being tracked.
+   */
+  public static boolean getBriefcaseTrackingConsentProperty() {
+    return Boolean.valueOf(
+            Preference.APPLICATION_SCOPED.get(BriefcasePreferences.BRIEFCASE_TRACKING_CONSENT_PROPERTY, Boolean.FALSE.toString())
+    ).booleanValue();
+  }
+
+  /**
+   * Get the persisted UUID for the current user.
+   * <P>Note that the method will generate and persist a UUID if the user doesn't have one.</P>
+   * @return the String representation of the user's UUID.
+   */
+  public static String getUniqueUserID() {
+    String defaultUuidValue = "UUID missing, defaulting to this message";
+    String uniqueUserID = Preference.APPLICATION_SCOPED.get(BriefcasePreferences.BRIEFCASE_UNIQUE_USER_ID_PROPERTY, defaultUuidValue);
+    if ( uniqueUserID.equals(defaultUuidValue)) {
+      Preference.APPLICATION_SCOPED.put(BriefcasePreferences.BRIEFCASE_UNIQUE_USER_ID_PROPERTY, UUID.randomUUID().toString());
+    }
+    return Preference.APPLICATION_SCOPED.get(BriefcasePreferences.BRIEFCASE_UNIQUE_USER_ID_PROPERTY, defaultUuidValue);
   }
 }

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -45,10 +45,11 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.opendatakit.aggregate.parser.BaseFormParserForJavaRosa;
+import org.opendatakit.briefcase.model.BriefcaseAnalytics;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
-import org.opendatakit.briefcase.model.ExportAbortEvent;
 import org.opendatakit.briefcase.model.FileSystemException;
 import org.opendatakit.briefcase.model.TerminationFuture;
+import org.opendatakit.briefcase.model.ExportAbortEvent;
 import org.opendatakit.briefcase.model.TransferAbortEvent;
 import org.opendatakit.briefcase.util.FileSystemUtils;
 
@@ -62,6 +63,7 @@ public class MainBriefcaseWindow implements WindowListener {
   private SettingsPanel settingsPanel;
   private final TerminationFuture exportTerminationFuture = new TerminationFuture();
   private final TerminationFuture transferTerminationFuture = new TerminationFuture();
+  private static BriefcaseAnalytics briefcaseAnalytics = BriefcaseAnalytics.getInstance();
 
   public static final String AGGREGATE_URL = "aggregate_url";
   public static final String DATE_FORMAT = "yyyy/MM/dd";
@@ -88,6 +90,8 @@ public class MainBriefcaseWindow implements WindowListener {
    * Launch the application.
    */
   public static void main(String[] args) {
+
+    briefcaseAnalytics.trackStartup();
 
     if (args.length == 0) {
 

--- a/src/org/opendatakit/briefcase/ui/MessageStrings.java
+++ b/src/org/opendatakit/briefcase/ui/MessageStrings.java
@@ -81,5 +81,6 @@ public class MessageStrings {
       "If you are behind a proxy, try setting up your proxy details through 'Settings' tab.";
 
   public static final String PARALLEL_PULLS = "Pull submissions in parallel (experimental)";
+  public static final String TRACKING_CONSENT = "Allow tracking of non-personal usage data";
 
 }

--- a/src/org/opendatakit/briefcase/ui/SettingsPanel.java
+++ b/src/org/opendatakit/briefcase/ui/SettingsPanel.java
@@ -47,6 +47,8 @@ public class SettingsPanel extends JPanel {
     private JSpinner spinPort;
     private JLabel lblParallel;
     private JCheckBox chkParallel;
+    private JLabel lblTrackingConsent;
+    private JCheckBox chkTrackingConsent;
 
     public SettingsPanel(MainBriefcaseWindow parentWindow) {
         this.parentWindow = parentWindow;
@@ -83,6 +85,11 @@ public class SettingsPanel extends JPanel {
         chkParallel.setSelected(BriefcasePreferences.getBriefcaseParallelPullsProperty());
         chkParallel.addActionListener(new ParallelPullToggleListener());
 
+        lblTrackingConsent = new JLabel(MessageStrings.TRACKING_CONSENT);
+        chkTrackingConsent = new JCheckBox();
+        chkTrackingConsent.setSelected(BriefcasePreferences.getBriefcaseTrackingConsentProperty());
+        chkTrackingConsent.addActionListener(new TrackingConsentToggleListener());
+
         GroupLayout groupLayout = new GroupLayout(this);
         groupLayout.setHorizontalGroup(
           groupLayout.createSequentialGroup()
@@ -90,7 +97,8 @@ public class SettingsPanel extends JPanel {
             .addGroup(
               groupLayout.createParallelGroup(Alignment.TRAILING)
                 .addComponent(chkProxy)
-                .addComponent(chkParallel))
+                .addComponent(chkParallel)
+                .addComponent(chkTrackingConsent))
             .addGroup(
               groupLayout.createParallelGroup(Alignment.LEADING)
                 .addGroup(
@@ -109,7 +117,8 @@ public class SettingsPanel extends JPanel {
                       groupLayout.createParallelGroup(Alignment.LEADING)
                         .addComponent(txtHost, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE)
                         .addComponent(spinPort, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE)))
-                      .addComponent(lblParallel))
+                      .addComponent(lblParallel)
+                      .addComponent(lblTrackingConsent))
             .addContainerGap()
         );
         groupLayout.setVerticalGroup(
@@ -133,6 +142,9 @@ public class SettingsPanel extends JPanel {
               .addGroup(groupLayout.createParallelGroup(Alignment.CENTER)
                 .addComponent(lblParallel)
                 .addComponent(chkParallel))
+              .addGroup(groupLayout.createParallelGroup(Alignment.CENTER)
+                .addComponent(lblTrackingConsent)
+                .addComponent(chkTrackingConsent))
               .addContainerGap()
         );
 
@@ -229,6 +241,17 @@ public class SettingsPanel extends JPanel {
             }
         }
     }
+
+    /**
+     * This listener will pass the user's consent to being tracked onto the
+     * application's preferences so it can be persisted and used elsewhere.
+     */
+    public class TrackingConsentToggleListener implements ActionListener {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            if (e.getSource() == chkTrackingConsent) {
+                BriefcasePreferences.setBriefcaseTrackingConsentProperty(chkTrackingConsent.isSelected());
+            }
+        }
+    }
 }
-
-


### PR DESCRIPTION
Add a checkBox in the settings tab so the user can give or deny their consent to having their behaviour tracked. The setting is persisted.

Generate a UUID for each unique user. The UUID is persisted.

On startup track the following: App name (Briefcase), app version, operating system type, unique user ID.