### PR TITLE
Closes #205: Race condition using parallel pulls causes HTTP 401 Unau…

### DIFF
--- a/src/org/opendatakit/briefcase/model/ServerConnectionInfo.java
+++ b/src/org/opendatakit/briefcase/model/ServerConnectionInfo.java
@@ -21,12 +21,13 @@ import org.apache.http.client.protocol.HttpClientContext;
 import org.opendatakit.briefcase.util.WebUtils;
 
 public class ServerConnectionInfo {
+
   private String url;
   private final String token; // for legacy ODK Aggregate 0.9.8 access
   private final String username;
   private final char[] password;
   private final boolean isOpenRosaServer;
-  private HttpClientContext httpContext = null;
+  private static final ThreadLocal<HttpClientContext> threadSafeContext = new ThreadLocal<>();
 
   public ServerConnectionInfo(String url, String username, char[] cs) {
     this.url = url;
@@ -69,11 +70,11 @@ public class ServerConnectionInfo {
   }
 
   public HttpClientContext getHttpContext() {
-    return httpContext;
+    return threadSafeContext.get();
   }
 
   public void setHttpContext(HttpClientContext httpContext) {
-    this.httpContext = httpContext;
+    this.threadSafeContext.set(httpContext);
   }
 
   public boolean isOpenRosaServer() {


### PR DESCRIPTION
…thorized

Closes #205 

#### What has been done to verify that this works as intended?

As mentioned in the issue description, this has been run against a fully concurrent server with parallel submissions enabled using relatively long pulls (3,000+ submissions). Without the fix, the pull fails with http 401s around midway through the pull. With the fix, the pulls succeed without issue.

#### Why is this the best possible solution? Were any other approaches considered?

This corrects the usage of the apache http components HttpContext objects by making them local to the thread that stores and retrieves them. This makes current usage thread-safe without sacrificing full concurrency by avoiding the use of locking.

#### Are there any risks to merging this code? If so, what are they?

This changes the scope of the HttpContext objects so an instance set is only visible to the thread that set it. This may result in null retrievals where previously there were none, however, this is only possible with incorrect usage (threads sharing context references) that should not be allowed in the first place. Non-concurrent pulls should operate as before.