### PR TITLE
Remove “Exporting..........” message

### DIFF
--- a/src/org/opendatakit/briefcase/ui/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/ExportPanel.java
@@ -64,8 +64,6 @@ public class ExportPanel extends JPanel {
 
     static final String TAB_NAME = "Export";
 
-    private static final String EXPORTING_DOT_ETC = "Exporting..........";
-
     private final JTextField txtExportDirectory;
 
     private final JComboBox<ExportType> comboBoxExportType;
@@ -337,7 +335,7 @@ public class ExportPanel extends JPanel {
         pickStartDate = new DatePicker();
         pickEndDate = new DatePicker();
 
-        lblExporting = new JLabel(EXPORTING_DOT_ETC);
+        lblExporting = new JLabel("");
         lblExporting.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
 
         progressBar = new JProgressBar(0, 100);


### PR DESCRIPTION
This “Exporting..........” text seems to be a vestage of an earlier method of showing progress. It was being cleared (and never seen), but I recently inadvertently removed code that prevented it from ever being seen. This change removes the vestage altogether.

Closes 181

#### What has been done to verify that this works as intended?
I ran with no forms and saw that the label is clear. Then I pulled a form and did an export and saw that the label changed to a success message.

#### Why is this the best possible solution? Were any other approaches considered?
It removes no longer used code.

#### Are there any risks to merging this code? If so, what are they?
None that I can see.