### PR TITLE
Fix problem with cache file written to current working directory

### DIFF
--- a/src/org/opendatakit/briefcase/util/FileSystemUtils.java
+++ b/src/org/opendatakit/briefcase/util/FileSystemUtils.java
@@ -62,7 +62,7 @@ public class FileSystemUtils {
 
   static final Log log = LogFactory.getLog(FileSystemUtils.class);
 
-  private static FormCache formCache = new NullFormCache();
+  private static FormCacheble formCache = new NullFormCache();
 
   public static final String FORMS_DIR = "forms";
   static final String INSTANCE_DIR = "instances";

--- a/src/org/opendatakit/briefcase/util/FormCache.java
+++ b/src/org/opendatakit/briefcase/util/FormCache.java
@@ -11,7 +11,7 @@ import java.io.ObjectOutputStream;
 import java.util.HashMap;
 import java.util.Map;
 
-public class FormCache {
+public class FormCache implements FormCacheble {
     private final File cacheFile;
     private Map<String, String> pathToMd5Map = new HashMap<>();
     private Map<String, BriefcaseFormDefinition> pathToDefinitionMap = new HashMap<>();
@@ -46,14 +46,17 @@ public class FormCache {
         }
     }
 
+    @Override
     public String getFormFileMd5Hash(String filePath) {
         return pathToMd5Map.get(filePath);
     }
 
+    @Override
     public void putFormFileMd5Hash(String filePath, String md5Hash) {
         pathToMd5Map.put(filePath, md5Hash);
     }
 
+    @Override
     public BriefcaseFormDefinition getFormFileFormDefinition(String filePath) {
         if (pathToDefinitionMap == null) {
             pathToDefinitionMap = new HashMap<>();
@@ -61,6 +64,7 @@ public class FormCache {
         return pathToDefinitionMap.get(filePath);
     }
 
+    @Override
     public void putFormFileFormDefinition(String filePath, BriefcaseFormDefinition definition) {
         pathToDefinitionMap.put(filePath, definition);
     }

--- a/src/org/opendatakit/briefcase/util/FormCacheble.java
+++ b/src/org/opendatakit/briefcase/util/FormCacheble.java
@@ -1,0 +1,13 @@
+package org.opendatakit.briefcase.util;
+
+import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
+
+public interface FormCacheble {
+    String getFormFileMd5Hash(String filePath);
+
+    void putFormFileMd5Hash(String filePath, String md5Hash);
+
+    BriefcaseFormDefinition getFormFileFormDefinition(String filePath);
+
+    void putFormFileFormDefinition(String filePath, BriefcaseFormDefinition definition);
+}

--- a/src/org/opendatakit/briefcase/util/NullFormCache.java
+++ b/src/org/opendatakit/briefcase/util/NullFormCache.java
@@ -3,11 +3,7 @@ package org.opendatakit.briefcase.util;
 import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
 
 /** Until the storage location is set, there is no place for the cache file. This class allows avoiding null checks. */
-public class NullFormCache extends FormCache {
-    public NullFormCache() {
-        super(null);
-    }
-
+public class NullFormCache implements FormCacheble {
     @Override
     public String getFormFileMd5Hash(String filePath) {
         throw new UnsupportedOperationException("getFormFileMd5Hash");


### PR DESCRIPTION
Something small I missed in the change to FormCache.

Having NullFormCache implement an interface instead of extending FormCache avoids some “faking out” which caused a cache.ser file to be written to the CWD.