### PR TITLE
Fixes #237. Replaces dialogs with command line messages in CLI

### DIFF
--- a/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
+++ b/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
@@ -223,9 +223,8 @@ public class BriefcaseCLI {
                           // ignore.
                         }
                         if (o == null) {
-                            ODKOptionPane.showErrorDialog(null,
-                                    errorMsg = "The supplied file is not in PEM format.",
-                                    "Invalid RSA Private Key");
+                            errorMsg = "The supplied file is not in PEM format.";
+                            System.err.println(errorMsg);
                             break;
                         }
                         PrivateKey privKey;
@@ -238,20 +237,16 @@ public class BriefcaseCLI {
                             privKey = null;
                         }
                         if (privKey == null) {
-                            ODKOptionPane.showErrorDialog(null,
-                                    errorMsg = "The supplied file does not contain a private key.",
-                                    "Invalid RSA Private Key");
+                            errorMsg = "The supplied file does not contain a private key.";
+                            System.err.println(errorMsg);
                             break;
                         }
                         toExport.setPrivateKey(privKey);
                         success = true;
                         break;
                     } catch (IOException e) {
-                        String msg = "The supplied PEM file could not be parsed.";
-                        log.error(msg, e);
-                        ODKOptionPane.showErrorDialog(null,
-                                errorMsg = msg,
-                                "Invalid RSA Private Key");
+                        System.err.println("The supplied PEM file could not be parsed.");
+                        e.printStackTrace();
                         break;
                     }
                 }


### PR DESCRIPTION
Closes #237 

#### What has been done to verify that this works as intended?
Ran this command `java -jar ODK\ Briefcase\ v1.8.0-50-gb2f3f12-dirty.jar -id encrypted-form -sd ~/Desktop -ed ~/Desktop -f test1.csv -pf ~/Downloads/test.pem` in terminal with a valid and invalid pem file and the response was as expected.

#### Why is this the best possible solution? Were any other approaches considered?
CLI should not have dialogs as a way to throw exception. Hence, getting rid of dialogs and introducing CL messages is the logical solution.

#### Are there any risks to merging this code? If so, what are they?
No, since this is related to error logging only.