### PR TITLE
Use NOP binding for SLF4J

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     compile group: 'org.hsqldb', name: 'hsqldb', version: '2.4.0'
     compile group: 'com.brsanthu', name: 'google-analytics-java', version: '1.1.2'
     compile group: 'log4j', name: 'log4j', version: '1.2.17'
+    compile group: 'org.slf4j', name: 'slf4j-nop', version: '1.7.25'
 
     testCompile group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.25'
     testCompile group: 'junit', name: 'junit', version: '4.12'


### PR DESCRIPTION
Closes #168

#### What has been done to verify that this works as intended?
Ran `./gradlew run` and confirmed the error message does not show.

#### Why is this the best possible solution? Were any other approaches considered?
I followed the instructions at https://www.slf4j.org/codes.html#StaticLoggerBinder to ignore logging for now. An alternative would have been slf4j-simple.jar which would print logging messages, but I could not find an easy way to configure it, so I think we need to have a longer conversation about how best to do logging.

#### Are there any risks to merging this code? If so, what are they?
You can't see any logging output and that might not be desirable. But it's not worse than the current situation where you can't see logging output AND you get a weird error message.