### PR TITLE
Convert ALLCAPS messages into Sentence Case and remove '!'.

### DIFF
--- a/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
+++ b/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
@@ -290,12 +290,12 @@ public class BriefcaseCLI {
 
     @EventSubscriber(eventClass = ExportFailedEvent.class)
     public void failedCompletion(ExportFailedEvent event) {
-        log.error("FAILED!");
+        log.error("Failed.");
     }
 
     @EventSubscriber(eventClass = ExportSucceededEvent.class)
     public void successfulCompletion(ExportSucceededEvent event) {
-        log.info("SUCCEEDED!");
+        log.info("Succeeded.");
     }
 
     @EventSubscriber(eventClass = TransferFailedEvent.class)

--- a/src/org/opendatakit/briefcase/ui/CharsetConverterDialog.java
+++ b/src/org/opendatakit/briefcase/ui/CharsetConverterDialog.java
@@ -295,7 +295,7 @@ public class CharsetConverterDialog extends JDialog implements ActionListener {
     } else {
       JOptionPane.showMessageDialog(this,
               "It appears that your installed Java Runtime Environment does not support any charset encodings!",
-              "Error!", JOptionPane.ERROR_MESSAGE);
+              "Error", JOptionPane.ERROR_MESSAGE);
     }
   }
 

