### PR TITLE
Restore basic logging functionality

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,11 +46,13 @@ dependencies {
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.10.0'
-    runtime group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.5'
 
     compile files('lib/smallsql-0.21.jar')
     compile files('lib/threetenbp-1.3.1.jar')
     compile files('lib/LGoodDatePicker-10.3.1-backport.jar')
+
+    runtime group: 'org.slf4j', name: 'jcl-over-slf4j', version: '1.7.5'
+    runtime group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.5'
 }
 
 // Required to use fileExtensions property in checkstyle file

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,10 @@ sourceSets {
 targetCompatibility = '1.7'
 sourceCompatibility = '1.7'
 
+configurations.all {
+    exclude group: 'commons-logging', module: 'commons-logging'
+}
+
 dependencies {
     compile group: 'org.bouncycastle', name: 'bcprov-jdk16', version: '1.46'
     compile group: 'commons-cli', name: 'commons-cli', version: '1.3.1'
@@ -42,6 +46,7 @@ dependencies {
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.10.0'
+    runtime group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.5'
 
     compile files('lib/smallsql-0.21.jar')
     compile files('lib/threetenbp-1.3.1.jar')


### PR DESCRIPTION
Closes #197 

#### What has been done to verify that this works as intended?

I ran briefcase and performed a pull and push, instead of seeing the slf4j binding error message, you see log statements at level INFO and higher. I immediately used this fix to enable http components logging to diagnose and fix a threading issue (which I will report separately). 

#### Why is this the best possible solution? Were any other approaches considered?

This is the best solution because it unifies all non-JDK logging into a single logging implementation, eliminates the slf4j error message due to a missing binding and restores basic logging functionality to the application. All non-JDK logging, including that of the google analytics library, can now be managed by one logging implementation.

Routing all to JDK logging is possible, but considerably more complicated without much of a gain. It also isn't necessary for briefcase's or its most important subsystems logging (like apache http components). 

#### Are there any risks to merging this code? If so, what are they?

You risk enabling logging again!

It went quiet when broken and you will see messages again. Other than that, there are minimal risks. The exclusion of JCL is normal and expected usage of the slf4j-over-jcl adapter and is meant to be used to unify code that uses JCL so it uses slf4j instead.

