### PR TITLE
HTTP code cleanup #206

### DIFF
--- a/src/org/opendatakit/briefcase/model/ServerConnectionInfo.java
+++ b/src/org/opendatakit/briefcase/model/ServerConnectionInfo.java
@@ -16,10 +16,6 @@
 
 package org.opendatakit.briefcase.model;
 
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.opendatakit.briefcase.util.WebUtils;
-
 public class ServerConnectionInfo {
 
   private String url;
@@ -27,7 +23,6 @@ public class ServerConnectionInfo {
   private final String username;
   private final char[] password;
   private final boolean isOpenRosaServer;
-  private static final ThreadLocal<HttpClientContext> threadSafeContext = new ThreadLocal<>();
 
   public ServerConnectionInfo(String url, String username, char[] cs) {
     this.url = url;
@@ -65,19 +60,11 @@ public class ServerConnectionInfo {
     return password;
   }
 
-  public HttpClient getHttpClient() {
-    return WebUtils.createHttpClient();
-  }
-
-  public HttpClientContext getHttpContext() {
-    return threadSafeContext.get();
-  }
-
-  public void setHttpContext(HttpClientContext httpContext) {
-    this.threadSafeContext.set(httpContext);
-  }
-
   public boolean isOpenRosaServer() {
     return isOpenRosaServer;
+  }
+
+  public boolean hasCredentials() {
+    return getUsername() != null && getUsername().length() != 0;
   }
 }

--- a/src/org/opendatakit/briefcase/util/AggregateUtils.java
+++ b/src/org/opendatakit/briefcase/util/AggregateUtils.java
@@ -236,9 +236,9 @@ public class AggregateUtils {
     // get shared HttpContext so that authentication and cookies are retained.
     HttpClientContext localContext = WebUtils.getHttpContext();
 
-    URI u = request.getURI();
+    URI uri = request.getURI();
 
-    WebUtils.setCredentials(localContext, serverInfo, u, alwaysResetCredentials);
+    WebUtils.setCredentials(localContext, serverInfo, uri, alwaysResetCredentials);
 
     if (!serverInfo.isOpenRosaServer()) {
       request.addHeader(BRIEFCASE_APP_TOKEN_PARAMETER, serverInfo.getToken());
@@ -272,26 +272,26 @@ public class AggregateUtils {
 
         if (statusCode == 400) {
           ex = new XmlDocumentFetchException(description.getFetchDocFailed() + webError + " while accessing: "
-              + u.toString() + "\nPlease verify that the " + description.getDocumentDescriptionType()
+              + uri.toString() + "\nPlease verify that the " + description.getDocumentDescriptionType()
               + " that is being uploaded is well-formed.");
         } else {
           ex = new XmlDocumentFetchException(
               description.getFetchDocFailed()
                   + webError
                   + " while accessing: "
-                  + u.toString()
+                  + uri.toString()
                   + "\nPlease verify that the URL, your user credentials and your permissions are all correct.");
         }
       } else if (entity == null) {
-        log.warn("No entity body returned from: " + u.toString() + " is not text/xml");
+        log.warn("No entity body returned from: " + uri.toString() + " is not text/xml");
         ex = new XmlDocumentFetchException(description.getFetchDocFailed()
-            + " Server unexpectedly returned no content while accessing: " + u.toString());
+            + " Server unexpectedly returned no content while accessing: " + uri.toString());
       } else if (!(lcContentType.contains(HTTP_CONTENT_TYPE_TEXT_XML) || lcContentType
           .contains(HTTP_CONTENT_TYPE_APPLICATION_XML))) {
         log.warn("ContentType: " + entity.getContentType().getValue() + "returned from: "
-            + u.toString() + " is not text/xml");
+            + uri.toString() + " is not text/xml");
         ex = new XmlDocumentFetchException(description.getFetchDocFailed()
-            + "A non-XML document was returned while accessing: " + u.toString()
+            + "A non-XML document was returned while accessing: " + uri.toString()
             + "\nA network login screen may be interfering with the transmission to the server.");
       }
 
@@ -333,7 +333,7 @@ public class AggregateUtils {
         }
       } catch (Exception e) {
         log.warn("Parsing failed with " + e.getMessage(), e);
-        throw new XmlDocumentFetchException(description.getFetchDocFailed() + " while accessing: " + u.toString());
+        throw new XmlDocumentFetchException(description.getFetchDocFailed() + " while accessing: " + uri.toString());
       }
 
       // examine header fields...
@@ -368,7 +368,7 @@ public class AggregateUtils {
         try {
           URL url = new URL(locations[0].getValue());
           URI uNew = url.toURI();
-          if (u.getHost().equalsIgnoreCase(uNew.getHost())) {
+          if (uri.getHost().equalsIgnoreCase(uNew.getHost())) {
             // trust the server to tell us a new location
             // ... and possibly to use https instead.
             String fullUrl = url.toExternalForm();

--- a/src/org/opendatakit/briefcase/util/AggregateUtils.java
+++ b/src/org/opendatakit/briefcase/util/AggregateUtils.java
@@ -115,23 +115,15 @@ public class AggregateUtils {
       throw e;
     }
 
-    // get shared HttpContext so that authentication and cookies are retained.
-    HttpClientContext localContext = serverInfo.getHttpContext();
+    HttpClient httpclient = WebUtils.createHttpClient();
 
-    HttpClient httpclient = serverInfo.getHttpClient();
+    // get shared HttpContext so that authentication and cookies are retained.
+    HttpClientContext localContext = WebUtils.getHttpContext();
 
     // set up request...
     HttpGet req = WebUtils.createOpenRosaHttpGet(u);
 
-    if (serverInfo.getUsername() != null && serverInfo.getUsername().length() != 0) {
-      if (!WebUtils.hasCredentials(localContext, serverInfo.getUsername(), u.getHost())) {
-        WebUtils.clearAllCredentials(localContext);
-        WebUtils.addCredentials(localContext, serverInfo.getUsername(), serverInfo.getPassword(),
-            u.getHost());
-      }
-    } else {
-      WebUtils.clearAllCredentials(localContext);
-    }
+    WebUtils.setCredentials(localContext, serverInfo, u);
 
     if (!serverInfo.isOpenRosaServer()) {
       req.addHeader(BRIEFCASE_APP_TOKEN_PARAMETER, serverInfo.getToken());
@@ -198,15 +190,6 @@ public class AggregateUtils {
       throw new XmlDocumentFetchException(msg);
     }
 
-    HttpClient httpClient = serverInfo.getHttpClient();
-
-    // get shared HttpContext so that authentication and cookies are retained.
-    HttpClientContext localContext = serverInfo.getHttpContext();
-    if (localContext == null) {
-      localContext = WebUtils.createHttpContext();
-      serverInfo.setHttpContext(localContext);
-    }
-
     // set up request...
     HttpGet req = WebUtils.createOpenRosaHttpGet(u);
 
@@ -248,23 +231,14 @@ public class AggregateUtils {
       DocumentDescription description, 
       ResponseAction action) throws XmlDocumentFetchException {
 
-    HttpClient httpClient = serverInfo.getHttpClient();
+    HttpClient httpClient = WebUtils.createHttpClient();
 
     // get shared HttpContext so that authentication and cookies are retained.
-    HttpClientContext localContext = serverInfo.getHttpContext();
+    HttpClientContext localContext = WebUtils.getHttpContext();
 
     URI u = request.getURI();
 
-    if (serverInfo.getUsername() != null && serverInfo.getUsername().length() != 0) {
-      if (alwaysResetCredentials
-          || !WebUtils.hasCredentials(localContext, serverInfo.getUsername(), u.getHost())) {
-        WebUtils.clearAllCredentials(localContext);
-        WebUtils.addCredentials(localContext, serverInfo.getUsername(), serverInfo.getPassword(),
-            u.getHost());
-      }
-    } else {
-      WebUtils.clearAllCredentials(localContext);
-    }
+    WebUtils.setCredentials(localContext, serverInfo, u, alwaysResetCredentials);
 
     if (!serverInfo.isOpenRosaServer()) {
       request.addHeader(BRIEFCASE_APP_TOKEN_PARAMETER, serverInfo.getToken());
@@ -466,24 +440,12 @@ public class AggregateUtils {
       throw new TransmissionException(msg);
     }
 
-    HttpClient httpClient = serverInfo.getHttpClient();
+    HttpClient httpClient = WebUtils.createHttpClient();
 
     // get shared HttpContext so that authentication and cookies are retained.
-    HttpClientContext localContext = serverInfo.getHttpContext();
-    if (localContext == null) {
-      localContext = WebUtils.createHttpContext();
-      serverInfo.setHttpContext(localContext);
-    }
+    HttpClientContext localContext = WebUtils.getHttpContext();
 
-    if (serverInfo.getUsername() != null && serverInfo.getUsername().length() != 0) {
-      if (!WebUtils.hasCredentials(localContext, serverInfo.getUsername(), u.getHost())) {
-        WebUtils.clearAllCredentials(localContext);
-        WebUtils.addCredentials(localContext, serverInfo.getUsername(), serverInfo.getPassword(),
-            u.getHost());
-      }
-    } else {
-      WebUtils.clearAllCredentials(localContext);
-    }
+    WebUtils.setCredentials(localContext, serverInfo, u);
 
     {
       // we need to issue a head request

--- a/src/org/opendatakit/briefcase/util/ServerFetcher.java
+++ b/src/org/opendatakit/briefcase/util/ServerFetcher.java
@@ -286,8 +286,8 @@ public class ServerFetcher {
     boolean allSuccessful = true;
     RemoteFormDefinition fd = (RemoteFormDefinition) fs.getFormDefinition();
     ExecutorService execSvc = getFetchExecutorService();
-    CompletionService<SubmissionChunk> chunkCompleter = new ExecutorCompletionService(execSvc);
-    CompletionService<String> submissionCompleter = new ExecutorCompletionService(execSvc);
+    CompletionService<SubmissionChunk> chunkCompleter = new ExecutorCompletionService<>(execSvc);
+    CompletionService<String> submissionCompleter = new ExecutorCompletionService<>(execSvc);
 
     String oldWebsafeCursorString, websafeCursorString = "";
 

--- a/src/org/opendatakit/briefcase/util/ServerUploader.java
+++ b/src/org/opendatakit/briefcase/util/ServerUploader.java
@@ -109,7 +109,6 @@ public class ServerUploader {
         }
       }
     }
-    
   }
   
   // remove any instances already completed on server
@@ -173,10 +172,11 @@ public class ServerUploader {
       }
     }
   }
-  
+
   public boolean uploadFormAndSubmissionFiles(List<FormStatus> formsToTransfer) {
+
     boolean allSuccessful = true;
-    
+
     for (FormStatus formToTransfer : formsToTransfer) {
 
       BriefcaseFormDefinition briefcaseLfd = (BriefcaseFormDefinition) formToTransfer.getFormDefinition();
@@ -212,7 +212,7 @@ public class ServerUploader {
         // error already logged...
         continue;
       }
-      
+
       Set<File> briefcaseInstances = FileSystemUtils.getFormSubmissionDirectories(briefcaseLfd.getFormDirectory());
       DatabaseUtils formDatabase = null;
       try {
@@ -342,23 +342,23 @@ public class ServerUploader {
     // We have the actual server URL in u, possibly redirected to https.
     // We know we are talking to the server because the head request
     // succeeded and had a Location header field.
-  
+
     // try to send instance
     // get instance file
     File file = new File(instanceDirectory, "submission.xml");
-  
+
     String submissionFile = file.getName();
-  
+
     if (!file.exists()) {
       String msg = "Submission file not found: " + file.getAbsolutePath();
       formToTransfer.setStatusString(msg, false);
       EventBus.publish(new FormStatusEvent(formToTransfer));
       return false;
     }
-  
+
     // find all files in parent directory
     File[] allFiles = instanceDirectory.listFiles();
-  
+
     // clean up the list, removing anything that is suspicious
     // or that we won't attempt to upload. For OpenRosa servers,
     // we'll upload just about everything...
@@ -376,7 +376,7 @@ public class ServerUploader {
       }
     }
     SubmissionResponseAction action = new SubmissionResponseAction(file);
-    
+
     if ( isCancelled() ) {
       formToTransfer.setStatusString("aborting upload of submission...", true);
       EventBus.publish(new FormStatusEvent(formToTransfer));
@@ -385,9 +385,9 @@ public class ServerUploader {
 
     DocumentDescription submissionUploadDescription = new DocumentDescription("Submission upload failed.  Detailed error: ",
         "Submission upload failed.", "submission (" + count + " of " + totalCount + ")", terminationFuture);
-    boolean outcome = AggregateUtils.uploadFilesToServer(serverInfo, u, "xml_submission_file", file, files, 
+    boolean outcome = AggregateUtils.uploadFilesToServer(serverInfo, u, "xml_submission_file", file, files,
         submissionUploadDescription, action, terminationFuture, formToTransfer);
-    
+
     // and try to rename the instance directory to be its instanceID
     action.afterUpload(formToTransfer);
     return outcome;

--- a/src/org/opendatakit/briefcase/util/ServerUploader.java
+++ b/src/org/opendatakit/briefcase/util/ServerUploader.java
@@ -112,7 +112,7 @@ public class ServerUploader {
   }
   
   // remove any instances already completed on server
-  private void removeAllServerInstances(FormStatus fs, DatabaseUtils formDatabase, Set<File> instancesToUpload) {
+  private void subtractServerInstances(FormStatus fs, DatabaseUtils formDatabase, Set<File> instancesToUpload) {
 
     /*
      * The /view/submissionList interface returns the list of COMPLETED submissions
@@ -220,10 +220,10 @@ public class ServerUploader {
         
         // make sure all the local instances are in the database...
         formDatabase.updateInstanceLists(briefcaseInstances);
-        
-        removeAllServerInstances(formToTransfer, formDatabase, briefcaseInstances);
-        // upload the submissions we have locally -- these will exclude whatever was on the server
-        
+
+        // exclude submissions the server reported as already submitted
+        subtractServerInstances(formToTransfer, formDatabase, briefcaseInstances);
+
         int i = 1;
         for (File briefcaseInstance : briefcaseInstances) {
           outcome = uploadSubmission(formDatabase, formToTransfer, u, i++, briefcaseInstances.size(), briefcaseInstance);


### PR DESCRIPTION
Gentle reorganization cleaning up HTTP code, as mentioned in https://github.com/opendatakit/briefcase/pull/206#discussion_r141114074

#### What has been done to verify that this works as intended?

Built (with checkstyle), ran and pulled from Aggregate, pushed to Aggregate. I confirmed no errors and verified all submissions were processed successfully.

#### Why is this the best possible solution? Were any other approaches considered?

This removes the possibility of sharing the http context across threads by "installing" the same reference in the thread local by calling `setHttpContext()`. It also adds javadoc comments to the code and some minor code cleanup.

I considered a more drastic cleanup, but did not want to cause more conflicts than necessary since I will not be the one resolving the conflicts myself. I also wanted to make it easy to review, so tried to keep changes minimal.

#### Are there any risks to merging this code? If so, what are they?

This touches code critical for pushing and pulling submissions to/from an Aggregate compatible server. The risks are that push and pull don't work or defects introduced.