--- a/src/org/opendatakit/briefcase/ui/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/ExportPanel.java
@@ -555,22 +555,22 @@ public class ExportPanel extends JPanel {
 
     @EventSubscriber(eventClass = ExportFailedEvent.class)
     public void failedCompletion(ExportFailedEvent event) {
-        exportStatusList.append("\n").append("FAILED!");
-        lblExporting.setText("FAILED!");
+        exportStatusList.append("\n").append("Failed.");
+        lblExporting.setText("Failed.");
         setActiveExportState(false);
     }
 
     @EventSubscriber(eventClass = ExportSucceededEvent.class)
     public void successfulCompletion(ExportSucceededEvent event) {
-        exportStatusList.append("\n").append("SUCCEEDED!");
-        lblExporting.setText("SUCCEEDED!");
+        exportStatusList.append("\n").append("Succeeded.");
+        lblExporting.setText("Succeeded.");
         setActiveExportState(false);
     }
 
     @EventSubscriber(eventClass = ExportSucceededWithErrorsEvent.class)
     public void successfulCompletionWithErrors(ExportSucceededWithErrorsEvent event) {
-        exportStatusList.append("\n").append("SUCCEEDED, BUT WITH ERRORS!");
-        lblExporting.setText("SUCCEEDED, BUT WITH ERRORS. SEE DETAILS!");
+        exportStatusList.append("\n").append("Succeeded, but with errors.");
+        lblExporting.setText("Succeeded, but with errors. See details.");
         setActiveExportState(false);
     }
 

--- a/src/org/opendatakit/briefcase/ui/MainFormUploaderWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainFormUploaderWindow.java
@@ -221,13 +221,13 @@ public class MainFormUploaderWindow {
 
   @EventSubscriber(eventClass = TransferFailedEvent.class)
   public void failedCompletion(TransferFailedEvent event) {
-    lblUploading.setText("Failed!");
+    lblUploading.setText("Failed.");
     setActiveTransferState(false);
   }
 
   @EventSubscriber(eventClass = TransferSucceededEvent.class)
   public void successfulCompletion(TransferSucceededEvent event) {
-    lblUploading.setText("Succeeded!");
+    lblUploading.setText("Succeeded.");
     setActiveTransferState(false);
   }
   

--- a/src/org/opendatakit/briefcase/ui/ScrollingStatusListDialog.java
+++ b/src/org/opendatakit/briefcase/ui/ScrollingStatusListDialog.java
@@ -146,12 +146,12 @@ public class ScrollingStatusListDialog extends JDialog implements ActionListener
   
   @EventSubscriber(eventClass = ExportFailedEvent.class)
   public void onEvent(ExportFailedEvent event) {
-    appendToDocument(editorArea,"FAILED!");
+    appendToDocument(editorArea,"Failed.");
   }
 
   @EventSubscriber(eventClass = ExportSucceededEvent.class)
   public void onEvent(ExportSucceededEvent event) {
-    appendToDocument(editorArea,"SUCCEEDED!");
+    appendToDocument(editorArea,"Succeeded.");
   }
 
   private void appendToDocument(JTextComponent component, String msg) {

--- a/src/org/opendatakit/briefcase/util/ExportToCsv.java
+++ b/src/org/opendatakit/briefcase/util/ExportToCsv.java
@@ -166,7 +166,7 @@ public class ExportToCsv implements ITransformFormAction {
 
     for (File instanceDir : instances) {
       if ( terminationFuture.isCancelled() ) {
-        EventBus.publish(new ExportProgressEvent("ABORTED"));
+        EventBus.publish(new ExportProgressEvent("Aborted"));
         allSuccessful = false;
         break;
       }
@@ -924,7 +924,7 @@ public class ExportToCsv implements ITransformFormAction {
       }
 
       if ( terminationFuture.isCancelled() ) {
-        EventBus.publish(new ExportProgressEvent("ABORTED"));
+        EventBus.publish(new ExportProgressEvent("Aborted"));
         return false;
       }
 

--- a/src/org/opendatakit/briefcase/util/ServerFetcher.java
+++ b/src/org/opendatakit/briefcase/util/ServerFetcher.java
@@ -68,8 +68,8 @@ public class ServerFetcher {
 
   private TerminationFuture terminationFuture;
 
-  public static String SUCCESS_STATUS = "SUCCESS!";
-  public static String FAILED_STATUS = "FAILED.";
+  public static String SUCCESS_STATUS = "Success.";
+  public static String FAILED_STATUS = "Failed.";
 
   public static class FormListException extends Exception {
 
@@ -346,7 +346,7 @@ public class ServerFetcher {
           } catch (InterruptedException | ExecutionException e) {
             log.error("failure during submission download", e);
             allSuccessful = false;
-            fs.setStatusString("SUBMISSION NOT RETRIEVED: " + e.getMessage(), false);
+            fs.setStatusString("Submission not retrieved: " + e.getMessage(), false);
             EventBus.publish(new FormStatusEvent(fs));
             // but try to get the next one...
           }
@@ -390,11 +390,11 @@ public class ServerFetcher {
         AggregateUtils.DocumentFetchResult fetchResult = AggregateUtils.getXmlDocument(fullUrl, serverInfo, false, submissionChunkDescription, null);
         return XmlManipulationUtils.parseSubmissionDownloadListResponse(fetchResult.doc);
       } catch (XmlDocumentFetchException e) {
-        fs.setStatusString("NOT ALL SUBMISSIONS RETRIEVED: Error fetching list of submissions: " + e.getMessage(), false);
+        fs.setStatusString("Not all submissions retrieved: Error fetching list of submissions: " + e.getMessage(), false);
         EventBus.publish(new FormStatusEvent(fs));
         throw e;
       } catch (ParsingException e) {
-        fs.setStatusString("NOT ALL SUBMISSIONS RETRIEVED: Error parsing the list of submissions: " + e.getMessage(), false);
+        fs.setStatusString("Not all submissions retrieved: Error parsing the list of submissions: " + e.getMessage(), false);
         EventBus.publish(new FormStatusEvent(fs));
         throw e;
       }

--- a/src/org/opendatakit/briefcase/util/ServerUploader.java
+++ b/src/org/opendatakit/briefcase/util/ServerUploader.java
@@ -150,7 +150,7 @@ public class ServerUploader {
             terminationFuture);
         result = AggregateUtils.getXmlDocument(fullUrl, serverInfo, false, submissionChunkDescription, null);
       } catch (XmlDocumentFetchException e) {
-        fs.setStatusString("NOT ALL SUBMISSIONS RETRIEVED: Error fetching list of instanceIds: " + e.getMessage(), false);
+        fs.setStatusString("Not all submissions retrieved: Error fetching list of instanceIds: " + e.getMessage(), false);
         EventBus.publish(new FormStatusEvent(fs));
         return;
       }
@@ -159,7 +159,7 @@ public class ServerUploader {
       try {
         chunk = XmlManipulationUtils.parseSubmissionDownloadListResponse(result.doc);
       } catch (ParsingException e) {
-        fs.setStatusString("Not all instanceIds retrived: Error parsing the submission download chunk: " + e.getMessage(), false);
+        fs.setStatusString("Not all instanceIds retrieved: Error parsing the submission download chunk: " + e.getMessage(), false);
         EventBus.publish(new FormStatusEvent(fs));
         return;
       }


### PR DESCRIPTION
Closes #114 

#### What has been done to verify that this works as intended?
Ran all gradlew tests and checkstyle. Tried to maintain consistency in punctuation to avoid issues with "!" ending sentences.

#### Why is this the best possible solution? Were any other approaches considered?
Separated commits for UI and util in case changes will only be applied to UI.

#### Are there any risks to merging this code? If so, what are they?
Potential inconsistencies in captialization or punctuation in messages.

If requested, I could make another pass through and remove all '!'s in all messages throughout the application, not just in the "Success", "Failed", "Error" messages.