### PR TITLE
Rework Google Analytics logic, fixing critical problem

### DIFF
--- a/src/org/opendatakit/briefcase/model/BriefcaseAnalytics.java
+++ b/src/org/opendatakit/briefcase/model/BriefcaseAnalytics.java
@@ -17,161 +17,161 @@ import org.opendatakit.briefcase.buildconfig.BuildConfig;
  */
 public class BriefcaseAnalytics {
 
-  private static final String GOOGLE_TRACKING_ID = BriefcasePreferences.GOOGLE_TRACKING_ID;
-  private static final String UNIQUE_USER_ID = BriefcasePreferences.getUniqueUserID();
-  private static final String EVENT_CATEGORY = "ODK Briefcase";
-  private static final String APPLICATION_NAME = BuildConfig.NAME;
-  private static final String APPLICATION_VERSION = BuildConfig.VERSION;
+    private static final String GOOGLE_TRACKING_ID = BriefcasePreferences.GOOGLE_TRACKING_ID;
+    private static final String UNIQUE_USER_ID = BriefcasePreferences.getUniqueUserID();
+    private static final String EVENT_CATEGORY = "ODK Briefcase";
+    private static final String APPLICATION_NAME = BuildConfig.NAME;
+    private static final String APPLICATION_VERSION = BuildConfig.VERSION;
 
-  private static BriefcaseAnalytics instance;
-  private static final GoogleAnalyticsConfig config = new GoogleAnalyticsConfig();
-  private static final GoogleAnalytics googleAnalytics = new GoogleAnalytics(config, GOOGLE_TRACKING_ID);
-  private static boolean hasTrackedStartup;
+    private static BriefcaseAnalytics instance;
+    private static final GoogleAnalyticsConfig config = new GoogleAnalyticsConfig();
+    private static final GoogleAnalytics googleAnalytics = new GoogleAnalytics(config, GOOGLE_TRACKING_ID);
+    private static boolean hasTrackedStartup;
 
-  /**
-   * Constructor
-   *
-   * <P>The constructor is private so as to adhere to the rules of the Singleton pattern.</P>
-   */
-  private BriefcaseAnalytics() {
-  }
-
-  /**
-   * Singleton creator.
-   *
-   * <P>This method (along with the private constructor) will ensure
-   * that only one instance of this class is instantiated.</P>
-   * @return the instantiated Singleton of {@link BriefcaseAnalytics}.
-   */
-  public static BriefcaseAnalytics getInstance() {
-    return instance == null ? (instance = new BriefcaseAnalytics()) : instance;
-  }
-
-  /**
-   *  Sends usage information to Google Analytics, only if the user has consented.
-   *  The information is modeled using an {@link EventHit} object.
-   *
-   * @param action (required) name of the event itself.
-   * @param label (optional) an open-ended label.
-   * @param value (optional) an open-ended value. Must be an integer.
-   * @return the {@link EventHit} object.
-   */
-  public EventHit trackEvent(String action, String label, Integer value) {
-    checkStateTrackingConsent();
-    EventHit eventHit = new EventHitBuilder()
-      .trackingID(GOOGLE_TRACKING_ID)
-      .clientID(UNIQUE_USER_ID)
-      .dataSource(System.getProperty("os.name"))
-      .applicationName(APPLICATION_NAME)
-      .applicationVersion(APPLICATION_VERSION)
-      .eventCategory(EVENT_CATEGORY)
-      .eventAction(action)
-      .eventLabel(label)
-      .eventValue(value)
-      .build();
-    googleAnalytics.postAsync(eventHit);
-    return eventHit;
-  }
-
-  /**
-   * Track this application's startup event.
-   *
-   * <P>This should only be run once per application execution.</P>
-   * <P>Note that the method will check to see if it has already tracked this session's startup.</P>
-   */
-  public void trackStartup() {
-    if (!hasTrackedStartup) {
-      trackEvent("Application-Startup", null, null);
-      hasTrackedStartup = true;
-    }
-  }
-
-  /**
-   * Check if the user has set or updated their consent
-   * to ODK tracking their application usage.
-   *
-   * <P>Note that this method should be executed before any event is tracked,
-   * in case the user has unticked the consent checkbox within the session.</P>
-   */
-  private void checkStateTrackingConsent() {
-    config.setGatherStats(BriefcasePreferences.getBriefcaseTrackingConsentProperty());
-  }
-
-  /**
-   * A helper class used to streamline the creation of EventHits.
-   *
-   * <P>An {@link EventHit} object is used to model the information being tracked.</P>
-   */
-  private static class EventHitBuilder {
-
-    private String trackingID;
-    private String clientID;
-    private String dataSource;
-    private String applicationName;
-    private String applicationVersion;
-    private String eventCategory;
-    private String eventAction;
-    private String eventLabel;
-    private Integer eventValue;
-
-    public EventHitBuilder trackingID(String trackingID) {
-      this.trackingID = trackingID;
-      return this;
+    /**
+     * Constructor
+     *
+     * <P>The constructor is private so as to adhere to the rules of the Singleton pattern.</P>
+     */
+    private BriefcaseAnalytics() {
     }
 
-    public EventHitBuilder clientID(String clientID) {
-      this.clientID = clientID;
-      return this;
+    /**
+     * Singleton creator.
+     *
+     * <P>This method (along with the private constructor) will ensure
+     * that only one instance of this class is instantiated.</P>
+     * @return the instantiated Singleton of {@link BriefcaseAnalytics}.
+     */
+    public static BriefcaseAnalytics getInstance() {
+        return instance == null ? (instance = new BriefcaseAnalytics()) : instance;
     }
 
-    public EventHitBuilder dataSource(String dataSource) {
-      this.dataSource = dataSource;
-      return this;
+    /**
+     *  Sends usage information to Google Analytics, only if the user has consented.
+     *  The information is modeled using an {@link EventHit} object.
+     *
+     * @param action (required) name of the event itself.
+     * @param label (optional) an open-ended label.
+     * @param value (optional) an open-ended value. Must be an integer.
+     * @return the {@link EventHit} object.
+     */
+    public EventHit trackEvent(String action, String label, Integer value) {
+        checkStateTrackingConsent();
+        EventHit eventHit = new EventHitBuilder()
+                .trackingID(GOOGLE_TRACKING_ID)
+                .clientID(UNIQUE_USER_ID)
+                .dataSource(System.getProperty("os.name"))
+                .applicationName(APPLICATION_NAME)
+                .applicationVersion(APPLICATION_VERSION)
+                .eventCategory(EVENT_CATEGORY)
+                .eventAction(action)
+                .eventLabel(label)
+                .eventValue(value)
+                .build();
+        googleAnalytics.postAsync(eventHit);
+        return eventHit;
     }
 
-    public EventHitBuilder applicationName(String applicationName) {
-      this.applicationName = applicationName;
-      return this;
+    /**
+     * Track this application's startup event.
+     *
+     * <P>This should only be run once per application execution.</P>
+     * <P>Note that the method will check to see if it has already tracked this session's startup.</P>
+     */
+    public void trackStartup() {
+        if (!hasTrackedStartup) {
+            trackEvent("Application-Startup", null, null);
+            hasTrackedStartup = true;
+        }
     }
 
-    public EventHitBuilder applicationVersion(String applicationVersion) {
-      this.applicationVersion = applicationVersion;
-      return this;
+    /**
+     * Check if the user has set or updated their consent
+     * to ODK tracking their application usage.
+     *
+     * <P>Note that this method should be executed before any event is tracked,
+     * in case the user has unticked the consent checkbox within the session.</P>
+     */
+    private void checkStateTrackingConsent() {
+        config.setGatherStats(BriefcasePreferences.getBriefcaseTrackingConsentProperty());
     }
 
-    public EventHitBuilder eventCategory(String eventCategory) {
-      this.eventCategory = eventCategory;
-      return this;
-    }
+    /**
+     * A helper class used to streamline the creation of EventHits.
+     *
+     * <P>An {@link EventHit} object is used to model the information being tracked.</P>
+     */
+    private static class EventHitBuilder {
 
-    public EventHitBuilder eventAction(String eventAction) {
-      this.eventAction = eventAction;
-      return this;
-    }
+        private String trackingID;
+        private String clientID;
+        private String dataSource;
+        private String applicationName;
+        private String applicationVersion;
+        private String eventCategory;
+        private String eventAction;
+        private String eventLabel;
+        private Integer eventValue;
 
-    public EventHitBuilder eventLabel(String eventLabel) {
-      this.eventLabel = eventLabel;
-      return this;
-    }
+        public EventHitBuilder trackingID(String trackingID) {
+            this.trackingID = trackingID;
+            return this;
+        }
 
-    public EventHitBuilder eventValue(Integer eventValue) {
-      this.eventValue = eventValue;
-      return this;
-    }
+        public EventHitBuilder clientID(String clientID) {
+            this.clientID = clientID;
+            return this;
+        }
 
-    public EventHit build() {
-      EventHit eventHit = new EventHit();
-      eventHit.trackingId(trackingID);
-      eventHit.clientId(clientID);
-      eventHit.dataSource(dataSource);
-      eventHit.applicationName(applicationName);
-      eventHit.applicationVersion(applicationVersion);
-      eventHit.eventCategory(eventCategory);
-      eventHit.eventAction(eventAction);
-      eventHit.eventLabel(eventLabel);
-      eventHit.eventValue(eventValue);
-      return eventHit;
-    }
+        public EventHitBuilder dataSource(String dataSource) {
+            this.dataSource = dataSource;
+            return this;
+        }
 
-  }
+        public EventHitBuilder applicationName(String applicationName) {
+            this.applicationName = applicationName;
+            return this;
+        }
+
+        public EventHitBuilder applicationVersion(String applicationVersion) {
+            this.applicationVersion = applicationVersion;
+            return this;
+        }
+
+        public EventHitBuilder eventCategory(String eventCategory) {
+            this.eventCategory = eventCategory;
+            return this;
+        }
+
+        public EventHitBuilder eventAction(String eventAction) {
+            this.eventAction = eventAction;
+            return this;
+        }
+
+        public EventHitBuilder eventLabel(String eventLabel) {
+            this.eventLabel = eventLabel;
+            return this;
+        }
+
+        public EventHitBuilder eventValue(Integer eventValue) {
+            this.eventValue = eventValue;
+            return this;
+        }
+
+        public EventHit build() {
+            EventHit eventHit = new EventHit();
+            eventHit.trackingId(trackingID);
+            eventHit.clientId(clientID);
+            eventHit.dataSource(dataSource);
+            eventHit.applicationName(applicationName);
+            eventHit.applicationVersion(applicationVersion);
+            eventHit.eventCategory(eventCategory);
+            eventHit.eventAction(eventAction);
+            eventHit.eventLabel(eventLabel);
+            eventHit.eventValue(eventValue);
+            return eventHit;
+        }
+
+    }
 }

--- a/src/org/opendatakit/briefcase/model/BriefcaseAnalytics.java
+++ b/src/org/opendatakit/briefcase/model/BriefcaseAnalytics.java
@@ -2,7 +2,6 @@ package org.opendatakit.briefcase.model;
 
 import com.brsanthu.googleanalytics.EventHit;
 import com.brsanthu.googleanalytics.GoogleAnalytics;
-import com.brsanthu.googleanalytics.GoogleAnalyticsConfig;
 import org.opendatakit.briefcase.buildconfig.BuildConfig;
 
 /**
@@ -22,29 +21,9 @@ public class BriefcaseAnalytics {
     private static final String EVENT_CATEGORY = "ODK Briefcase";
     private static final String APPLICATION_NAME = BuildConfig.NAME;
     private static final String APPLICATION_VERSION = BuildConfig.VERSION;
+    private final GoogleAnalytics googleAnalytics = new GoogleAnalytics(GOOGLE_TRACKING_ID);
 
-    private static BriefcaseAnalytics instance;
-    private static final GoogleAnalyticsConfig config = new GoogleAnalyticsConfig();
-    private static final GoogleAnalytics googleAnalytics = new GoogleAnalytics(config, GOOGLE_TRACKING_ID);
-    private static boolean hasTrackedStartup;
-
-    /**
-     * Constructor
-     *
-     * <P>The constructor is private so as to adhere to the rules of the Singleton pattern.</P>
-     */
-    private BriefcaseAnalytics() {
-    }
-
-    /**
-     * Singleton creator.
-     *
-     * <P>This method (along with the private constructor) will ensure
-     * that only one instance of this class is instantiated.</P>
-     * @return the instantiated Singleton of {@link BriefcaseAnalytics}.
-     */
-    public static BriefcaseAnalytics getInstance() {
-        return instance == null ? (instance = new BriefcaseAnalytics()) : instance;
+    public BriefcaseAnalytics() {
     }
 
     /**
@@ -54,124 +33,28 @@ public class BriefcaseAnalytics {
      * @param action (required) name of the event itself.
      * @param label (optional) an open-ended label.
      * @param value (optional) an open-ended value. Must be an integer.
-     * @return the {@link EventHit} object.
      */
-    public EventHit trackEvent(String action, String label, Integer value) {
-        checkStateTrackingConsent();
-        EventHit eventHit = new EventHitBuilder()
-                .trackingID(GOOGLE_TRACKING_ID)
-                .clientID(UNIQUE_USER_ID)
-                .dataSource(System.getProperty("os.name"))
-                .applicationName(APPLICATION_NAME)
-                .applicationVersion(APPLICATION_VERSION)
-                .eventCategory(EVENT_CATEGORY)
-                .eventAction(action)
-                .eventLabel(label)
-                .eventValue(value)
-                .build();
-        googleAnalytics.postAsync(eventHit);
-        return eventHit;
+    public void trackEvent(String action, String label, Integer value) {
+        if (BriefcasePreferences.getBriefcaseTrackingConsentProperty()) {
+            EventHit eventHit = new EventHit();
+            eventHit.trackingId(GOOGLE_TRACKING_ID);
+            eventHit.clientId(UNIQUE_USER_ID);
+            eventHit.dataSource(System.getProperty("os.name"));
+            eventHit.applicationName(APPLICATION_NAME);
+            eventHit.applicationVersion(APPLICATION_VERSION);
+            eventHit.eventCategory(EVENT_CATEGORY);
+            eventHit.eventAction(action);
+            eventHit.eventLabel(label);
+            eventHit.eventValue(value);
+
+            googleAnalytics.postAsync(eventHit);
+        }
     }
 
     /**
      * Track this application's startup event.
-     *
-     * <P>This should only be run once per application execution.</P>
-     * <P>Note that the method will check to see if it has already tracked this session's startup.</P>
      */
     public void trackStartup() {
-        if (!hasTrackedStartup) {
-            trackEvent("Application-Startup", null, null);
-            hasTrackedStartup = true;
-        }
-    }
-
-    /**
-     * Check if the user has set or updated their consent
-     * to ODK tracking their application usage.
-     *
-     * <P>Note that this method should be executed before any event is tracked,
-     * in case the user has unticked the consent checkbox within the session.</P>
-     */
-    private void checkStateTrackingConsent() {
-        config.setGatherStats(BriefcasePreferences.getBriefcaseTrackingConsentProperty());
-    }
-
-    /**
-     * A helper class used to streamline the creation of EventHits.
-     *
-     * <P>An {@link EventHit} object is used to model the information being tracked.</P>
-     */
-    private static class EventHitBuilder {
-
-        private String trackingID;
-        private String clientID;
-        private String dataSource;
-        private String applicationName;
-        private String applicationVersion;
-        private String eventCategory;
-        private String eventAction;
-        private String eventLabel;
-        private Integer eventValue;
-
-        public EventHitBuilder trackingID(String trackingID) {
-            this.trackingID = trackingID;
-            return this;
-        }
-
-        public EventHitBuilder clientID(String clientID) {
-            this.clientID = clientID;
-            return this;
-        }
-
-        public EventHitBuilder dataSource(String dataSource) {
-            this.dataSource = dataSource;
-            return this;
-        }
-
-        public EventHitBuilder applicationName(String applicationName) {
-            this.applicationName = applicationName;
-            return this;
-        }
-
-        public EventHitBuilder applicationVersion(String applicationVersion) {
-            this.applicationVersion = applicationVersion;
-            return this;
-        }
-
-        public EventHitBuilder eventCategory(String eventCategory) {
-            this.eventCategory = eventCategory;
-            return this;
-        }
-
-        public EventHitBuilder eventAction(String eventAction) {
-            this.eventAction = eventAction;
-            return this;
-        }
-
-        public EventHitBuilder eventLabel(String eventLabel) {
-            this.eventLabel = eventLabel;
-            return this;
-        }
-
-        public EventHitBuilder eventValue(Integer eventValue) {
-            this.eventValue = eventValue;
-            return this;
-        }
-
-        public EventHit build() {
-            EventHit eventHit = new EventHit();
-            eventHit.trackingId(trackingID);
-            eventHit.clientId(clientID);
-            eventHit.dataSource(dataSource);
-            eventHit.applicationName(applicationName);
-            eventHit.applicationVersion(applicationVersion);
-            eventHit.eventCategory(eventCategory);
-            eventHit.eventAction(eventAction);
-            eventHit.eventLabel(eventLabel);
-            eventHit.eventValue(eventValue);
-            return eventHit;
-        }
-
+        trackEvent("Application-Startup", null, null);
     }
 }

--- a/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
+++ b/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
@@ -199,9 +199,8 @@ public class BriefcasePreferences {
      * @return the boolean representation of the user's consent to being tracked.
      */
     public static boolean getBriefcaseTrackingConsentProperty() {
-        return Boolean.valueOf(
-                Preference.APPLICATION_SCOPED.get(BriefcasePreferences.BRIEFCASE_TRACKING_CONSENT_PROPERTY, Boolean.FALSE.toString())
-        ).booleanValue();
+        return Boolean.valueOf(Preference.APPLICATION_SCOPED.get(
+                BriefcasePreferences.BRIEFCASE_TRACKING_CONSENT_PROPERTY, Boolean.FALSE.toString()));
     }
 
     /**

--- a/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
+++ b/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
@@ -28,193 +28,193 @@ import org.opendatakit.briefcase.buildconfig.BuildConfig;
  * {@link java.util.prefs.Preferences Preferences API}.
  */
 public class BriefcasePreferences {
-  
-  public static final String VERSION = BuildConfig.VERSION;
-  public static final String GOOGLE_TRACKING_ID = BuildConfig.GOOGLE_TRACKING_ID;
-  public static final String USERNAME = "username";
-  public static final String TOKEN = "token";
-  public static final String AGGREGATE_1_0_URL = "url_1_0";
-  public static final String AGGREGATE_0_9_X_URL = "url_0_9_X";
-  
-  private static final String BRIEFCASE_DIR_PROPERTY = "briefcaseDir";
-  private static final String BRIEFCASE_PROXY_HOST_PROPERTY = "briefcaseProxyHost";
-  private static final String BRIEFCASE_PROXY_PORT_PROPERTY = "briefcaseProxyPort";
-  private static final String BRIEFCASE_PARALLEL_PULLS_PROPERTY = "briefcaseParallelPulls";
-  private static final String BRIEFCASE_TRACKING_CONSENT_PROPERTY = "briefcaseTrackingConsent";
-  private static final String BRIEFCASE_UNIQUE_USER_ID_PROPERTY = "uniqueUserID";
-  
-  static {
-    // load the security provider
-    Security.addProvider(new BouncyCastleProvider());
-  }
 
-  private final Preferences preferences;
-  
-  private BriefcasePreferences(Class<?> node, PreferenceScope scope) {
-    this.preferences = scope.preferenceFactory(node);
-  }
-  
-  /**
-   * Factory that creates a class scoped <tt>BriefcasePreferences</tt> object. 
-   * @param node the managing class
-   */
-  public static BriefcasePreferences forClass(Class<?> node) {
-    return new BriefcasePreferences(node, PreferenceScope.CLASS_NAME);
-  }
+    public static final String VERSION = BuildConfig.VERSION;
+    public static final String GOOGLE_TRACKING_ID = BuildConfig.GOOGLE_TRACKING_ID;
+    public static final String USERNAME = "username";
+    public static final String TOKEN = "token";
+    public static final String AGGREGATE_1_0_URL = "url_1_0";
+    public static final String AGGREGATE_0_9_X_URL = "url_0_9_X";
 
-  /**
-   * Returns the value associated with the specified key in this preference
-   * node. Returns the specified default if there is no value associated with
-   * the key, or the backing store is inaccessible.
-   * 
-   * @param key
-   *          key whose associated value is to be returned.
-   * @param defaultValue
-   *          the value to be returned in the event that this preference node
-   *          has no value associated with key.
-   * @return the value associated with key, or defaultValue if no value is associated
-   *         with key, or the backing store is inaccessible.
-   */
-  public String get(String key, String defaultValue) {
-    return preferences.get(key, defaultValue);
-  }
-  
-  /**
-   * Associates the specified value with the specified key in this preference
-   * node.
-   * 
-   * @param key
-   *          key with which the specified value is to be associated.
-   * @param value
-   *          value to be associated with the specified key.
-   */
-  public void put(String key, String value) {
-    preferences.put(key, value);
-  }
-  
-  /**
-   * Removes the value associated with the specified key in this preference
-   * node, if any.
-   * 
-   * @param key
-   *          key whose mapping is to be removed from the preference node.
-   */
-  public void remove(String key) {
-    preferences.remove(key);
-  }
+    private static final String BRIEFCASE_DIR_PROPERTY = "briefcaseDir";
+    private static final String BRIEFCASE_PROXY_HOST_PROPERTY = "briefcaseProxyHost";
+    private static final String BRIEFCASE_PROXY_PORT_PROPERTY = "briefcaseProxyPort";
+    private static final String BRIEFCASE_PARALLEL_PULLS_PROPERTY = "briefcaseParallelPulls";
+    private static final String BRIEFCASE_TRACKING_CONSENT_PROPERTY = "briefcaseTrackingConsent";
+    private static final String BRIEFCASE_UNIQUE_USER_ID_PROPERTY = "uniqueUserID";
 
-  public static void setBriefcaseDirectoryProperty(String value) {
-    if (value == null) {
-      Preference.APPLICATION_SCOPED.remove(BRIEFCASE_DIR_PROPERTY);
-    } else {
-      Preference.APPLICATION_SCOPED.put(BriefcasePreferences.BRIEFCASE_DIR_PROPERTY, value);
+    static {
+        // load the security provider
+        Security.addProvider(new BouncyCastleProvider());
     }
-  }
 
-  public static String getBriefcaseDirectoryIfSet() {
-    return Preference.APPLICATION_SCOPED.get(BriefcasePreferences.BRIEFCASE_DIR_PROPERTY, null);
-  }
+    private final Preferences preferences;
 
-  public static String getBriefcaseDirectoryProperty() {
-    return Preference.APPLICATION_SCOPED.get(BriefcasePreferences.BRIEFCASE_DIR_PROPERTY,
-        System.getProperty("user.home"));
-  }
-
-  public static void setBriefcaseProxyProperty(HttpHost value) {
-    if (value == null) {
-    Preference.APPLICATION_SCOPED.remove(BRIEFCASE_PROXY_HOST_PROPERTY);
-    Preference.APPLICATION_SCOPED.remove(BRIEFCASE_PROXY_PORT_PROPERTY);
-    } else {
-    Preference.APPLICATION_SCOPED.put(BriefcasePreferences.BRIEFCASE_PROXY_HOST_PROPERTY, value.getHostName());
-    Preference.APPLICATION_SCOPED.put(BriefcasePreferences.BRIEFCASE_PROXY_PORT_PROPERTY, new Integer(value.getPort()).toString());
+    private BriefcasePreferences(Class<?> node, PreferenceScope scope) {
+        this.preferences = scope.preferenceFactory(node);
     }
-  }
 
-  public static void setBriefcaseParallelPullsProperty(Boolean value) {
-    if (value == null) {
-      Preference.APPLICATION_SCOPED.remove(BRIEFCASE_PARALLEL_PULLS_PROPERTY);
-    } else {
-      Preference.APPLICATION_SCOPED.put(BriefcasePreferences.BRIEFCASE_PARALLEL_PULLS_PROPERTY, value.toString());
+    /**
+     * Factory that creates a class scoped <tt>BriefcasePreferences</tt> object.
+     * @param node the managing class
+     */
+    public static BriefcasePreferences forClass(Class<?> node) {
+        return new BriefcasePreferences(node, PreferenceScope.CLASS_NAME);
     }
-  }
 
-  public static Boolean getBriefcaseParallelPullsProperty() {
-    return Boolean.valueOf(
-            Preference.APPLICATION_SCOPED.get(BriefcasePreferences.BRIEFCASE_PARALLEL_PULLS_PROPERTY, Boolean.FALSE.toString())
-    );
-  }
-  
-  /**
-   * Enum that implements the strategies, to create differently scoped preferences.
-   */
-  private enum PreferenceScope {
-    APPLICATION {
-      @Override
-      public Preferences preferenceFactory(Class<?> node) {
-        return Preferences.userNodeForPackage(node);
-      }
-    },
-    CLASS_NAME {
-      @Override
-      public Preferences preferenceFactory(Class<?> node) {
-        return Preferences.userRoot().node(node.getName());
-      }
-    };
-    public abstract Preferences preferenceFactory(Class<?> node);
-  }
-  
-  /**
-   * Through this static nested class, we implement the Initialization-on-demand
-   * holder idiom. It enables a safe, highly concurrent lazy initialization for
-   * singletons. For more information on this idiom, please refer to <a href=
-   * "https://en.wikipedia.org/wiki/Initialization-on-demand_holder_idiom">
-   * Initialization-on-demand holder idiom</a>.
-   */
-  private static class Preference {
-    private static final BriefcasePreferences APPLICATION_SCOPED =
-        new BriefcasePreferences(BriefcasePreferences.class, PreferenceScope.APPLICATION);
-  }
- 
-  public static HttpHost getBriefCaseProxyConnection() {
-    String host = Preference.APPLICATION_SCOPED.get(
-        BriefcasePreferences.BRIEFCASE_PROXY_HOST_PROPERTY,null);
-    if (host != null) {
-      Integer port = Integer.parseInt(Preference.APPLICATION_SCOPED.get(
-          BriefcasePreferences.BRIEFCASE_PROXY_PORT_PROPERTY,"0"));
-      return new HttpHost(host, port);
+    /**
+     * Returns the value associated with the specified key in this preference
+     * node. Returns the specified default if there is no value associated with
+     * the key, or the backing store is inaccessible.
+     *
+     * @param key
+     *          key whose associated value is to be returned.
+     * @param defaultValue
+     *          the value to be returned in the event that this preference node
+     *          has no value associated with key.
+     * @return the value associated with key, or defaultValue if no value is associated
+     *         with key, or the backing store is inaccessible.
+     */
+    public String get(String key, String defaultValue) {
+        return preferences.get(key, defaultValue);
     }
-    return null;
-  }
 
-  /**
-   * Persist the user's decision to allow/disallow their behaviour being tracked.
-   * @param value (required) the boolean value representing the user's decision.
-   */
-  public static void setBriefcaseTrackingConsentProperty(boolean value) {
-      Preference.APPLICATION_SCOPED.put(BriefcasePreferences.BRIEFCASE_TRACKING_CONSENT_PROPERTY, Boolean.valueOf(value).toString());
-  }
-
-  /**
-   * Get the user's persisted decision regarding their consent to being tracked.
-   * @return the boolean representation of the user's consent to being tracked.
-   */
-  public static boolean getBriefcaseTrackingConsentProperty() {
-    return Boolean.valueOf(
-            Preference.APPLICATION_SCOPED.get(BriefcasePreferences.BRIEFCASE_TRACKING_CONSENT_PROPERTY, Boolean.FALSE.toString())
-    ).booleanValue();
-  }
-
-  /**
-   * Get the persisted UUID for the current user.
-   * <P>Note that the method will generate and persist a UUID if the user doesn't have one.</P>
-   * @return the String representation of the user's UUID.
-   */
-  public static String getUniqueUserID() {
-    String defaultUuidValue = "UUID missing, defaulting to this message";
-    String uniqueUserID = Preference.APPLICATION_SCOPED.get(BriefcasePreferences.BRIEFCASE_UNIQUE_USER_ID_PROPERTY, defaultUuidValue);
-    if ( uniqueUserID.equals(defaultUuidValue)) {
-      Preference.APPLICATION_SCOPED.put(BriefcasePreferences.BRIEFCASE_UNIQUE_USER_ID_PROPERTY, UUID.randomUUID().toString());
+    /**
+     * Associates the specified value with the specified key in this preference
+     * node.
+     *
+     * @param key
+     *          key with which the specified value is to be associated.
+     * @param value
+     *          value to be associated with the specified key.
+     */
+    public void put(String key, String value) {
+        preferences.put(key, value);
     }
-    return Preference.APPLICATION_SCOPED.get(BriefcasePreferences.BRIEFCASE_UNIQUE_USER_ID_PROPERTY, defaultUuidValue);
-  }
+
+    /**
+     * Removes the value associated with the specified key in this preference
+     * node, if any.
+     *
+     * @param key
+     *          key whose mapping is to be removed from the preference node.
+     */
+    public void remove(String key) {
+        preferences.remove(key);
+    }
+
+    public static void setBriefcaseDirectoryProperty(String value) {
+        if (value == null) {
+            Preference.APPLICATION_SCOPED.remove(BRIEFCASE_DIR_PROPERTY);
+        } else {
+            Preference.APPLICATION_SCOPED.put(BriefcasePreferences.BRIEFCASE_DIR_PROPERTY, value);
+        }
+    }
+
+    public static String getBriefcaseDirectoryIfSet() {
+        return Preference.APPLICATION_SCOPED.get(BriefcasePreferences.BRIEFCASE_DIR_PROPERTY, null);
+    }
+
+    public static String getBriefcaseDirectoryProperty() {
+        return Preference.APPLICATION_SCOPED.get(BriefcasePreferences.BRIEFCASE_DIR_PROPERTY,
+                System.getProperty("user.home"));
+    }
+
+    public static void setBriefcaseProxyProperty(HttpHost value) {
+        if (value == null) {
+            Preference.APPLICATION_SCOPED.remove(BRIEFCASE_PROXY_HOST_PROPERTY);
+            Preference.APPLICATION_SCOPED.remove(BRIEFCASE_PROXY_PORT_PROPERTY);
+        } else {
+            Preference.APPLICATION_SCOPED.put(BriefcasePreferences.BRIEFCASE_PROXY_HOST_PROPERTY, value.getHostName());
+            Preference.APPLICATION_SCOPED.put(BriefcasePreferences.BRIEFCASE_PROXY_PORT_PROPERTY, new Integer(value.getPort()).toString());
+        }
+    }
+
+    public static void setBriefcaseParallelPullsProperty(Boolean value) {
+        if (value == null) {
+            Preference.APPLICATION_SCOPED.remove(BRIEFCASE_PARALLEL_PULLS_PROPERTY);
+        } else {
+            Preference.APPLICATION_SCOPED.put(BriefcasePreferences.BRIEFCASE_PARALLEL_PULLS_PROPERTY, value.toString());
+        }
+    }
+
+    public static Boolean getBriefcaseParallelPullsProperty() {
+        return Boolean.valueOf(
+                Preference.APPLICATION_SCOPED.get(BriefcasePreferences.BRIEFCASE_PARALLEL_PULLS_PROPERTY, Boolean.FALSE.toString())
+        );
+    }
+
+    /**
+     * Enum that implements the strategies, to create differently scoped preferences.
+     */
+    private enum PreferenceScope {
+        APPLICATION {
+            @Override
+            public Preferences preferenceFactory(Class<?> node) {
+                return Preferences.userNodeForPackage(node);
+            }
+        },
+        CLASS_NAME {
+            @Override
+            public Preferences preferenceFactory(Class<?> node) {
+                return Preferences.userRoot().node(node.getName());
+            }
+        };
+        public abstract Preferences preferenceFactory(Class<?> node);
+    }
+
+    /**
+     * Through this static nested class, we implement the Initialization-on-demand
+     * holder idiom. It enables a safe, highly concurrent lazy initialization for
+     * singletons. For more information on this idiom, please refer to <a href=
+     * "https://en.wikipedia.org/wiki/Initialization-on-demand_holder_idiom">
+     * Initialization-on-demand holder idiom</a>.
+     */
+    private static class Preference {
+        private static final BriefcasePreferences APPLICATION_SCOPED =
+                new BriefcasePreferences(BriefcasePreferences.class, PreferenceScope.APPLICATION);
+    }
+
+    public static HttpHost getBriefCaseProxyConnection() {
+        String host = Preference.APPLICATION_SCOPED.get(
+                BriefcasePreferences.BRIEFCASE_PROXY_HOST_PROPERTY,null);
+        if (host != null) {
+            Integer port = Integer.parseInt(Preference.APPLICATION_SCOPED.get(
+                    BriefcasePreferences.BRIEFCASE_PROXY_PORT_PROPERTY,"0"));
+            return new HttpHost(host, port);
+        }
+        return null;
+    }
+
+    /**
+     * Persist the user's decision to allow/disallow their behaviour being tracked.
+     * @param value (required) the boolean value representing the user's decision.
+     */
+    public static void setBriefcaseTrackingConsentProperty(boolean value) {
+        Preference.APPLICATION_SCOPED.put(BriefcasePreferences.BRIEFCASE_TRACKING_CONSENT_PROPERTY, Boolean.valueOf(value).toString());
+    }
+
+    /**
+     * Get the user's persisted decision regarding their consent to being tracked.
+     * @return the boolean representation of the user's consent to being tracked.
+     */
+    public static boolean getBriefcaseTrackingConsentProperty() {
+        return Boolean.valueOf(
+                Preference.APPLICATION_SCOPED.get(BriefcasePreferences.BRIEFCASE_TRACKING_CONSENT_PROPERTY, Boolean.FALSE.toString())
+        ).booleanValue();
+    }
+
+    /**
+     * Get the persisted UUID for the current user.
+     * <P>Note that the method will generate and persist a UUID if the user doesn't have one.</P>
+     * @return the String representation of the user's UUID.
+     */
+    public static String getUniqueUserID() {
+        String defaultUuidValue = "UUID missing, defaulting to this message";
+        String uniqueUserID = Preference.APPLICATION_SCOPED.get(BriefcasePreferences.BRIEFCASE_UNIQUE_USER_ID_PROPERTY, defaultUuidValue);
+        if ( uniqueUserID.equals(defaultUuidValue)) {
+            Preference.APPLICATION_SCOPED.put(BriefcasePreferences.BRIEFCASE_UNIQUE_USER_ID_PROPERTY, UUID.randomUUID().toString());
+        }
+        return Preference.APPLICATION_SCOPED.get(BriefcasePreferences.BRIEFCASE_UNIQUE_USER_ID_PROPERTY, defaultUuidValue);
+    }
 }

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -54,568 +54,568 @@ import org.opendatakit.briefcase.model.TransferAbortEvent;
 import org.opendatakit.briefcase.util.FileSystemUtils;
 
 public class MainBriefcaseWindow implements WindowListener {
-  private static final String BRIEFCASE_VERSION = "ODK Briefcase - " + BriefcasePreferences.VERSION;
+    private static final String BRIEFCASE_VERSION = "ODK Briefcase - " + BriefcasePreferences.VERSION;
 
-  private JFrame frame;
-  private PullTransferPanel gatherPanel;
-  private PushTransferPanel uploadPanel;
-  private ExportPanel exportPanel;
-  private SettingsPanel settingsPanel;
-  private final TerminationFuture exportTerminationFuture = new TerminationFuture();
-  private final TerminationFuture transferTerminationFuture = new TerminationFuture();
-  private static BriefcaseAnalytics briefcaseAnalytics = BriefcaseAnalytics.getInstance();
+    private JFrame frame;
+    private PullTransferPanel gatherPanel;
+    private PushTransferPanel uploadPanel;
+    private ExportPanel exportPanel;
+    private SettingsPanel settingsPanel;
+    private final TerminationFuture exportTerminationFuture = new TerminationFuture();
+    private final TerminationFuture transferTerminationFuture = new TerminationFuture();
+    private static BriefcaseAnalytics briefcaseAnalytics = BriefcaseAnalytics.getInstance();
 
-  public static final String AGGREGATE_URL = "aggregate_url";
-  public static final String DATE_FORMAT = "yyyy/MM/dd";
-  public static final String EXCLUDE_MEDIA_EXPORT = "exclude_media_export";
-  public static final String EXPORT_DIRECTORY = "export_directory";
-  public static final String EXPORT_END_DATE = "export_end_date";
-  public static final String EXPORT_FILENAME = "export_filename";
-  public static final String EXPORT_START_DATE = "export_start_date";
-  public static final String FORM_ID = "form_id";
-  public static final String ODK_PASSWORD = "odk_password";
-  public static final String ODK_USERNAME = "odk_username";
-  public static final String OVERWRITE_CSV_EXPORT = "overwrite_csv_export";
-  public static final String STORAGE_DIRECTORY = "storage_directory";
-  public static final String ODK_DIR = "odk_directory";
-  public static final String HELP = "help";
-  public static final String VERSION = "version";
-  public static final String PEM_FILE = "pem_file";
+    public static final String AGGREGATE_URL = "aggregate_url";
+    public static final String DATE_FORMAT = "yyyy/MM/dd";
+    public static final String EXCLUDE_MEDIA_EXPORT = "exclude_media_export";
+    public static final String EXPORT_DIRECTORY = "export_directory";
+    public static final String EXPORT_END_DATE = "export_end_date";
+    public static final String EXPORT_FILENAME = "export_filename";
+    public static final String EXPORT_START_DATE = "export_start_date";
+    public static final String FORM_ID = "form_id";
+    public static final String ODK_PASSWORD = "odk_password";
+    public static final String ODK_USERNAME = "odk_username";
+    public static final String OVERWRITE_CSV_EXPORT = "overwrite_csv_export";
+    public static final String STORAGE_DIRECTORY = "storage_directory";
+    public static final String ODK_DIR = "odk_directory";
+    public static final String HELP = "help";
+    public static final String VERSION = "version";
+    public static final String PEM_FILE = "pem_file";
 
-  private static final Log log = LogFactory.getLog(BaseFormParserForJavaRosa.class.getName());
+    private static final Log log = LogFactory.getLog(BaseFormParserForJavaRosa.class.getName());
 
-  private JTabbedPane tabbedPane;
+    private JTabbedPane tabbedPane;
 
-  /**
-   * Launch the application.
-   */
-  public static void main(String[] args) {
+    /**
+     * Launch the application.
+     */
+    public static void main(String[] args) {
 
-    briefcaseAnalytics.trackStartup();
+        briefcaseAnalytics.trackStartup();
 
-    if (args.length == 0) {
+        if (args.length == 0) {
 
-      EventQueue.invokeLater(new Runnable() {
-        public void run() {
-          try {
-            // Set System L&F
-            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+            EventQueue.invokeLater(new Runnable() {
+                public void run() {
+                    try {
+                        // Set System L&F
+                        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
 
-            MainBriefcaseWindow window = new MainBriefcaseWindow();
-            window.frame.setTitle(BRIEFCASE_VERSION);
-            ImageIcon icon = new ImageIcon(MainBriefcaseWindow.class.getClassLoader().getResource("odk_logo.png"));
-            window.frame.setIconImage(icon.getImage());
-            window.frame.setVisible(true);
-          } catch (Exception e) {
-            log.error("failed to launch app", e);
-          }
-        }
-      });
-    } else {
-      Options options = addOptions();
-      CommandLineParser parser = new DefaultParser();
-      CommandLine cmd = null;
-
-        try {
-            cmd = parser.parse(options, args);
-        } catch (ParseException e1) {
-            log.error("Launch Failed: " + e1.getMessage());
-            showHelp(options);
-            System.exit(1);
-        }
-
-        if (cmd.hasOption(HELP)) {
-            showHelp(options);
-            System.exit(1);
-        }
-
-        if (cmd.hasOption(VERSION)) {
-            showVersion();
-            System.exit(1);
-        }
-
-        // required for all operations
-        if (!cmd.hasOption(FORM_ID) || !cmd.hasOption(STORAGE_DIRECTORY)) {
-            log.error(FORM_ID + " and " + STORAGE_DIRECTORY + " are required");
-            showHelp(options);
-            System.exit(1);
-        }
-
-        // pull from collect or aggregate, not both
-        if (cmd.hasOption(ODK_DIR) && cmd.hasOption(AGGREGATE_URL)) {
-            log.error("Can only have one of " + ODK_DIR + " or " + AGGREGATE_URL);
-            showHelp(options);
-            System.exit(1);
-        }
-
-        // pull from aggregate
-        if (cmd.hasOption(AGGREGATE_URL) && (!(cmd.hasOption(ODK_USERNAME) && cmd.hasOption(ODK_PASSWORD)))) {
-            log.error(ODK_USERNAME + " and " + ODK_PASSWORD + " required when " + AGGREGATE_URL + " is specified");
-            showHelp(options);
-            System.exit(1);
-        }
-
-        // export files
-        if (cmd.hasOption(EXPORT_DIRECTORY) && !cmd.hasOption(EXPORT_FILENAME) || !cmd.hasOption(EXPORT_DIRECTORY) && cmd.hasOption(EXPORT_FILENAME)) {
-            log.error(EXPORT_DIRECTORY + " and " + EXPORT_FILENAME + " are both required to export");
-            showHelp(options);
-            System.exit(1);
-        }
-
-        if (cmd.hasOption(EXPORT_END_DATE)) {
-            if (!testDateFormat(cmd.getOptionValue(EXPORT_END_DATE))) {
-                log.error("Invalid date format in " + EXPORT_END_DATE);
-                showHelp(options);
-                System.exit(1);
-            }
-        }
-        if (cmd.hasOption(EXPORT_START_DATE)) {
-            if (!testDateFormat(cmd.getOptionValue(EXPORT_START_DATE))) {
-                log.error("Invalid date format in " + EXPORT_START_DATE);
-                showHelp(options);
-                System.exit(1);
-            }
-        }
-      
-      
-      BriefcaseCLI bcli = new BriefcaseCLI(cmd);
-      bcli.run();
-    }
-  }
-
-  void setFullUIEnabled(boolean state) {
-    String path = BriefcasePreferences.getBriefcaseDirectoryIfSet();
-    if ( path != null ) {
-      settingsPanel.getTxtBriefcaseDir().setText(path + File.separator + FileSystemUtils.BRIEFCASE_DIR);
-    } else {
-      settingsPanel.getTxtBriefcaseDir().setText("");
-    }
-    if ( state ) {
-      exportPanel.updateComboBox();
-      uploadPanel.updateFormStatuses();
-      exportPanel.setEnabled(true);
-      gatherPanel.setEnabled(true);
-      uploadPanel.setEnabled(true);
-      tabbedPane.setEnabled(true);
-    } else {
-      exportPanel.setEnabled(false);
-      gatherPanel.setEnabled(false);
-      uploadPanel.setEnabled(false);
-      tabbedPane.setEnabled(false);
-    }
-  }
-
-  /**
-   * Create the application.
-   */
-  public MainBriefcaseWindow() {
-    frame = new JFrame();
-    frame.setBounds(100, 100, 680, 595);
-    frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-
-    frame.addWindowListener(new WindowListener() {
-      @Override
-      public void windowOpened(WindowEvent e) {
-      }
-
-      @Override
-      public void windowClosing(WindowEvent e) {
-      }
-
-      @Override
-      public void windowClosed(WindowEvent e) {
-      }
-
-      @Override
-      public void windowIconified(WindowEvent e) {
-      }
-
-      @Override
-      public void windowDeiconified(WindowEvent e) {
-      }
-
-      @Override
-      public void windowActivated(WindowEvent e) {
-      }
-
-      @Override
-      public void windowDeactivated(WindowEvent e) {
-      }
-    });
-
-    tabbedPane = new JTabbedPane(JTabbedPane.TOP);
-    GroupLayout groupLayout = new GroupLayout(frame.getContentPane());
-    groupLayout.setHorizontalGroup(groupLayout.createParallelGroup(Alignment.LEADING).addGroup(
-        groupLayout
-            .createSequentialGroup()
-            .addContainerGap()
-            .addGroup(
-                groupLayout
-                    .createParallelGroup(Alignment.LEADING)
-                    .addComponent(tabbedPane, Alignment.TRAILING, GroupLayout.DEFAULT_SIZE, 628,
-                        Short.MAX_VALUE))
-            .addContainerGap()));
-    groupLayout.setVerticalGroup(groupLayout.createParallelGroup(Alignment.LEADING).addGroup(
-        groupLayout
-            .createSequentialGroup()
-            .addContainerGap()
-            .addComponent(tabbedPane, GroupLayout.DEFAULT_SIZE, 446, Short.MAX_VALUE)
-            .addContainerGap()));
-
-    gatherPanel = new PullTransferPanel(transferTerminationFuture);
-    tabbedPane.addTab(PullTransferPanel.TAB_NAME, null, gatherPanel, null);
-    PullTransferPanel.TAB_POSITION = 0;
-
-    uploadPanel = new PushTransferPanel(transferTerminationFuture);
-    tabbedPane.addTab(PushTransferPanel.TAB_NAME, null, uploadPanel, null);
-    PushTransferPanel.TAB_POSITION = 1;
-
-    exportPanel = new ExportPanel(exportTerminationFuture);
-    tabbedPane.addTab(ExportPanel.TAB_NAME, null, exportPanel, null);
-    frame.getContentPane().setLayout(groupLayout);
-    ExportPanel.TAB_POSITION = 2;
-
-    settingsPanel = new SettingsPanel(this);
-    tabbedPane.addTab(SettingsPanel.TAB_NAME, null, settingsPanel, null);
-
-    frame.addWindowListener(this);
-    setFullUIEnabled(false);
-
-    frame.setFocusTraversalPolicy(new FocusTraversalPolicy() {
-
-      @Override
-      public Component getComponentAfter(Container arg0, Component arg1) {
-        ArrayList<Component> componentOrdering = new ArrayList<Component>();
-        for (;;) {
-          int nextPanel = PullTransferPanel.TAB_POSITION; 
-          componentOrdering.clear();
-          componentOrdering.add(tabbedPane);
-          int idx = tabbedPane.getSelectedIndex();
-          if ( idx == PullTransferPanel.TAB_POSITION ) {
-            componentOrdering.addAll(gatherPanel.getTraversalOrdering());
-            nextPanel = PushTransferPanel.TAB_POSITION;
-          } else if ( idx == PushTransferPanel.TAB_POSITION ) {
-            componentOrdering.addAll(uploadPanel.getTraversalOrdering());
-            nextPanel = ExportPanel.TAB_POSITION;
-          } else if ( idx == ExportPanel.TAB_POSITION ) {
-            componentOrdering.addAll(exportPanel.getTraversalOrdering());
-            nextPanel = PullTransferPanel.TAB_POSITION;
-          }
-          boolean found = false;
-          for ( int i = 0 ; i < componentOrdering.size() - 1 ; ++i ) {
-            if ( found || arg1 == componentOrdering.get(i) ) {
-              found = true;
-              Component comp = componentOrdering.get(i + 1);
-              if ( comp == tabbedPane ) {
-                return comp;
-              }
-              if ( comp.isVisible()  && (!(comp instanceof JTextField) || ((JTextField) comp).isEditable()) ) {
-                return comp;
-              }
-            }
-          }
-          if ( !found ) {
-            return componentOrdering.get(0);
-          }
-
-          tabbedPane.setSelectedIndex(nextPanel);
-        }
-      }
-
-      @Override
-      public Component getComponentBefore(Container arg0, Component arg1) {
-        ArrayList<Component> componentOrdering = new ArrayList<Component>();
-        for (;;) {
-          int nextPanel = PullTransferPanel.TAB_POSITION;
-          componentOrdering.clear();
-          componentOrdering.add(tabbedPane);
-          int idx = tabbedPane.getSelectedIndex();
-          if ( idx == PullTransferPanel.TAB_POSITION ) {
-            componentOrdering.addAll(gatherPanel.getTraversalOrdering());
-            nextPanel = ExportPanel.TAB_POSITION;
-          } else if ( idx == PushTransferPanel.TAB_POSITION ) {
-            componentOrdering.addAll(uploadPanel.getTraversalOrdering());
-            nextPanel = PullTransferPanel.TAB_POSITION;
-          } else if ( idx == ExportPanel.TAB_POSITION ) {
-            componentOrdering.addAll(exportPanel.getTraversalOrdering());
-            nextPanel = PushTransferPanel.TAB_POSITION;
-          }
-          boolean found = false;
-          for ( int i = componentOrdering.size() - 1 ; i > 0 ; --i ) {
-            if ( found || arg1 == componentOrdering.get(i) ) {
-              found = true;
-              Component comp = componentOrdering.get(i - 1);
-              if ( comp == tabbedPane ) {
-                return comp;
-              }
-              if ( comp.isVisible()  && (!(comp instanceof JTextField) || ((JTextField) comp).isEditable()) ) {
-                return comp;
-              }
-            }
-          }
-          if ( !found ) {
-            return componentOrdering.get(componentOrdering.size() - 1);
-          }
-          tabbedPane.setSelectedIndex(nextPanel);
-        }
-      }
-
-      @Override
-      public Component getDefaultComponent(Container arg0) {
-        return tabbedPane;
-      }
-
-      @Override
-      public Component getFirstComponent(Container arg0) {
-        return tabbedPane;
-      }
-
-      @Override
-      public Component getLastComponent(Container arg0) {
-        return tabbedPane;
-      }
-    });
-  }
-
-  public void establishBriefcaseStorageLocation(boolean showDialog) {
-    // set the enabled/disabled status of the panels based upon validity of default briefcase directory.
-    String briefcaseDir = BriefcasePreferences.getBriefcaseDirectoryIfSet();
-    boolean reset = false;
-    if ( briefcaseDir == null ) {
-      reset = true;
-    } else {
-      File dir = new File(briefcaseDir);
-      if ( !dir.exists() || !dir.isDirectory()) {
-        reset = true;
-      } else {
-        File folder = FileSystemUtils.getBriefcaseFolder();
-        if ( !folder.exists() || !folder.isDirectory()) {
-          reset = true;
-        }
-
-      }
-    }
-
-    if ( showDialog || reset ) {
-      // ask for new briefcase location...
-      BriefcaseStorageLocationDialog fs =
-          new BriefcaseStorageLocationDialog(MainBriefcaseWindow.this.frame);
-      
-      // If reset is not needed, dialog has been triggered from Settings page
-      if (!reset) {
-    	  fs.updateForSettingsPage();
-      }
-      
-      fs.setVisible(true);
-      if ( fs.isCancelled() ) {
-        // if we need to reset the briefcase location,
-        // and have cancelled, then disable the UI.
-        // otherwise the value we have is fine.
-        setFullUIEnabled(!reset);
-      } else {
-        String briefcasePath = BriefcasePreferences.getBriefcaseDirectoryIfSet();
-        if ( briefcasePath == null ) {
-          // we had a bad path -- disable all but Choose...
-          setFullUIEnabled(false);
+                        MainBriefcaseWindow window = new MainBriefcaseWindow();
+                        window.frame.setTitle(BRIEFCASE_VERSION);
+                        ImageIcon icon = new ImageIcon(MainBriefcaseWindow.class.getClassLoader().getResource("odk_logo.png"));
+                        window.frame.setIconImage(icon.getImage());
+                        window.frame.setVisible(true);
+                    } catch (Exception e) {
+                        log.error("failed to launch app", e);
+                    }
+                }
+            });
         } else {
-          setFullUIEnabled(true);
+            Options options = addOptions();
+            CommandLineParser parser = new DefaultParser();
+            CommandLine cmd = null;
+
+            try {
+                cmd = parser.parse(options, args);
+            } catch (ParseException e1) {
+                log.error("Launch Failed: " + e1.getMessage());
+                showHelp(options);
+                System.exit(1);
+            }
+
+            if (cmd.hasOption(HELP)) {
+                showHelp(options);
+                System.exit(1);
+            }
+
+            if (cmd.hasOption(VERSION)) {
+                showVersion();
+                System.exit(1);
+            }
+
+            // required for all operations
+            if (!cmd.hasOption(FORM_ID) || !cmd.hasOption(STORAGE_DIRECTORY)) {
+                log.error(FORM_ID + " and " + STORAGE_DIRECTORY + " are required");
+                showHelp(options);
+                System.exit(1);
+            }
+
+            // pull from collect or aggregate, not both
+            if (cmd.hasOption(ODK_DIR) && cmd.hasOption(AGGREGATE_URL)) {
+                log.error("Can only have one of " + ODK_DIR + " or " + AGGREGATE_URL);
+                showHelp(options);
+                System.exit(1);
+            }
+
+            // pull from aggregate
+            if (cmd.hasOption(AGGREGATE_URL) && (!(cmd.hasOption(ODK_USERNAME) && cmd.hasOption(ODK_PASSWORD)))) {
+                log.error(ODK_USERNAME + " and " + ODK_PASSWORD + " required when " + AGGREGATE_URL + " is specified");
+                showHelp(options);
+                System.exit(1);
+            }
+
+            // export files
+            if (cmd.hasOption(EXPORT_DIRECTORY) && !cmd.hasOption(EXPORT_FILENAME) || !cmd.hasOption(EXPORT_DIRECTORY) && cmd.hasOption(EXPORT_FILENAME)) {
+                log.error(EXPORT_DIRECTORY + " and " + EXPORT_FILENAME + " are both required to export");
+                showHelp(options);
+                System.exit(1);
+            }
+
+            if (cmd.hasOption(EXPORT_END_DATE)) {
+                if (!testDateFormat(cmd.getOptionValue(EXPORT_END_DATE))) {
+                    log.error("Invalid date format in " + EXPORT_END_DATE);
+                    showHelp(options);
+                    System.exit(1);
+                }
+            }
+            if (cmd.hasOption(EXPORT_START_DATE)) {
+                if (!testDateFormat(cmd.getOptionValue(EXPORT_START_DATE))) {
+                    log.error("Invalid date format in " + EXPORT_START_DATE);
+                    showHelp(options);
+                    System.exit(1);
+                }
+            }
+
+
+            BriefcaseCLI bcli = new BriefcaseCLI(cmd);
+            bcli.run();
         }
-      }
-    } else {
-      File f = new File( BriefcasePreferences.getBriefcaseDirectoryProperty());
-      if (BriefcaseFolderChooser.testAndMessageBadBriefcaseStorageLocationParentFolder(f, frame)) {
-        try {
-          FileSystemUtils.assertBriefcaseStorageLocationParentFolder(f);
-          setFullUIEnabled(true);
-        } catch (FileSystemException e1) {
-          String msg = "Unable to create " + FileSystemUtils.BRIEFCASE_DIR;
-          log.error(msg, e1);
-          ODKOptionPane.showErrorDialog(frame, msg, "Failed to Create " + FileSystemUtils.BRIEFCASE_DIR);
-          // we had a bad path -- disable all but Choose...
-          setFullUIEnabled(false);
-        }
-      } else {
-        // we had a bad path -- disable all but Choose...
-        setFullUIEnabled(false);
-      }
     }
-  }
 
-  @Override
-  public void windowActivated(WindowEvent arg0) {
-    // NO-OP
-  }
+    void setFullUIEnabled(boolean state) {
+        String path = BriefcasePreferences.getBriefcaseDirectoryIfSet();
+        if ( path != null ) {
+            settingsPanel.getTxtBriefcaseDir().setText(path + File.separator + FileSystemUtils.BRIEFCASE_DIR);
+        } else {
+            settingsPanel.getTxtBriefcaseDir().setText("");
+        }
+        if ( state ) {
+            exportPanel.updateComboBox();
+            uploadPanel.updateFormStatuses();
+            exportPanel.setEnabled(true);
+            gatherPanel.setEnabled(true);
+            uploadPanel.setEnabled(true);
+            tabbedPane.setEnabled(true);
+        } else {
+            exportPanel.setEnabled(false);
+            gatherPanel.setEnabled(false);
+            uploadPanel.setEnabled(false);
+            tabbedPane.setEnabled(false);
+        }
+    }
 
-  @Override
-  public void windowClosed(WindowEvent arg0) {
-    // NO-OP
-  }
+    /**
+     * Create the application.
+     */
+    public MainBriefcaseWindow() {
+        frame = new JFrame();
+        frame.setBounds(100, 100, 680, 595);
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
-  @Override
-  public void windowClosing(WindowEvent arg0) {
-    exportTerminationFuture.markAsCancelled(new ExportAbortEvent("Main window closed"));
-    transferTerminationFuture.markAsCancelled(new TransferAbortEvent("Main window closed"));
-  }
+        frame.addWindowListener(new WindowListener() {
+            @Override
+            public void windowOpened(WindowEvent e) {
+            }
 
-  @Override
-  public void windowDeactivated(WindowEvent arg0) {
-    // NO-OP
-  }
+            @Override
+            public void windowClosing(WindowEvent e) {
+            }
 
-  @Override
-  public void windowDeiconified(WindowEvent arg0) {
-    // NO-OP
-  }
+            @Override
+            public void windowClosed(WindowEvent e) {
+            }
 
-  @Override
-  public void windowIconified(WindowEvent arg0) {
-    // NO-OP
-  }
+            @Override
+            public void windowIconified(WindowEvent e) {
+            }
 
-  @Override
-  public void windowOpened(WindowEvent arg0) {
-    establishBriefcaseStorageLocation(false);
-  }
+            @Override
+            public void windowDeiconified(WindowEvent e) {
+            }
 
-  static void showHelp(Options options) {
-    HelpFormatter formatter = new HelpFormatter();
-    formatter.printHelp("java -jar briefcase.jar", options);
-  }
+            @Override
+            public void windowActivated(WindowEvent e) {
+            }
 
-  static void showVersion() {
-    System.out.println("version: " + BriefcasePreferences.VERSION);
-}
+            @Override
+            public void windowDeactivated(WindowEvent e) {
+            }
+        });
 
-  /**
-   * Setting up options for Command Line Interface
-   * @return
-   */
-  static Options addOptions() {
-    Options options = new Options();
+        tabbedPane = new JTabbedPane(JTabbedPane.TOP);
+        GroupLayout groupLayout = new GroupLayout(frame.getContentPane());
+        groupLayout.setHorizontalGroup(groupLayout.createParallelGroup(Alignment.LEADING).addGroup(
+                groupLayout
+                        .createSequentialGroup()
+                        .addContainerGap()
+                        .addGroup(
+                                groupLayout
+                                        .createParallelGroup(Alignment.LEADING)
+                                        .addComponent(tabbedPane, Alignment.TRAILING, GroupLayout.DEFAULT_SIZE, 628,
+                                                Short.MAX_VALUE))
+                        .addContainerGap()));
+        groupLayout.setVerticalGroup(groupLayout.createParallelGroup(Alignment.LEADING).addGroup(
+                groupLayout
+                        .createSequentialGroup()
+                        .addContainerGap()
+                        .addComponent(tabbedPane, GroupLayout.DEFAULT_SIZE, 446, Short.MAX_VALUE)
+                        .addContainerGap()));
 
-    Option server = Option.builder("url")
-        .argName("url")
-        .hasArg()
-        .longOpt(AGGREGATE_URL)
-        .desc("ODK Aggregate URL (must start with http:// or https://)")
-        .build();
+        gatherPanel = new PullTransferPanel(transferTerminationFuture);
+        tabbedPane.addTab(PullTransferPanel.TAB_NAME, null, gatherPanel, null);
+        PullTransferPanel.TAB_POSITION = 0;
 
-    Option username = Option.builder("u")
-        .argName("username")
-        .hasArg()
-        .longOpt(ODK_USERNAME)
-        .desc("ODK username")
-        .build();
+        uploadPanel = new PushTransferPanel(transferTerminationFuture);
+        tabbedPane.addTab(PushTransferPanel.TAB_NAME, null, uploadPanel, null);
+        PushTransferPanel.TAB_POSITION = 1;
 
-    Option password = Option.builder("p")
-        .argName("password")
-        .hasArg()
-        .longOpt(ODK_PASSWORD)
-        .desc("ODK password")
-        .build();
+        exportPanel = new ExportPanel(exportTerminationFuture);
+        tabbedPane.addTab(ExportPanel.TAB_NAME, null, exportPanel, null);
+        frame.getContentPane().setLayout(groupLayout);
+        ExportPanel.TAB_POSITION = 2;
 
-    Option formid = Option.builder("id")
-        .argName("form_id")
-        .hasArg()
-        .longOpt(FORM_ID)
-        .desc("Form ID of form to download and export")
-        .build();
+        settingsPanel = new SettingsPanel(this);
+        tabbedPane.addTab(SettingsPanel.TAB_NAME, null, settingsPanel, null);
 
-    Option storageDir = Option.builder("sd")
-        .argName("/path/to/dir")
-        .hasArg()
-        .longOpt(STORAGE_DIRECTORY)
-        .desc("Directory to create or find ODK Briefcase Storage directory (relative path unless it begins with / or C:\\)")
-        .build();
+        frame.addWindowListener(this);
+        setFullUIEnabled(false);
 
-    Option exportDir = Option.builder("ed")
-        .argName("/path/to/dir")
-        .hasArg()
-        .longOpt(EXPORT_DIRECTORY)
-        .desc("Directory to export the CSV and media files into (relative path unless it begins with / or C:\\)")
-        .build();
+        frame.setFocusTraversalPolicy(new FocusTraversalPolicy() {
 
-    Option exportMedia = Option.builder("em")
-        .longOpt(EXCLUDE_MEDIA_EXPORT)
-        .desc("Flag to exclude media on export")
-        .build();
+            @Override
+            public Component getComponentAfter(Container arg0, Component arg1) {
+                ArrayList<Component> componentOrdering = new ArrayList<Component>();
+                for (;;) {
+                    int nextPanel = PullTransferPanel.TAB_POSITION;
+                    componentOrdering.clear();
+                    componentOrdering.add(tabbedPane);
+                    int idx = tabbedPane.getSelectedIndex();
+                    if ( idx == PullTransferPanel.TAB_POSITION ) {
+                        componentOrdering.addAll(gatherPanel.getTraversalOrdering());
+                        nextPanel = PushTransferPanel.TAB_POSITION;
+                    } else if ( idx == PushTransferPanel.TAB_POSITION ) {
+                        componentOrdering.addAll(uploadPanel.getTraversalOrdering());
+                        nextPanel = ExportPanel.TAB_POSITION;
+                    } else if ( idx == ExportPanel.TAB_POSITION ) {
+                        componentOrdering.addAll(exportPanel.getTraversalOrdering());
+                        nextPanel = PullTransferPanel.TAB_POSITION;
+                    }
+                    boolean found = false;
+                    for ( int i = 0 ; i < componentOrdering.size() - 1 ; ++i ) {
+                        if ( found || arg1 == componentOrdering.get(i) ) {
+                            found = true;
+                            Component comp = componentOrdering.get(i + 1);
+                            if ( comp == tabbedPane ) {
+                                return comp;
+                            }
+                            if ( comp.isVisible()  && (!(comp instanceof JTextField) || ((JTextField) comp).isEditable()) ) {
+                                return comp;
+                            }
+                        }
+                    }
+                    if ( !found ) {
+                        return componentOrdering.get(0);
+                    }
 
-    Option startDate = Option.builder("start")
-        .argName(DATE_FORMAT)
-        .hasArg()
-        .longOpt(EXPORT_START_DATE)
-        .desc("Include submission dates after (inclusive) this date in export to CSV")
-        .build();
+                    tabbedPane.setSelectedIndex(nextPanel);
+                }
+            }
 
-    Option endDate = Option.builder("end")
-        .argName(DATE_FORMAT)
-        .hasArg()
-        .longOpt(EXPORT_END_DATE)
-        .desc("Include submission dates before (exclusive) this date in export to CSV")
-        .build();
+            @Override
+            public Component getComponentBefore(Container arg0, Component arg1) {
+                ArrayList<Component> componentOrdering = new ArrayList<Component>();
+                for (;;) {
+                    int nextPanel = PullTransferPanel.TAB_POSITION;
+                    componentOrdering.clear();
+                    componentOrdering.add(tabbedPane);
+                    int idx = tabbedPane.getSelectedIndex();
+                    if ( idx == PullTransferPanel.TAB_POSITION ) {
+                        componentOrdering.addAll(gatherPanel.getTraversalOrdering());
+                        nextPanel = ExportPanel.TAB_POSITION;
+                    } else if ( idx == PushTransferPanel.TAB_POSITION ) {
+                        componentOrdering.addAll(uploadPanel.getTraversalOrdering());
+                        nextPanel = PullTransferPanel.TAB_POSITION;
+                    } else if ( idx == ExportPanel.TAB_POSITION ) {
+                        componentOrdering.addAll(exportPanel.getTraversalOrdering());
+                        nextPanel = PushTransferPanel.TAB_POSITION;
+                    }
+                    boolean found = false;
+                    for ( int i = componentOrdering.size() - 1 ; i > 0 ; --i ) {
+                        if ( found || arg1 == componentOrdering.get(i) ) {
+                            found = true;
+                            Component comp = componentOrdering.get(i - 1);
+                            if ( comp == tabbedPane ) {
+                                return comp;
+                            }
+                            if ( comp.isVisible()  && (!(comp instanceof JTextField) || ((JTextField) comp).isEditable()) ) {
+                                return comp;
+                            }
+                        }
+                    }
+                    if ( !found ) {
+                        return componentOrdering.get(componentOrdering.size() - 1);
+                    }
+                    tabbedPane.setSelectedIndex(nextPanel);
+                }
+            }
 
-    Option exportFilename = Option.builder("f")
-        .argName("name.csv")
-        .hasArg()
-        .longOpt(EXPORT_FILENAME)
-        .desc("File name for exported CSV")
-        .build();
+            @Override
+            public Component getDefaultComponent(Container arg0) {
+                return tabbedPane;
+            }
 
-    Option overwrite = Option.builder("oc")
-        .longOpt(OVERWRITE_CSV_EXPORT)
-        .desc("Flag to overwrite CSV on export")
-        .build();
+            @Override
+            public Component getFirstComponent(Container arg0) {
+                return tabbedPane;
+            }
 
-    Option help = Option.builder("h")
-        .longOpt(HELP)
-        .desc("Print help information (this screen)")
-        .build();
+            @Override
+            public Component getLastComponent(Container arg0) {
+                return tabbedPane;
+            }
+        });
+    }
 
-    Option version = Option.builder("v")
-        .longOpt(VERSION)
-        .desc("Print version information")
-        .build();
+    public void establishBriefcaseStorageLocation(boolean showDialog) {
+        // set the enabled/disabled status of the panels based upon validity of default briefcase directory.
+        String briefcaseDir = BriefcasePreferences.getBriefcaseDirectoryIfSet();
+        boolean reset = false;
+        if ( briefcaseDir == null ) {
+            reset = true;
+        } else {
+            File dir = new File(briefcaseDir);
+            if ( !dir.exists() || !dir.isDirectory()) {
+                reset = true;
+            } else {
+                File folder = FileSystemUtils.getBriefcaseFolder();
+                if ( !folder.exists() || !folder.isDirectory()) {
+                    reset = true;
+                }
 
-    Option odkDir = Option.builder("od")
-        .argName("/path/to/dir")
-        .hasArg()
-        .longOpt(ODK_DIR)
-        .desc("/odk directory from ODK Collect (relative path unless it begins with / or C:\\)")
-        .build();
+            }
+        }
 
-    Option keyFile = Option.builder("pf")
-        .argName("/path/to/file.pem")
-        .hasArg()
-        .longOpt(PEM_FILE)
-        .desc("PEM private key file (relative path unless it begins with / or C:\\)")
-        .build();
+        if ( showDialog || reset ) {
+            // ask for new briefcase location...
+            BriefcaseStorageLocationDialog fs =
+                    new BriefcaseStorageLocationDialog(MainBriefcaseWindow.this.frame);
 
-    options.addOption(server);
-    options.addOption(username);
-    options.addOption(password);
-    options.addOption(formid);
-    options.addOption(storageDir);
-    options.addOption(exportDir);
-    options.addOption(exportMedia);
-    options.addOption(startDate);
-    options.addOption(endDate);
-    options.addOption(exportFilename);
-    options.addOption(overwrite);
-    options.addOption(help);
-    options.addOption(version);
-    options.addOption(odkDir);
-    options.addOption(keyFile);
+            // If reset is not needed, dialog has been triggered from Settings page
+            if (!reset) {
+                fs.updateForSettingsPage();
+            }
 
-    return options;
-  }
-  
-  static boolean testDateFormat(String date) {
-      try {
-          DateFormat df = new SimpleDateFormat(DATE_FORMAT);
-          df.parse(date);
-      } catch (java.text.ParseException e) {
-          return false;     
-      }
-      return true;         
-  }
+            fs.setVisible(true);
+            if ( fs.isCancelled() ) {
+                // if we need to reset the briefcase location,
+                // and have cancelled, then disable the UI.
+                // otherwise the value we have is fine.
+                setFullUIEnabled(!reset);
+            } else {
+                String briefcasePath = BriefcasePreferences.getBriefcaseDirectoryIfSet();
+                if ( briefcasePath == null ) {
+                    // we had a bad path -- disable all but Choose...
+                    setFullUIEnabled(false);
+                } else {
+                    setFullUIEnabled(true);
+                }
+            }
+        } else {
+            File f = new File( BriefcasePreferences.getBriefcaseDirectoryProperty());
+            if (BriefcaseFolderChooser.testAndMessageBadBriefcaseStorageLocationParentFolder(f, frame)) {
+                try {
+                    FileSystemUtils.assertBriefcaseStorageLocationParentFolder(f);
+                    setFullUIEnabled(true);
+                } catch (FileSystemException e1) {
+                    String msg = "Unable to create " + FileSystemUtils.BRIEFCASE_DIR;
+                    log.error(msg, e1);
+                    ODKOptionPane.showErrorDialog(frame, msg, "Failed to Create " + FileSystemUtils.BRIEFCASE_DIR);
+                    // we had a bad path -- disable all but Choose...
+                    setFullUIEnabled(false);
+                }
+            } else {
+                // we had a bad path -- disable all but Choose...
+                setFullUIEnabled(false);
+            }
+        }
+    }
+
+    @Override
+    public void windowActivated(WindowEvent arg0) {
+        // NO-OP
+    }
+
+    @Override
+    public void windowClosed(WindowEvent arg0) {
+        // NO-OP
+    }
+
+    @Override
+    public void windowClosing(WindowEvent arg0) {
+        exportTerminationFuture.markAsCancelled(new ExportAbortEvent("Main window closed"));
+        transferTerminationFuture.markAsCancelled(new TransferAbortEvent("Main window closed"));
+    }
+
+    @Override
+    public void windowDeactivated(WindowEvent arg0) {
+        // NO-OP
+    }
+
+    @Override
+    public void windowDeiconified(WindowEvent arg0) {
+        // NO-OP
+    }
+
+    @Override
+    public void windowIconified(WindowEvent arg0) {
+        // NO-OP
+    }
+
+    @Override
+    public void windowOpened(WindowEvent arg0) {
+        establishBriefcaseStorageLocation(false);
+    }
+
+    static void showHelp(Options options) {
+        HelpFormatter formatter = new HelpFormatter();
+        formatter.printHelp("java -jar briefcase.jar", options);
+    }
+
+    static void showVersion() {
+        System.out.println("version: " + BriefcasePreferences.VERSION);
+    }
+
+    /**
+     * Setting up options for Command Line Interface
+     * @return
+     */
+    static Options addOptions() {
+        Options options = new Options();
+
+        Option server = Option.builder("url")
+                .argName("url")
+                .hasArg()
+                .longOpt(AGGREGATE_URL)
+                .desc("ODK Aggregate URL (must start with http:// or https://)")
+                .build();
+
+        Option username = Option.builder("u")
+                .argName("username")
+                .hasArg()
+                .longOpt(ODK_USERNAME)
+                .desc("ODK username")
+                .build();
+
+        Option password = Option.builder("p")
+                .argName("password")
+                .hasArg()
+                .longOpt(ODK_PASSWORD)
+                .desc("ODK password")
+                .build();
+
+        Option formid = Option.builder("id")
+                .argName("form_id")
+                .hasArg()
+                .longOpt(FORM_ID)
+                .desc("Form ID of form to download and export")
+                .build();
+
+        Option storageDir = Option.builder("sd")
+                .argName("/path/to/dir")
+                .hasArg()
+                .longOpt(STORAGE_DIRECTORY)
+                .desc("Directory to create or find ODK Briefcase Storage directory (relative path unless it begins with / or C:\\)")
+                .build();
+
+        Option exportDir = Option.builder("ed")
+                .argName("/path/to/dir")
+                .hasArg()
+                .longOpt(EXPORT_DIRECTORY)
+                .desc("Directory to export the CSV and media files into (relative path unless it begins with / or C:\\)")
+                .build();
+
+        Option exportMedia = Option.builder("em")
+                .longOpt(EXCLUDE_MEDIA_EXPORT)
+                .desc("Flag to exclude media on export")
+                .build();
+
+        Option startDate = Option.builder("start")
+                .argName(DATE_FORMAT)
+                .hasArg()
+                .longOpt(EXPORT_START_DATE)
+                .desc("Include submission dates after (inclusive) this date in export to CSV")
+                .build();
+
+        Option endDate = Option.builder("end")
+                .argName(DATE_FORMAT)
+                .hasArg()
+                .longOpt(EXPORT_END_DATE)
+                .desc("Include submission dates before (exclusive) this date in export to CSV")
+                .build();
+
+        Option exportFilename = Option.builder("f")
+                .argName("name.csv")
+                .hasArg()
+                .longOpt(EXPORT_FILENAME)
+                .desc("File name for exported CSV")
+                .build();
+
+        Option overwrite = Option.builder("oc")
+                .longOpt(OVERWRITE_CSV_EXPORT)
+                .desc("Flag to overwrite CSV on export")
+                .build();
+
+        Option help = Option.builder("h")
+                .longOpt(HELP)
+                .desc("Print help information (this screen)")
+                .build();
+
+        Option version = Option.builder("v")
+                .longOpt(VERSION)
+                .desc("Print version information")
+                .build();
+
+        Option odkDir = Option.builder("od")
+                .argName("/path/to/dir")
+                .hasArg()
+                .longOpt(ODK_DIR)
+                .desc("/odk directory from ODK Collect (relative path unless it begins with / or C:\\)")
+                .build();
+
+        Option keyFile = Option.builder("pf")
+                .argName("/path/to/file.pem")
+                .hasArg()
+                .longOpt(PEM_FILE)
+                .desc("PEM private key file (relative path unless it begins with / or C:\\)")
+                .build();
+
+        options.addOption(server);
+        options.addOption(username);
+        options.addOption(password);
+        options.addOption(formid);
+        options.addOption(storageDir);
+        options.addOption(exportDir);
+        options.addOption(exportMedia);
+        options.addOption(startDate);
+        options.addOption(endDate);
+        options.addOption(exportFilename);
+        options.addOption(overwrite);
+        options.addOption(help);
+        options.addOption(version);
+        options.addOption(odkDir);
+        options.addOption(keyFile);
+
+        return options;
+    }
+
+    static boolean testDateFormat(String date) {
+        try {
+            DateFormat df = new SimpleDateFormat(DATE_FORMAT);
+            df.parse(date);
+        } catch (java.text.ParseException e) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -63,7 +63,7 @@ public class MainBriefcaseWindow implements WindowListener {
     private SettingsPanel settingsPanel;
     private final TerminationFuture exportTerminationFuture = new TerminationFuture();
     private final TerminationFuture transferTerminationFuture = new TerminationFuture();
-    private static BriefcaseAnalytics briefcaseAnalytics = BriefcaseAnalytics.getInstance();
+    private BriefcaseAnalytics briefcaseAnalytics = new BriefcaseAnalytics();
 
     public static final String AGGREGATE_URL = "aggregate_url";
     public static final String DATE_FORMAT = "yyyy/MM/dd";
@@ -90,8 +90,6 @@ public class MainBriefcaseWindow implements WindowListener {
      * Launch the application.
      */
     public static void main(String[] args) {
-
-        briefcaseAnalytics.trackStartup();
 
         if (args.length == 0) {
 
@@ -209,6 +207,8 @@ public class MainBriefcaseWindow implements WindowListener {
      * Create the application.
      */
     public MainBriefcaseWindow() {
+        briefcaseAnalytics.trackStartup();
+
         frame = new JFrame();
         frame.setBounds(100, 100, 680, 595);
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);

--- a/src/test/java/org/opendatakit/briefcase/model/BriefcaseAnalyticsTest.java
+++ b/src/test/java/org/opendatakit/briefcase/model/BriefcaseAnalyticsTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.assertNotNull;
 
 public class BriefcaseAnalyticsTest {
     @Test
-    public void canGetBriefcaseAnalyticsInstance() {
+    public void canCreateBriefcaseAnalytics() {
         BriefcaseAnalytics ba = new BriefcaseAnalytics();
         assertNotNull(ba);
     }

--- a/src/test/java/org/opendatakit/briefcase/model/BriefcaseAnalyticsTest.java
+++ b/src/test/java/org/opendatakit/briefcase/model/BriefcaseAnalyticsTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertNotNull;
 public class BriefcaseAnalyticsTest {
     @Test
     public void canGetBriefcaseAnalyticsInstance() {
-        BriefcaseAnalytics ba = BriefcaseAnalytics.getInstance();
+        BriefcaseAnalytics ba = new BriefcaseAnalytics();
         assertNotNull(ba);
     }
 }


### PR DESCRIPTION
Fix critical problem in original implementation: data was in fact being sent to Google even when the user unchecked the checkbox. config.setGatherStats(false) does not disable the HTTP post to Google. New approach: wrap the post with if (BriefcasePreferences.getBriefcaseTrackingConsentProperty()).

Simplify code:
- remove the unneeded singleton logic
- remove the unneeded builder pattern to create the EventHits
- remove the unneeded code to prevent trackStartup from being called more than once

I don’t know why the commits are repeated. Perhaps because I renamed the local branch. Here is the [key commit](https://github.com/opendatakit/briefcase/pull/175/commits/0851336f527b97bb78554d2a61dec2306d497c3b).

#### What has been done to verify that this works as intended?
I ran in the debugger with the checkbox checked and unchecked and confirmed that the call to the Google Analytics library was made only at the appropriate time. I haven’t viewed the results in Google Analytics.

#### Why is this the best possible solution? Were any other approaches considered?
It’s very simple.

#### Are there any risks to merging this code? If so, what are they?
No