### PR TITLE
CircleCI 2 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,4 +21,4 @@ jobs:
           path: build/libs
           destination: libs
       - store_test_results:
-          path: build/reports/tests/test
+          path: build/reports/tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,16 @@ jobs:
       - image: circleci/openjdk:latest
     steps:
       - checkout
+      - restore_cache:
+          key: jars-{{ checksum "build.gradle" }}
       - run: ./gradlew check test jar
+      - save_cache:
+          paths:
+            - ~/.gradle
+            - ~/code/.gradle
+          key: jars-{{ checksum "build.gradle" }}
       - store_test_results:
           path: build/reports
       - store_artifacts:
           path: build/libs
+          destination: libs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,11 @@ jobs:
             - ~/.gradle
             - ~/code/.gradle
           key: jars-{{ checksum "build.gradle" }}
-      - store_test_results:
+      - store_artifacts:
           path: build/reports
+          destination: reports
       - store_artifacts:
           path: build/libs
           destination: libs
+      - store_test_results:
+          path: build/reports/tests/test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,4 +21,4 @@ jobs:
           path: build/libs
           destination: libs
       - store_test_results:
-          path: build/tests-results
+          path: build/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/code
+    docker:
+      - image: circleci/openjdk:latest
+    steps:
+      - checkout
+      - run: ./gradlew check test jar
+      - store_test_results:
+          path: build/reports
+      - store_artifacts:
+          path: build/libs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,4 +21,4 @@ jobs:
           path: build/libs
           destination: libs
       - store_test_results:
-          path: build/reports/tests
+          path: build/tests-results

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,0 @@
-test:
-  override:
-    - ./gradlew check test jar
-
-  post:
-    - cp -r build/libs $CIRCLE_ARTIFACTS
-    - cp -r build/reports/tests/test $CIRCLE_TEST_REPORTS/junit
-    - cp -r build/reports/checkstyle $CIRCLE_TEST_REPORTS


### PR DESCRIPTION
I have confirmed that
* The cache is saved and restored (it's mostly ~/.gradle that has the useful jars)
* The reports show up in artifacts and it has HTML that renders
* The jar shows up in artifacts and it runs on macOS
* The test results show up in test summary

This cuts build time in half, which is nice. You should squash and merge!