### PR TITLE
BRIEFCASE-210: Adding console and file appender for slf4j.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     compile files('lib/LGoodDatePicker-10.3.1-backport.jar')
 
     runtime group: 'org.slf4j', name: 'jcl-over-slf4j', version: '1.7.5'
-    runtime group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.5'
+    runtime group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
 }
 
 // Required to use fileExtensions property in checkstyle file

--- a/res/logback.xml
+++ b/res/logback.xml
@@ -1,0 +1,29 @@
+<configuration>
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>briefcase.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>briefcase.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <!-- keep 10 log history capped at 100MB total size and 10 MB each -->
+            <maxHistory>10</maxHistory>
+            <maxFileSize>10MB</maxFileSize>
+            <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%date %level [%thread] %logger{10} %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+        <encoder>
+            <pattern>%date %level [%thread] %logger{10} %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="FILE" />
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
Closes #210 

#### What has been done to verify that this works as intended?
I run briefcase and look at the generated console log and file log.

#### Why is this the best possible solution? Were any other approaches considered?
Since the google analytics require slf4j to work, we need to re-route all of our logging through slf4j and remove the dependency to commons-logging.

#### Are there any risks to merging this code? If so, what are they?
This could create a pretty big log file.