### PR TITLE
Conform to Checkstyle OverloadMethodsDeclarationOrder rule

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -165,7 +165,7 @@
             <property name="ignoreFinal" value="false"/>
             <property name="allowedAbbreviationLength" value="1"/>
         </module> -->
-        <!-- <module name="OverloadMethodsDeclarationOrder"/> -->
+        <module name="OverloadMethodsDeclarationOrder"/>
         <!-- <module name="VariableDeclarationUsageDistance"/> -->
         <!-- <module name="CustomImportOrder">
             <property name="sortImportsInGroupAlphabetically" value="true"/>

--- a/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
+++ b/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
@@ -293,14 +293,14 @@ public class BriefcaseCLI {
         log.error("Failed.");
     }
 
-    @EventSubscriber(eventClass = ExportSucceededEvent.class)
-    public void successfulCompletion(ExportSucceededEvent event) {
-        log.info("Succeeded.");
-    }
-
     @EventSubscriber(eventClass = TransferFailedEvent.class)
     public void failedCompletion(TransferFailedEvent event) {
         log.error("Transfer Failed");
+    }
+
+    @EventSubscriber(eventClass = ExportSucceededEvent.class)
+    public void successfulCompletion(ExportSucceededEvent event) {
+        log.info("Succeeded.");
     }
 
     @EventSubscriber(eventClass = TransferSucceededEvent.class)

--- a/src/org/opendatakit/common/web/constants/HtmlStrUtil.java
+++ b/src/org/opendatakit/common/web/constants/HtmlStrUtil.java
@@ -107,14 +107,14 @@ public class HtmlStrUtil {
   public static final String createInput(String type, String name, String value) {
       return createInput(type, name, value, false, INPUT_WIDGET_SIZE_LIMIT, null);
   }
-  
+
+  public static final String createInput(String type, String name, String value, boolean checked) {
+    return createInput(type, name, value, checked, INPUT_WIDGET_SIZE_LIMIT, null);
+  }
+
   public static final String createNonSavingPasswordInput(String name) {
       return createInput(HtmlConsts.INPUT_TYPE_PASSWORD, name, "",
                             false, INPUT_WIDGET_SIZE_LIMIT, "autocomplete=\"off\"");
-  }
-  
-  public static final String createInput(String type, String name, String value, boolean checked) {
-    return createInput(type, name, value, checked, INPUT_WIDGET_SIZE_LIMIT, null);
   }
   
   public static final String createFormBeginTag(String action, String encodingType, String method) {


### PR DESCRIPTION
Small PR to partially address #94 
- uncommented OverloadMethodsDeclarationOrder rule in checkstyle.xml
- changed two classes (reported by Checkstyle) to conform to rule
- ran Checkstyle again to verify that it's happy now

Should be pretty risk-free - just changes position of two methods within its classes.