### PR TITLE
Continue (complete?) the task of removing Aggregate 0.9.x support. 

### DIFF
--- a/src/org/opendatakit/briefcase/model/ServerConnectionInfo.java
+++ b/src/org/opendatakit/briefcase/model/ServerConnectionInfo.java
@@ -21,13 +21,11 @@ public class ServerConnectionInfo {
   private String url;
   private final String username;
   private final char[] password;
-  private final boolean isOpenRosaServer;
 
   public ServerConnectionInfo(String url, String username, char[] cs) {
     this.url = url;
     this.username = username;
     this.password = cs;
-    this.isOpenRosaServer = true;
   }
 
   public String getUrl() {
@@ -44,10 +42,6 @@ public class ServerConnectionInfo {
 
   public char[] getPassword() {
     return password;
-  }
-
-  public boolean isOpenRosaServer() {
-    return isOpenRosaServer;
   }
 
   public boolean hasCredentials() {

--- a/src/org/opendatakit/briefcase/ui/MainFormUploaderWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainFormUploaderWindow.java
@@ -143,16 +143,11 @@ public class MainFormUploaderWindow {
       d.setVisible(true);
       if (d.isSuccessful()) {
         ServerConnectionInfo info = d.getServerInfo();
-        if (info.isOpenRosaServer()) {
-          destinationServerInfo = d.getServerInfo();
-          txtDestinationName.setText(destinationServerInfo.getUrl());
-          setUploadFormEnabled(true);
-          lblUploading.setText("");
-          btnDetails.setEnabled(false);
-        } else {
-          ODKOptionPane.showErrorDialog(MainFormUploaderWindow.this.frame,
-              "Server is not an ODK Aggregate 1.0 server", "Invalid Server URL");
-        }
+        destinationServerInfo = d.getServerInfo();
+        txtDestinationName.setText(destinationServerInfo.getUrl());
+        setUploadFormEnabled(true);
+        lblUploading.setText("");
+        btnDetails.setEnabled(false);
       }
     }
 

--- a/src/org/opendatakit/briefcase/ui/PushTransferPanel.java
+++ b/src/org/opendatakit/briefcase/ui/PushTransferPanel.java
@@ -124,16 +124,10 @@ public class PushTransferPanel extends JPanel {
             (Window) PushTransferPanel.this.getTopLevelAncestor(), destinationServerInfo, true);
         d.setVisible(true);
         if (d.isSuccessful()) {
-          ServerConnectionInfo info = d.getServerInfo();
-          if (info.isOpenRosaServer()) {
-            destinationServerInfo = d.getServerInfo();
-            txtDestinationName.setText(destinationServerInfo.getUrl());
-            PREFERENCES.put(BriefcasePreferences.USERNAME, destinationServerInfo.getUsername());
-            PREFERENCES.put(BriefcasePreferences.AGGREGATE_1_0_URL, destinationServerInfo.getUrl());
-          } else {
-            ODKOptionPane.showErrorDialog(PushTransferPanel.this,
-                "Server is not an ODK Aggregate 1.0 server", "Invalid Server URL");
-          }
+          destinationServerInfo = d.getServerInfo();
+          txtDestinationName.setText(destinationServerInfo.getUrl());
+          PREFERENCES.put(BriefcasePreferences.USERNAME, destinationServerInfo.getUsername());
+          PREFERENCES.put(BriefcasePreferences.AGGREGATE_1_0_URL, destinationServerInfo.getUrl());
         }
       } else {
         throw new IllegalStateException("unexpected case");

--- a/src/org/opendatakit/briefcase/util/AggregateUtils.java
+++ b/src/org/opendatakit/briefcase/util/AggregateUtils.java
@@ -448,16 +448,9 @@ public class AggregateUtils {
         int statusCode = response.getStatusLine().getStatusCode();
         if (statusCode == 204) {
           Header[] openRosaVersions = response.getHeaders(WebUtils.OPEN_ROSA_VERSION_HEADER);
-          if (openRosaVersions != null && openRosaVersions.length != 0) {
-            if (!serverInfo.isOpenRosaServer()) {
-              String msg = "Url: " + u.toString()
-                  + " is for an ODK Aggregate 1.0 or higher (OpenRosa compliant) server!";
-              log.warn(msg);
-              throw new TransmissionException(msg);
-            }
-          } else if (serverInfo.isOpenRosaServer()) {
+          if (openRosaVersions == null || openRosaVersions.length == 0) {
             String msg = "Url: " + u.toString()
-                + " is for an ODK Aggregate 0.9x or earlier (non-OpenRosa compliant) server!";
+                    + ", header missing: " + WebUtils.OPEN_ROSA_VERSION_HEADER;
             log.warn(msg);
             throw new TransmissionException(msg);
           }

--- a/src/org/opendatakit/briefcase/util/ServerFetcher.java
+++ b/src/org/opendatakit/briefcase/util/ServerFetcher.java
@@ -500,15 +500,11 @@ public class ServerFetcher {
       fo.write(submissionManifest.submissionXml);
       fo.close();
 
-      // if we get here and it was a legacy server (0.9.x), we don't
-      // actually know whether the submission was complete.  Otherwise,
       // if we get here, we know that this is a completed submission
       // (because it was in /view/submissionList) and that we safely
       // copied it into the storage area (because we didn't get any
       // exceptions).
-      if ( serverInfo.isOpenRosaServer() ) {
-        formDatabase.assertRecordedInstanceDirectory(uri, instanceDir);
-      }
+      formDatabase.assertRecordedInstanceDirectory(uri, instanceDir);
     } else {
       // create instance directory...
       File instanceDir = FileSystemUtils.assertFormSubmissionDirectory(formInstancesDir,
@@ -525,15 +521,11 @@ public class ServerFetcher {
       fo.write(submissionManifest.submissionXml);
       fo.close();
 
-      // if we get here and it was a legacy server (0.9.x), we don't
-      // actually know whether the submission was complete.  Otherwise,
       // if we get here, we know that this is a completed submission
       // (because it was in /view/submissionList) and that we safely
       // copied it into the storage area (because we didn't get any
       // exceptions).
-      if ( serverInfo.isOpenRosaServer() ) {
-        formDatabase.assertRecordedInstanceDirectory(uri, instanceDir);
-      }
+      formDatabase.assertRecordedInstanceDirectory(uri, instanceDir);
     }
 
   }


### PR DESCRIPTION
ServerConnectionInfo always sets the final boolean isOpenRosaServer to true. This change consists of the following:

Change isOpenRosaServer to always return true
Inline that method, creating always-true or always-false code.
Use automatic refactorings to remove code and if statements.
In the case of AggregateUtils, there was an incorrect error message produced when there is no WebUtils.OPEN_ROSA_VERSION_HEADER. Correct this.

Closes #225 

#### What has been done to verify that this works as intended?
All changes, except the error message correction were made with IDEA automatic corrections and refactorings. I ran Briefcase and did a push and a pull. Perhaps @batkinson can review the error message change in AggregateUtils.

#### Why is this the best possible solution? Were any other approaches considered?
There’s only one way to do this.

#### Are there any risks to merging this code? If so, what are they?
No
