### PR TITLE
Downgraded hsqldb to 2.3.5 to work with Java 7. Fixes #203

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,8 @@ dependencies {
     compile group: 'org.apache.httpcomponents', name: 'httpmime', version: '4.5.2'
     compile group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
     compile group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.5.1'
-    compile group: 'org.hsqldb', name: 'hsqldb', version: '2.4.0'
+    // There is a compatibility issue with hsqldb - 2.4.0 and Java 7. So we use version 2.3.5
+    compile group: 'org.hsqldb', name: 'hsqldb', version: '2.3.5'
     compile group: 'com.brsanthu', name: 'google-analytics-java', version: '1.1.2'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'


### PR DESCRIPTION
Closes #203 

#### What has been done to verify that this works as intended?
Application was running with both Java 7 and Java 8.

#### Why is this the best possible solution? Were any other approaches considered?
The latest version of hsqldb - 2.4.0 is not compatible with Java 7. Since we are currently supporting Java 7, we can use hsqldb - 2.3.5. This can be upgraded once we move to Java 8.

#### Are there any risks to merging this code? If so, what are they?
No.