### PR TITLE
Do not show Google Analytics UI

### DIFF
--- a/src/org/opendatakit/briefcase/ui/SettingsPanel.java
+++ b/src/org/opendatakit/briefcase/ui/SettingsPanel.java
@@ -91,7 +91,7 @@ public class SettingsPanel extends JPanel {
                 .addComponent(chkProxy)
                 .addComponent(chkParallel)
 //                .addComponent(chkTrackingConsent)
-            )
+)
             .addGroup(
               groupLayout.createParallelGroup(Alignment.LEADING)
                 .addGroup(
@@ -112,7 +112,7 @@ public class SettingsPanel extends JPanel {
                         .addComponent(spinPort, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE)))
                       .addComponent(lblParallel)
 //                      .addComponent(lblTrackingConsent)
-            )
+)
             .addContainerGap()
         );
         groupLayout.setVerticalGroup(
@@ -139,7 +139,7 @@ public class SettingsPanel extends JPanel {
               .addGroup(groupLayout.createParallelGroup(Alignment.CENTER)
 //                .addComponent(lblTrackingConsent)
 //                .addComponent(chkTrackingConsent)
-              )
+)
               .addContainerGap()
         );
 

--- a/src/org/opendatakit/briefcase/ui/SettingsPanel.java
+++ b/src/org/opendatakit/briefcase/ui/SettingsPanel.java
@@ -90,7 +90,8 @@ public class SettingsPanel extends JPanel {
               groupLayout.createParallelGroup(Alignment.TRAILING)
                 .addComponent(chkProxy)
                 .addComponent(chkParallel)
-                .addComponent(chkTrackingConsent))
+//                .addComponent(chkTrackingConsent)
+            )
             .addGroup(
               groupLayout.createParallelGroup(Alignment.LEADING)
                 .addGroup(
@@ -110,7 +111,8 @@ public class SettingsPanel extends JPanel {
                         .addComponent(txtHost, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE)
                         .addComponent(spinPort, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE)))
                       .addComponent(lblParallel)
-                      .addComponent(lblTrackingConsent))
+//                      .addComponent(lblTrackingConsent)
+            )
             .addContainerGap()
         );
         groupLayout.setVerticalGroup(
@@ -135,8 +137,9 @@ public class SettingsPanel extends JPanel {
                 .addComponent(lblParallel)
                 .addComponent(chkParallel))
               .addGroup(groupLayout.createParallelGroup(Alignment.CENTER)
-                .addComponent(lblTrackingConsent)
-                .addComponent(chkTrackingConsent))
+//                .addComponent(lblTrackingConsent)
+//                .addComponent(chkTrackingConsent)
+              )
               .addContainerGap()
         );
 


### PR DESCRIPTION
I'm submitting this PR because I think opt-in is not the way to go and I want to delay that decision until the next release.

#### What has been done to verify that this works as intended?
I ran the application and confirmed that the checkbox and label are not in the UI.

#### Why is this the best possible solution? Were any other approaches considered?
This is as minimal of a change as I could come up with. 

#### Are there any risks to merging this code? If so, what are they?
There might be an issue where developers who already have a previous build and have persisted the setting want to toggle it, but they can't because it's not in the UI.