### PR TITLE
Add a cli adapter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'application'
     id 'checkstyle'
     id 'de.fuerstenau.buildconfig' version '1.1.8'
+    id 'idea'
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,8 @@ sourceSets {
     }
 }
 
-targetCompatibility = '1.7'
-sourceCompatibility = '1.7'
+targetCompatibility = '1.8'
+sourceCompatibility = '1.8'
 
 configurations.all {
     exclude group: 'commons-logging', module: 'commons-logging'

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ buildConfig {
     buildConfigField 'String', 'GOOGLE_TRACKING_ID', "UA-91951913-3"
 }
 
-mainClassName = 'org.opendatakit.briefcase.ui.MainBriefcaseWindow'
+mainClassName = 'org.opendatakit.briefcase.Launcher'
 
 jar {
     baseName = buildConfig.appName

--- a/src/org/opendatakit/briefcase/Launcher.java
+++ b/src/org/opendatakit/briefcase/Launcher.java
@@ -1,5 +1,9 @@
 package org.opendatakit.briefcase;
 
+import static org.opendatakit.briefcase.operations.Export.EXPORT_FORM;
+import static org.opendatakit.briefcase.operations.ImportFromODK.IMPORT_FROM_ODK;
+import static org.opendatakit.briefcase.operations.PullFormFromAggregate.PULL_FORM_FROM_AGGREGATE;
+
 import org.opendatakit.briefcase.ui.MainBriefcaseWindow;
 import org.opendatakit.common.cli.Cli;
 
@@ -12,6 +16,9 @@ import org.opendatakit.common.cli.Cli;
 public class Launcher {
   public static void main(String[] args) {
     new Cli()
+        .register(PULL_FORM_FROM_AGGREGATE)
+        .register(IMPORT_FROM_ODK)
+        .register(EXPORT_FORM)
         .otherwise(() -> MainBriefcaseWindow.main(args))
         .run(args);
   }

--- a/src/org/opendatakit/briefcase/Launcher.java
+++ b/src/org/opendatakit/briefcase/Launcher.java
@@ -1,0 +1,18 @@
+package org.opendatakit.briefcase;
+
+import org.opendatakit.briefcase.ui.MainBriefcaseWindow;
+import org.opendatakit.common.cli.Cli;
+
+/**
+ * Main launcher for Briefcase
+ * <p>
+ * It leverages the command-line {@link Cli} adapter to define operations and run
+ * Briefcase with some command-line args
+ */
+public class Launcher {
+  public static void main(String[] args) {
+    new Cli()
+        .otherwise(() -> MainBriefcaseWindow.main(args))
+        .run(args);
+  }
+}

--- a/src/org/opendatakit/briefcase/operations/Common.java
+++ b/src/org/opendatakit/briefcase/operations/Common.java
@@ -1,0 +1,40 @@
+package org.opendatakit.briefcase.operations;
+
+import java.io.File;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.opendatakit.briefcase.model.BriefcasePreferences;
+import org.opendatakit.briefcase.ui.StorageLocation;
+import org.opendatakit.briefcase.util.FileSystemUtils;
+import org.opendatakit.common.cli.Param;
+
+class Common {
+  private static final Log LOGGER = LogFactory.getLog(Common.class);
+
+  static final Param<String> STORAGE_DIR = Param.arg("sd", "storage_directory", "Briefcase storage directory");
+  static final Param<String> FORM_ID = Param.arg("f", "form_id", "Form ID");
+
+  static void bootCache(String storageDir) {
+    BriefcasePreferences.setBriefcaseDirectoryProperty(storageDir);
+    File f = new StorageLocation().getBriefcaseFolder();
+
+    if (!f.exists()) {
+      boolean success = f.mkdirs();
+      if (success) {
+        LOGGER.info("Successfully created directory. Using: " + f.getAbsolutePath());
+      } else {
+        LOGGER.error("Unable to create directory: " + f.getAbsolutePath());
+        System.exit(1);
+      }
+    } else if (f.exists() && !f.isDirectory()) {
+      LOGGER.error("Not a directory.  " + f.getAbsolutePath());
+      System.exit(1);
+    } else if (f.exists() && f.isDirectory()) {
+      LOGGER.info("Directory found, using " + f.getAbsolutePath());
+    }
+
+    if (BriefcasePreferences.appScoped().getBriefcaseDirectoryOrNull() != null) {
+      FileSystemUtils.createFormCacheInBriefcaseFolder();
+    }
+  }
+}

--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -35,13 +35,13 @@ public class Export {
   private static final Log LOGGER = LogFactory.getLog(Export.class);
   private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy/MM/dd");
   private static final Param<Void> EXPORT = Param.flag("e", "export", "Export a form");
-  private static final Param<String> EXPORT_DIR = Param.arg("ed", "export_dir", "Export directory");
-  private static final Param<String> FILE = Param.arg("file", "filename", "Filename for export operation");
-  private static final Param<Date> START = Param.arg("start", "start-date", "Export start date", Export::toDate);
-  private static final Param<Date> END = Param.arg("end", "end-date", "Export end date", Export::toDate);
-  private static final Param<Void> EXCLUDE_MEDIA = Param.flag("exme", "exclude-media", "Exclude media in export");
-  private static final Param<Void> OVERWRITE = Param.flag("ow", "overwrite", "Overwrite files during export");
-  private static final Param<String> PEM_FILE = Param.arg("pem", "pem-file", "PEM file for form decryption");
+  private static final Param<String> EXPORT_DIR = Param.arg("ed", "export_directory", "Export directory");
+  private static final Param<String> FILE = Param.arg("file", "export_filename", "Filename for export operation");
+  private static final Param<Date> START = Param.arg("start", "export_start_date", "Export start date", Export::toDate);
+  private static final Param<Date> END = Param.arg("end", "export_end_date", "Export end date", Export::toDate);
+  private static final Param<Void> EXCLUDE_MEDIA = Param.flag("exme", "exclude_media_export", "Exclude media in export");
+  private static final Param<Void> OVERWRITE = Param.flag("ow", "overwrite_csv_export", "Overwrite files during export");
+  private static final Param<String> PEM_FILE = Param.arg("pem", "pem_file", "PEM file for form decryption");
 
   public static Date toDate(String s) {
     try {

--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -1,0 +1,157 @@
+package org.opendatakit.briefcase.operations;
+
+import static org.opendatakit.briefcase.operations.Common.FORM_ID;
+import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
+import static org.opendatakit.briefcase.operations.Common.bootCache;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.bouncycastle.openssl.PEMReader;
+import org.bushe.swing.event.EventBus;
+import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
+import org.opendatakit.briefcase.model.ExportFailedEvent;
+import org.opendatakit.briefcase.model.ExportProgressEvent;
+import org.opendatakit.briefcase.model.TerminationFuture;
+import org.opendatakit.briefcase.util.ExportToCsv;
+import org.opendatakit.briefcase.util.FileSystemUtils;
+import org.opendatakit.common.cli.Operation;
+import org.opendatakit.common.cli.Param;
+
+public class Export {
+  private static final Log LOGGER = LogFactory.getLog(Export.class);
+  private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy/MM/dd");
+  private static final Param<Void> EXPORT = Param.flag("e", "export", "Export a form");
+  private static final Param<String> EXPORT_DIR = Param.arg("ed", "export_dir", "Export directory");
+  private static final Param<String> FILE = Param.arg("file", "filename", "Filename for export operation");
+  private static final Param<Date> START = Param.arg("start", "start-date", "Export start date", Export::toDate);
+  private static final Param<Date> END = Param.arg("end", "end-date", "Export end date", Export::toDate);
+  private static final Param<Void> EXCLUDE_MEDIA = Param.flag("exme", "exclude-media", "Exclude media in export");
+  private static final Param<Void> OVERWRITE = Param.flag("ow", "overwrite", "Overwrite files during export");
+  private static final Param<String> PEM_FILE = Param.arg("pem", "pem-file", "PEM file for form decryption");
+
+  public static Date toDate(String s) {
+    try {
+      return DATE_FORMAT.parse(s);
+    } catch (ParseException e) {
+      LOGGER.error("bad date range", e);
+      return null;
+    }
+  }
+
+
+  public static Operation EXPORT_FORM = Operation.of(
+      EXPORT,
+      args -> export(
+          args.get(STORAGE_DIR),
+          args.get(FORM_ID),
+          args.get(FILE),
+          args.get(EXPORT_DIR),
+          args.getOrNull(START),
+          args.getOrNull(END),
+          !args.has(EXCLUDE_MEDIA),
+          args.has(OVERWRITE),
+          args.getOptional(PEM_FILE)
+      ),
+      Arrays.asList(STORAGE_DIR, FORM_ID, FILE, EXPORT_DIR),
+      Arrays.asList(PEM_FILE, EXCLUDE_MEDIA, OVERWRITE, START, END)
+  );
+
+  public static void export(String storageDir, String formid, String fileName, String exportPath, Date startDateString, Date endDateString, boolean exportMedia, boolean overwrite, Optional<String> pemKeyFile) {
+    bootCache(storageDir);
+    BriefcaseFormDefinition formDefinition = null;
+    List<BriefcaseFormDefinition> forms = FileSystemUtils.getBriefcaseFormList();
+    for (int i = 0; i < forms.size(); i++) {
+      BriefcaseFormDefinition x = forms.get(i);
+      if (formid.equals(x.getFormId())) {
+        formDefinition = x;
+        break;
+      }
+    }
+
+    if (formDefinition == null) {
+      LOGGER.error("Form not found");
+      return;
+    }
+
+    if (formDefinition.isFileEncryptedForm() || formDefinition.isFieldEncryptedForm()) {
+      File pemFile;
+      if (!pemKeyFile.isPresent()) {
+        LOGGER.error("Briefcase action failed: No specified PrivateKey file for encrypted form");
+        return;
+      }
+      pemFile = new File(pemKeyFile.get());
+      if (!pemFile.exists()) {
+        LOGGER.error("Briefcase action failed: No PrivateKey file for encrypted form");
+        return;
+      }
+
+      String errorMsg = null;
+      boolean success = false;
+      for (; ; ) /* this only executes once... */ {
+        try {
+          BufferedReader br = new BufferedReader(new InputStreamReader(
+              new FileInputStream(pemFile), "UTF-8"));
+          PEMReader rdr = new PEMReader(br);
+          Object o = rdr.readObject();
+          try {
+            rdr.close();
+          } catch (IOException e) {
+            // ignore.
+          }
+          if (o == null) {
+            errorMsg = "The supplied file is not in PEM format.";
+            System.err.println(errorMsg);
+            break;
+          }
+          PrivateKey privKey;
+          if (o instanceof KeyPair) {
+            KeyPair kp = (KeyPair) o;
+            privKey = kp.getPrivate();
+          } else if (o instanceof PrivateKey) {
+            privKey = (PrivateKey) o;
+          } else {
+            privKey = null;
+          }
+          if (privKey == null) {
+            errorMsg = "The supplied file does not contain a private key.";
+            System.err.println(errorMsg);
+            break;
+          }
+          formDefinition.setPrivateKey(privKey);
+          success = true;
+          break;
+        } catch (IOException e) {
+          System.err.println("The supplied PEM file could not be parsed.");
+          e.printStackTrace();
+          break;
+        }
+      }
+      if (!success) {
+        EventBus.publish(new ExportProgressEvent(errorMsg));
+        EventBus.publish(new ExportFailedEvent(formDefinition));
+        return;
+      }
+    }
+
+    TerminationFuture terminationFuture = new TerminationFuture();
+    terminationFuture.reset();
+    File dir = new File(exportPath);
+    LOGGER.info("exporting to : " + dir.getAbsolutePath());
+    ExportToCsv exp = new ExportToCsv(dir, formDefinition, terminationFuture, fileName, exportMedia, overwrite, startDateString, endDateString);
+    exp.doAction();
+  }
+}

--- a/src/org/opendatakit/briefcase/operations/ImportFromODK.java
+++ b/src/org/opendatakit/briefcase/operations/ImportFromODK.java
@@ -18,7 +18,7 @@ import org.opendatakit.common.cli.Param;
 public class ImportFromODK {
 
   private static final Param<Void> IMPORT = Param.flag("i", "import-odk", "Import from ODK");
-  private static final Param<String> ODK_DIR = Param.arg("od", "odk_dir", "ODK directory");
+  private static final Param<String> ODK_DIR = Param.arg("od", "odk_directory", "ODK directory");
 
   public static final Operation IMPORT_FROM_ODK = Operation.of(
       IMPORT,

--- a/src/org/opendatakit/briefcase/operations/ImportFromODK.java
+++ b/src/org/opendatakit/briefcase/operations/ImportFromODK.java
@@ -1,0 +1,45 @@
+package org.opendatakit.briefcase.operations;
+
+import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
+import static org.opendatakit.briefcase.operations.Common.bootCache;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.opendatakit.briefcase.model.FormStatus;
+import org.opendatakit.briefcase.model.OdkCollectFormDefinition;
+import org.opendatakit.briefcase.model.TerminationFuture;
+import org.opendatakit.briefcase.util.FileSystemUtils;
+import org.opendatakit.briefcase.util.TransferFromODK;
+import org.opendatakit.common.cli.Operation;
+import org.opendatakit.common.cli.Param;
+
+public class ImportFromODK {
+
+  private static final Param<Void> IMPORT = Param.flag("i", "import-odk", "Import from ODK");
+  private static final Param<String> ODK_DIR = Param.arg("od", "odk_dir", "ODK directory");
+
+  public static final Operation IMPORT_FROM_ODK = Operation.of(
+      IMPORT,
+      args -> importODK(
+          args.get(STORAGE_DIR),
+          args.get(ODK_DIR)
+      ),
+      Arrays.asList(STORAGE_DIR, ODK_DIR)
+  );
+
+  public static void importODK(String storageDir, String odkDir) {
+    bootCache(storageDir);
+    TerminationFuture terminationFuture = new TerminationFuture();
+    List<FormStatus> statuses = new ArrayList<FormStatus>();
+    File odk = new File(odkDir);
+    List<OdkCollectFormDefinition> forms = FileSystemUtils.getODKFormList(odk);
+    for (OdkCollectFormDefinition form : forms) {
+      statuses.add(new FormStatus(FormStatus.TransferType.GATHER, form));
+    }
+
+    TransferFromODK source = new TransferFromODK(odk, terminationFuture, statuses);
+    source.doAction();
+  }
+}

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -1,0 +1,91 @@
+package org.opendatakit.briefcase.operations;
+
+import static org.opendatakit.briefcase.operations.Common.FORM_ID;
+import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
+import static org.opendatakit.briefcase.operations.Common.bootCache;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.opendatakit.briefcase.model.FormStatus;
+import org.opendatakit.briefcase.model.ParsingException;
+import org.opendatakit.briefcase.model.ServerConnectionInfo;
+import org.opendatakit.briefcase.model.TerminationFuture;
+import org.opendatakit.briefcase.model.XmlDocumentFetchException;
+import org.opendatakit.briefcase.util.RetrieveAvailableFormsFromServer;
+import org.opendatakit.briefcase.util.ServerConnectionTest;
+import org.opendatakit.briefcase.util.TransferFromServer;
+import org.opendatakit.common.cli.Operation;
+import org.opendatakit.common.cli.Param;
+
+public class PullFormFromAggregate {
+  private static final Log LOGGER = LogFactory.getLog(PullFormFromAggregate.class);
+  private static final Param<Void> PULL_AGGREGATE = Param.flag("pa", "pull-aggregate", "Pull form from an Aggregate instance");
+  private static final Param<String> ODK_USERNAME = Param.arg("u", "odk_username", "ODK Username");
+  private static final Param<String> ODK_PASSWORD = Param.arg("p", "odk_password", "ODK Password");
+  private static final Param<String> AGGREGATE_SERVER = Param.arg("s", "aggregate_url", "Aggregate server URL");
+
+  public static Operation PULL_FORM_FROM_AGGREGATE = Operation.of(
+      PULL_AGGREGATE,
+      args -> pullFormFromAggregate(
+          args.get(STORAGE_DIR),
+          args.get(FORM_ID),
+          args.get(ODK_USERNAME),
+          args.get(ODK_PASSWORD),
+          args.get(AGGREGATE_SERVER)
+      ),
+      Arrays.asList(STORAGE_DIR, FORM_ID, ODK_USERNAME, ODK_PASSWORD, AGGREGATE_SERVER)
+  );
+
+  public static void pullFormFromAggregate(String storageDir, String formid, String username, String password, String server) {
+    bootCache(storageDir);
+    TerminationFuture terminationFuture = new TerminationFuture();
+    ServerConnectionInfo sci = new ServerConnectionInfo(server, username, password.toCharArray());
+
+    ServerConnectionTest backgroundAction = new ServerConnectionTest(sci, terminationFuture, true);
+
+    backgroundAction.run();
+    boolean isSuccessful = backgroundAction.isSuccessful();
+
+    if (!isSuccessful) {
+      String errorString = backgroundAction.getErrorReason();
+      LOGGER.error(errorString);
+      System.exit(1);
+    }
+
+    terminationFuture.reset();
+
+    RetrieveAvailableFormsFromServer source = new RetrieveAvailableFormsFromServer(sci, terminationFuture);
+    try {
+      source.doAction();
+    } catch (XmlDocumentFetchException | ParsingException e) {
+      LOGGER.error("failed to retrieve forms", e);
+    }
+
+    List<FormStatus> statuses = source.getAvailableForms();
+    FormStatus toDl = null;
+    boolean found = false;
+    for (int i = 0; i < statuses.size(); i++) {
+      FormStatus fs = statuses.get(i);
+      if (formid.equals(fs.getFormDefinition().getFormId())) {
+        found = true;
+        toDl = fs;
+      }
+    }
+    if (!found) {
+      LOGGER.error("form ID doesn't exist on server");
+      System.exit(0);
+    }
+
+    LOGGER.info("beginning download: " + toDl.getFormName());
+    terminationFuture.reset();
+    List<FormStatus> formsToTransfer = new ArrayList<FormStatus>();
+    formsToTransfer.add(toDl);
+
+    TransferFromServer serverSource = new TransferFromServer(sci, terminationFuture, formsToTransfer);
+
+    boolean status = serverSource.doAction();
+  }
+}

--- a/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
+++ b/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
@@ -17,304 +17,111 @@
 
 package org.opendatakit.briefcase.ui;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.security.KeyPair;
-import java.security.PrivateKey;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
+import static org.opendatakit.briefcase.operations.Export.export;
+import static org.opendatakit.briefcase.operations.ImportFromODK.importODK;
+import static org.opendatakit.briefcase.operations.PullFormFromAggregate.pullFormFromAggregate;
 
+import java.util.Optional;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.bouncycastle.openssl.PEMReader;
-import org.bushe.swing.event.EventBus;
 import org.bushe.swing.event.annotation.EventSubscriber;
 import org.opendatakit.aggregate.parser.BaseFormParserForJavaRosa;
-import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
-import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.ExportFailedEvent;
 import org.opendatakit.briefcase.model.ExportProgressEvent;
 import org.opendatakit.briefcase.model.ExportSucceededEvent;
-import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.FormStatusEvent;
-import org.opendatakit.briefcase.model.OdkCollectFormDefinition;
-import org.opendatakit.briefcase.model.ParsingException;
 import org.opendatakit.briefcase.model.RetrieveAvailableFormsFailedEvent;
-import org.opendatakit.briefcase.model.ServerConnectionInfo;
-import org.opendatakit.briefcase.model.TerminationFuture;
 import org.opendatakit.briefcase.model.TransferFailedEvent;
 import org.opendatakit.briefcase.model.TransferSucceededEvent;
-import org.opendatakit.briefcase.model.XmlDocumentFetchException;
-import org.opendatakit.briefcase.util.ExportToCsv;
-import org.opendatakit.briefcase.util.FileSystemUtils;
-import org.opendatakit.briefcase.util.RetrieveAvailableFormsFromServer;
-import org.opendatakit.briefcase.util.ServerConnectionTest;
-import org.opendatakit.briefcase.util.TransferFromODK;
-import org.opendatakit.briefcase.util.TransferFromServer;
+import org.opendatakit.briefcase.operations.Export;
 
 /**
- * 
  * Command line interface contributed by Nafundi
- * 
- * @author chartung@nafundi.com
  *
+ * @author chartung@nafundi.com
  */
 public class BriefcaseCLI {
 
-    private CommandLine mCommandline;
+  private CommandLine mCommandline;
 
-    private static final Log log = LogFactory.getLog(BaseFormParserForJavaRosa.class);
+  private static final Log log = LogFactory.getLog(BaseFormParserForJavaRosa.class);
 
-    public BriefcaseCLI(CommandLine cl) {
-        mCommandline = cl;
+  public BriefcaseCLI(CommandLine cl) {
+    mCommandline = cl;
+  }
+
+  public void run() {
+    String username = mCommandline.getOptionValue(MainBriefcaseWindow.ODK_USERNAME);
+    String password = mCommandline.getOptionValue(MainBriefcaseWindow.ODK_PASSWORD);
+    String server = mCommandline.getOptionValue(MainBriefcaseWindow.AGGREGATE_URL);
+    String formid = mCommandline.getOptionValue(MainBriefcaseWindow.FORM_ID);
+    String storageDir = mCommandline.getOptionValue(MainBriefcaseWindow.STORAGE_DIRECTORY);
+    String fileName = mCommandline.getOptionValue(MainBriefcaseWindow.EXPORT_FILENAME);
+    String exportPath = mCommandline.getOptionValue(MainBriefcaseWindow.EXPORT_DIRECTORY);
+    String startDateString = mCommandline.getOptionValue(MainBriefcaseWindow.EXPORT_START_DATE);
+    String endDateString = mCommandline.getOptionValue(MainBriefcaseWindow.EXPORT_END_DATE);
+    // note that we invert incoming value
+    boolean exportMedia = !mCommandline.hasOption(MainBriefcaseWindow.EXCLUDE_MEDIA_EXPORT);
+    boolean overwrite = mCommandline.hasOption(MainBriefcaseWindow.OVERWRITE_CSV_EXPORT);
+    String odkDir = mCommandline.getOptionValue(MainBriefcaseWindow.ODK_DIR);
+    String pemKeyFile = mCommandline.getOptionValue(MainBriefcaseWindow.PEM_FILE);
+
+    if (odkDir != null) {
+      importODK(storageDir, odkDir);
+    } else if (server != null) {
+      pullFormFromAggregate(storageDir, formid, username, password, server);
     }
 
-    public void run() {
-        String username = mCommandline.getOptionValue(MainBriefcaseWindow.ODK_USERNAME);
-        String password = mCommandline.getOptionValue(MainBriefcaseWindow.ODK_PASSWORD);
-        String server = mCommandline.getOptionValue(MainBriefcaseWindow.AGGREGATE_URL);
-        String formid = mCommandline.getOptionValue(MainBriefcaseWindow.FORM_ID);
-        String storageDir = mCommandline.getOptionValue(MainBriefcaseWindow.STORAGE_DIRECTORY);
-        String fileName = mCommandline.getOptionValue(MainBriefcaseWindow.EXPORT_FILENAME);
-        String exportPath = mCommandline.getOptionValue(MainBriefcaseWindow.EXPORT_DIRECTORY);
-        String startDateString = mCommandline.getOptionValue(MainBriefcaseWindow.EXPORT_START_DATE);
-        String endDateString = mCommandline.getOptionValue(MainBriefcaseWindow.EXPORT_END_DATE);
-        // note that we invert incoming value
-        boolean exportMedia = !mCommandline.hasOption(MainBriefcaseWindow.EXCLUDE_MEDIA_EXPORT);
-        boolean overwrite = mCommandline.hasOption(MainBriefcaseWindow.OVERWRITE_CSV_EXPORT);
-        String odkDir = mCommandline.getOptionValue(MainBriefcaseWindow.ODK_DIR);
-        String pemKeyFile = mCommandline.getOptionValue(MainBriefcaseWindow.PEM_FILE);
-
-        BriefcaseFormDefinition toExport = null;
-        TerminationFuture terminationFuture = new TerminationFuture();
-
-        BriefcasePreferences.setBriefcaseDirectoryProperty(storageDir);
-        File f = new StorageLocation().getBriefcaseFolder();
-
-        if (!f.exists()) {
-            boolean success = f.mkdirs();
-            if (success) {
-                log.info("Successfully created directory. Using: " + f.getAbsolutePath());
-            } else {
-                log.error("Unable to create directory: " + f.getAbsolutePath());
-                System.exit(0);
-            }
-        } else if (f.exists() && !f.isDirectory()) {
-            log.error("Not a directory.  " + f.getAbsolutePath());
-            System.exit(0);
-        } else if (f.exists() && f.isDirectory()) {
-            log.info("Directory found, using " + f.getAbsolutePath());
-        }
-
-        if (BriefcasePreferences.appScoped().getBriefcaseDirectoryOrNull() != null) {
-            FileSystemUtils.createFormCacheInBriefcaseFolder();
-        }
-
-        if (odkDir != null) {
-            // importing from ODK dir
-            List<FormStatus> statuses = new ArrayList<FormStatus>();
-            File odk = new File(odkDir);
-            List<OdkCollectFormDefinition> forms = FileSystemUtils.getODKFormList(odk);
-            for (OdkCollectFormDefinition form : forms) {
-                statuses.add(new FormStatus(FormStatus.TransferType.GATHER, form));
-            }
-
-            TransferFromODK source = new TransferFromODK(odk, terminationFuture, statuses);
-            source.doAction();
-        } else if (server != null) {
-            // importing from server
-            ServerConnectionInfo sci = new ServerConnectionInfo(server, username,
-                    password.toCharArray());
-
-            ServerConnectionTest backgroundAction = new ServerConnectionTest(sci,
-                    terminationFuture, true);
-
-            backgroundAction.run();
-            boolean isSuccessful = backgroundAction.isSuccessful();
-
-            if (!isSuccessful) {
-                String errorString = backgroundAction.getErrorReason();
-                log.error(errorString);
-                System.exit(1);
-            }
-
-            terminationFuture.reset();
-            
-            RetrieveAvailableFormsFromServer source = new RetrieveAvailableFormsFromServer(sci,
-                    terminationFuture);
-            try {
-                source.doAction();
-            } catch (XmlDocumentFetchException | ParsingException e) {
-                log.error("failed to retrieve forms", e);
-            }
-
-            List<FormStatus> statuses = source.getAvailableForms();
-            FormStatus toDl = null;
-            boolean found = false;
-            for (int i = 0; i < statuses.size(); i++) {
-                FormStatus fs = statuses.get(i);
-                if (formid.equals(fs.getFormDefinition().getFormId())) {
-                    found = true;
-                    toDl = fs;
-                }
-            }
-            if (!found) {
-                log.error("form ID doesn't exist on server");
-                System.exit(0);
-            }
-
-            log.info("beginning download: " + toDl.getFormName());
-            terminationFuture.reset();
-            List<FormStatus> formsToTransfer = new ArrayList<FormStatus>();
-            formsToTransfer.add(toDl);
-
-            TransferFromServer serverSource = new TransferFromServer(sci, terminationFuture,
-                    formsToTransfer);
-
-            boolean status = serverSource.doAction();
-        }
-
-        if (exportPath != null) {
-            List<BriefcaseFormDefinition> forms = FileSystemUtils.getBriefcaseFormList();
-            for (int i = 0; i < forms.size(); i++) {
-                BriefcaseFormDefinition x = forms.get(i);
-                if (formid.equals(x.getFormId())) {
-                    toExport = x;
-                    break;
-                }
-            }
-
-            if (toExport == null) {
-                log.error("Form not found");
-                return;
-            }
-
-            File pemFile = null;
-            if (toExport.isFileEncryptedForm() || toExport.isFieldEncryptedForm()) {
-                if (pemKeyFile == null) {
-                    log.error("Briefcase action failed: No specified PrivateKey file for encrypted form");
-                    return;
-                }
-                pemFile = new File(pemKeyFile);
-                if (!pemFile.exists()) {
-                    log.error("Briefcase action failed: No PrivateKey file for encrypted form");
-                    return;
-                }
-
-                String errorMsg = null;
-                boolean success = false;
-                for (;;) /* this only executes once... */ {
-                    try {
-                        BufferedReader br = new BufferedReader(new InputStreamReader(
-                                new FileInputStream(pemFile), "UTF-8"));
-                        PEMReader rdr = new PEMReader(br);
-                        Object o = rdr.readObject();
-                        try {
-                          rdr.close();
-                        } catch ( IOException e ) {
-                          // ignore.
-                        }
-                        if (o == null) {
-                            errorMsg = "The supplied file is not in PEM format.";
-                            System.err.println(errorMsg);
-                            break;
-                        }
-                        PrivateKey privKey;
-                        if (o instanceof KeyPair) {
-                            KeyPair kp = (KeyPair)o;
-                            privKey = kp.getPrivate();
-                        } else if (o instanceof PrivateKey) {
-                            privKey = (PrivateKey)o;
-                        } else {
-                            privKey = null;
-                        }
-                        if (privKey == null) {
-                            errorMsg = "The supplied file does not contain a private key.";
-                            System.err.println(errorMsg);
-                            break;
-                        }
-                        toExport.setPrivateKey(privKey);
-                        success = true;
-                        break;
-                    } catch (IOException e) {
-                        System.err.println("The supplied PEM file could not be parsed.");
-                        e.printStackTrace();
-                        break;
-                    }
-                }
-                if (!success) {
-                    EventBus.publish(new ExportProgressEvent(errorMsg));
-                    EventBus.publish(new ExportFailedEvent(toExport));
-                    return;
-                }
-            }
-
-            Date startDate = null;
-            Date endDate = null;
-            DateFormat df = new SimpleDateFormat(MainBriefcaseWindow.DATE_FORMAT);
-
-            try {
-                if (startDateString != null) {
-                    startDate = df.parse(startDateString);
-                }
-                if (endDateString != null) {
-                    endDate = df.parse(endDateString);
-                }
-            } catch (ParseException e) {
-                log.error("bad date range", e);
-            }
-
-            terminationFuture.reset();
-            File dir = new File(exportPath);
-            log.info("exporting to : " + dir.getAbsolutePath());
-            ExportToCsv exp = new ExportToCsv(dir, toExport, terminationFuture, fileName,
-                    exportMedia, overwrite, startDate, endDate);
-            exp.doAction();
-        }
-
+    if (exportPath != null) {
+      export(
+          storageDir,
+          formid,
+          fileName,
+          exportPath,
+          Optional.ofNullable(startDateString).map(Export::toDate).orElse(null),
+          Optional.ofNullable(endDateString).map(Export::toDate).orElse(null),
+          exportMedia,
+          overwrite,
+          Optional.ofNullable(pemKeyFile)
+      );
     }
 
-    @EventSubscriber(eventClass = ExportProgressEvent.class)
-    public void progress(ExportProgressEvent event) {
-        log.info(event.getText());
-    }
+  }
 
-    @EventSubscriber(eventClass = ExportFailedEvent.class)
-    public void failedCompletion(ExportFailedEvent event) {
-        log.error("Failed.");
-    }
+  @EventSubscriber(eventClass = ExportProgressEvent.class)
+  public void progress(ExportProgressEvent event) {
+    log.info(event.getText());
+  }
 
-    @EventSubscriber(eventClass = TransferFailedEvent.class)
-    public void failedCompletion(TransferFailedEvent event) {
-        log.error("Transfer Failed");
-    }
+  @EventSubscriber(eventClass = ExportFailedEvent.class)
+  public void failedCompletion(ExportFailedEvent event) {
+    log.error("Failed.");
+  }
 
-    @EventSubscriber(eventClass = ExportSucceededEvent.class)
-    public void successfulCompletion(ExportSucceededEvent event) {
-        log.info("Succeeded.");
-    }
+  @EventSubscriber(eventClass = TransferFailedEvent.class)
+  public void failedCompletion(TransferFailedEvent event) {
+    log.error("Transfer Failed");
+  }
 
-    @EventSubscriber(eventClass = TransferSucceededEvent.class)
-    public void successfulCompletion(TransferSucceededEvent event) {
-        log.info("Transfer Succeeded");
-    }
+  @EventSubscriber(eventClass = ExportSucceededEvent.class)
+  public void successfulCompletion(ExportSucceededEvent event) {
+    log.info("Succeeded.");
+  }
 
-    @EventSubscriber(eventClass = FormStatusEvent.class)
-    public void updateDetailedStatus(FormStatusEvent fse) {
-        log.info(fse.getStatusString());
-    }
+  @EventSubscriber(eventClass = TransferSucceededEvent.class)
+  public void successfulCompletion(TransferSucceededEvent event) {
+    log.info("Transfer Succeeded");
+  }
 
-    @EventSubscriber(eventClass = RetrieveAvailableFormsFailedEvent.class)
-    public void formsAvailableFromServer(RetrieveAvailableFormsFailedEvent event) {
-        log.error("Accessing the server failed with error: " + event.getReason());
-    }
+  @EventSubscriber(eventClass = FormStatusEvent.class)
+  public void updateDetailedStatus(FormStatusEvent fse) {
+    log.info(fse.getStatusString());
+  }
+
+  @EventSubscriber(eventClass = RetrieveAvailableFormsFailedEvent.class)
+  public void formsAvailableFromServer(RetrieveAvailableFormsFailedEvent event) {
+    log.error("Accessing the server failed with error: " + event.getReason());
+  }
 
 }

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -97,16 +97,7 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
 
     if (args.length == 0) {
 
-            EventQueue.invokeLater(new Runnable() {
-                public void run() {
-                    try {
-                        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-                        MainBriefcaseWindow window = new MainBriefcaseWindow();
-                    } catch (Exception e) {
-                        log.error("failed to launch app", e);
-                    }
-                }
-            });
+            launchGUI();
         } else {
             Options options = addOptions();
             CommandLineParser parser = new DefaultParser();
@@ -177,6 +168,19 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
             BriefcaseCLI bcli = new BriefcaseCLI(cmd);
             bcli.run();
         }
+    }
+
+    public static void launchGUI() {
+        EventQueue.invokeLater(new Runnable() {
+            public void run() {
+                try {
+                    UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+                    MainBriefcaseWindow window = new MainBriefcaseWindow();
+                } catch (Exception e) {
+                    log.error("failed to launch app", e);
+                }
+            }
+        });
     }
 
     @Override

--- a/src/org/opendatakit/common/cli/Args.java
+++ b/src/org/opendatakit/common/cli/Args.java
@@ -1,0 +1,124 @@
+package org.opendatakit.common.cli;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.commons.cli.CommandLine;
+
+/**
+ * This class serves as a container of values parsed from the command line.
+ * <p>It holds the values inside a <code>{@link Map}&lt;{@link Param}, String&gt;</code> and offers a
+ * type-safe, null-safe API to get them thanks to the use of generics and the
+ * {@link Optional} type.
+ */
+public class Args {
+  private final Map<Param, String> valuesMap;
+
+  /**
+   * Private constructor.
+   * <p>Users of this class should call the {@link #from(CommandLine, Set)}
+   * factory instead.
+   *
+   * @param valuesMap the <code>{@link java.util.Map}&lt;{@link Param}, String&gt;</code> with the params and values
+   *                  that this instance will hold
+   */
+  private Args(Map<Param, String> valuesMap) {
+    this.valuesMap = valuesMap;
+  }
+
+  /**
+   * <p>Factory that extracts a set of values for the given params set from a
+   * {@link CommandLine} instance
+   * <ul>
+   * <li>For argument params, it extracts their value</li>
+   * <li>For flag params, it uses a <code>null</code> value</li>
+   * </ul>
+   *
+   * @param cli    A {@link CommandLine} instance
+   * @param params A <code>{@link Set}&lt;{@link Param}&gt;</code> with the params to extract using <code>cli</code>
+   * @return An {@link Args} instance
+   */
+  static Args from(CommandLine cli, Set<Param> params) {
+    Map<Param, String> valuesMap = new HashMap<>();
+    // We can't collect toMap() because it will throw NPEs if values are null
+    params.forEach(param -> {
+      if (param.isArg())
+        valuesMap.put(param, cli.getOptionValue(param.shortCode));
+      if (param.isFlag() && cli.hasOption(param.shortCode))
+        valuesMap.put(param, null);
+
+    });
+    return new Args(valuesMap);
+  }
+
+  /**
+   * <p>Returns true if the <code>key</code> is contained in the <code>valuesMap</code>
+   * <p>Useful to check for presence of flag params
+   *
+   * @param key the {@link Param} instance to be searched
+   * @return true if <code>key</code> is contained in the <code>valuesMap</code>
+   */
+  public boolean has(Param<?> key) {
+    return valuesMap.containsKey(key);
+  }
+
+  /**
+   * <p>Returns an {@link Optional} instance with the value of the given <code>key</code>
+   *
+   * @param key the {@link Param} key of the value to be retrieved
+   * @param <T> type of the value to be retrieved
+   * @return an {@link Optional} instance with the value of the given <code>key</code>
+   */
+  public <T> Optional<T> getOptional(Param<T> key) {
+    return Optional.ofNullable(valuesMap.get(key))
+        .map(key::map);
+  }
+
+  /**
+   * <p>Returns the value contained in the given <code>key</code>
+   * <p>Throws an {@link IllegalArgumentException} if the key is not contained,
+   * or if the <code>key</code> corresponds to a flag param
+   *
+   * @param key the {@link Param} key of the value to be retrieved
+   * @param <T> type of the value to be retrieved
+   * @return the value contained in the given <code>key</code>
+   */
+  public <T> T get(Param<T> key) {
+    return getOptional(key)
+        .orElseThrow(() -> new IllegalArgumentException("No param -" + key.shortCode + " has been declared"));
+  }
+
+  /**
+   * <p>Shortcut to <code>getOptional(key).orElse(null)</code> to avoid handling explicit
+   * null values
+   *
+   * @param key the {@link Param} key of the value to be retrieved
+   * @param <T> type of the value to be retrieved
+   * @return the value contained in the given <code>key</code> or <code>null</code> if the key is not contained
+   */
+  public <T> T getOrNull(Param<T> key) {
+    return getOptional(key).orElse(null);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Args args = (Args) o;
+    return Objects.equals(valuesMap, args.valuesMap);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(valuesMap);
+  }
+
+  @Override
+  public String toString() {
+    return "Args{" +
+        "valuesMap=" + valuesMap +
+        '}';
+  }
+}

--- a/src/org/opendatakit/common/cli/Cli.java
+++ b/src/org/opendatakit/common/cli/Cli.java
@@ -1,0 +1,156 @@
+package org.opendatakit.common.cli;
+
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toSet;
+import static org.opendatakit.common.cli.CustomHelpFormatter.printHelp;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.opendatakit.briefcase.model.BriefcasePreferences;
+
+/**
+ * <p>Cli is a command line adapter. It helps define executable operations and their
+ * required and optional params.
+ * <p>It defines some default operations like "show help" and "show version"
+ */
+public class Cli {
+  private static final Param<Void> SHOW_HELP = Param.flag("h", "help", "Show help");
+  private static final Param<Void> SHOW_VERSION = Param.flag("v", "version", "Show version");
+
+  private final Set<Operation> requiredOperations = new HashSet<>();
+  private final Set<Operation> operations = new HashSet<>();
+  private final Set<Runnable> otherwiseRunnables = new HashSet<>();
+  private final Set<Operation> executedOperations = new HashSet<>();
+
+  public Cli() {
+    register(Operation.of(SHOW_HELP, args -> printHelp(requiredOperations, operations)));
+    register(Operation.of(SHOW_VERSION, args -> printVersion()));
+  }
+
+  /**
+   * Register an {@link Operation}
+   *
+   * @param operation an {@link Operation} instance
+   * @return self {@link Cli} instance to chain more method calls
+   */
+  public Cli register(Operation operation) {
+    operations.add(operation);
+    return this;
+  }
+
+  /**
+   * Register a {@link Runnable} block that will be executed if no {@link Operation}
+   * is executed. For example, if the user passes no arguments when executing this program
+   *
+   * @param runnable a {@link Runnable} block
+   * @return self {@link Cli} instance to chain more method calls
+   */
+  public Cli otherwise(Runnable runnable) {
+    otherwiseRunnables.add(runnable);
+    return this;
+  }
+
+  /**
+   * Runs the command line program
+   *
+   * @param args command line arguments
+   * @see <a href="https://blog.idrsolutions.com/2015/03/java-8-consumer-supplier-explained-in-5-minutes/">Java 8 consumer supplier explained in 5 minutes</a>
+   */
+  public void run(String[] args) {
+    Set<Param> allParams = getAllParams();
+    CommandLine cli = getCli(args, allParams);
+
+    requiredOperations.forEach(operation -> {
+      checkForMissingParams(cli, operation.requiredParams);
+      operation.argsConsumer.accept(Args.from(cli, operation.requiredParams));
+    });
+
+    operations.forEach(operation -> {
+      if (cli.hasOption(operation.param.shortCode)) {
+        checkForMissingParams(cli, operation.requiredParams);
+        operation.argsConsumer.accept(Args.from(cli, operation.getAllParams()));
+        executedOperations.add(operation);
+      }
+    });
+
+    if (executedOperations.isEmpty())
+      otherwiseRunnables.forEach(Runnable::run);
+  }
+
+  /**
+   * Flatmap all required params from all required operations, all params
+   * from all operations and flatmap them into a {@link Set}&lt;{@link Param}>&gt;
+   *
+   * @return a {@link Set} of {@link Param}> instances
+   * @see <a href="https://www.mkyong.com/java8/java-8-flatmap-example/">Java 8 flatmap example</a>
+   */
+  private Set<Param> getAllParams() {
+    return Stream.of(
+        requiredOperations.stream().flatMap(operation -> operation.requiredParams.stream()),
+        operations.stream().flatMap(operation -> operation.getAllParams().stream())
+    ).flatMap(Function.identity()).collect(toSet());
+  }
+
+  private CommandLine getCli(String[] args, Set<Param> params) {
+    try {
+      return new DefaultParser().parse(mapToOptions(params), args, false);
+    } catch (ParseException e) {
+      e.printStackTrace();
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void checkForMissingParams(CommandLine cli, Set<Param> paramsToCheck) {
+    Set<Param> missingParams = paramsToCheck.stream().filter(param -> !cli.hasOption(param.shortCode)).collect(toSet());
+    if (!missingParams.isEmpty()) {
+      System.out.printf("Missing params: ");
+      System.out.printf(missingParams.stream().map(param -> "-" + param.shortCode).collect(joining(", ")));
+      System.out.println("");
+      printHelp(requiredOperations, operations);
+      System.exit(1);
+    }
+  }
+
+  static Options mapToOptions(Set<Param> params) {
+    Options options = new Options();
+    params.forEach(param -> options.addOption(param.option));
+    return options;
+  }
+
+  private static void printVersion() {
+    System.out.println("Briefcase " + BriefcasePreferences.VERSION);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Cli cli = (Cli) o;
+    return Objects.equals(requiredOperations, cli.requiredOperations) &&
+        Objects.equals(operations, cli.operations) &&
+        Objects.equals(otherwiseRunnables, cli.otherwiseRunnables) &&
+        Objects.equals(executedOperations, cli.executedOperations);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(requiredOperations, operations, otherwiseRunnables, executedOperations);
+  }
+
+  @Override
+  public String toString() {
+    return "Cli{" +
+        "requiredOperations=" + requiredOperations +
+        ", operations=" + operations +
+        ", otherwiseRunnables=" + otherwiseRunnables +
+        ", executedOperations=" + executedOperations +
+        '}';
+  }
+}

--- a/src/org/opendatakit/common/cli/Cli.java
+++ b/src/org/opendatakit/common/cli/Cli.java
@@ -12,7 +12,7 @@ import java.util.stream.Stream;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.UnrecognizedOptionException;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
 
 /**
@@ -101,9 +101,15 @@ public class Cli {
   private CommandLine getCli(String[] args, Set<Param> params) {
     try {
       return new DefaultParser().parse(mapToOptions(params), args, false);
-    } catch (ParseException e) {
-      e.printStackTrace();
-      throw new RuntimeException(e);
+    } catch (UnrecognizedOptionException e) {
+      System.err.println(e.getMessage());
+      printHelp(requiredOperations, operations);
+      System.exit(1);
+      return null;
+    } catch (Throwable t) {
+      t.printStackTrace();
+      System.exit(1);
+      return null;
     }
   }
 

--- a/src/org/opendatakit/common/cli/CustomHelpFormatter.java
+++ b/src/org/opendatakit/common/cli/CustomHelpFormatter.java
@@ -1,0 +1,95 @@
+package org.opendatakit.common.cli;
+
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+import static org.opendatakit.common.cli.Cli.mapToOptions;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+
+class CustomHelpFormatter {
+  static void printHelp(Set<Operation> requiredOperations, Set<Operation> operations) {
+    printUsage();
+    Map<String, String> helpLinesPerShortcode = getParamHelpLines(requiredOperations, operations);
+    if (!requiredOperations.isEmpty())
+      printRequiredParams(helpLinesPerShortcode, requiredOperations);
+    printAvailableOperations(helpLinesPerShortcode, operations);
+    printParamsPerOperation(helpLinesPerShortcode, operations);
+  }
+
+  private static void printParamsPerOperation(Map<String, String> helpLinesPerShortcode, Set<Operation> operations) {
+    operations.forEach(operation -> {
+      if (operation.hasAnyParam())
+        System.out.println("Params for -" + operation.param.shortCode + " operation:");
+      if (operation.hasRequiredParams())
+        printRequiredParams(helpLinesPerShortcode, operation);
+      if (operation.hasOptionalParams())
+        printOptionalParams(helpLinesPerShortcode, operation);
+      if (operation.hasAnyParam())
+        System.out.println("");
+    });
+  }
+
+  private static void printRequiredParams(Map<String, String> helpLinesPerShortcode, Operation operation) {
+    operation.requiredParams.stream()
+        .sorted(Comparator.comparing(param -> param.shortCode))
+        .forEach(param -> System.out.println("  " + helpLinesPerShortcode.get(param.shortCode)));
+  }
+
+  private static void printRequiredParams(Map<String, String> helpLinesPerShortcode, Set<Operation> requiredOperations) {
+    System.out.println("Required params:");
+    requiredOperations.stream()
+        .flatMap(operation -> operation.requiredParams.stream())
+        .sorted(Comparator.comparing(param -> param.shortCode))
+        .forEach(param -> System.out.println(helpLinesPerShortcode.get(param.shortCode)));
+    System.out.println("");
+  }
+
+  private static void printOptionalParams(Map<String, String> helpLinesPerShortcode, Operation operation) {
+    System.out.println("  (optionally)");
+    operation.optionalParams.stream()
+        .sorted(Comparator.comparing(param -> param.shortCode))
+        .forEach(param -> System.out.println("  " + helpLinesPerShortcode.get(param.shortCode)));
+  }
+
+  private static void printAvailableOperations(Map<String, String> helpLinesPerShortcode, Set<Operation> operations) {
+    System.out.println("Available operations:");
+    operations.stream()
+        .sorted(Comparator.comparing(operation -> operation.param.shortCode))
+        .forEach(operation -> System.out.println(helpLinesPerShortcode.get(operation.param.shortCode)));
+    System.out.println("");
+  }
+
+  private static void printUsage() {
+    System.out.println("Usage: java -jar briefcase.jar <params>");
+    System.out.println("");
+  }
+
+  private static Map<String, String> getParamHelpLines(Set<Operation> requiredOperations, Set<Operation> operations) {
+    Set<Param> allParams = Stream.of(
+        requiredOperations.stream().flatMap(operation -> operation.requiredParams.stream()),
+        operations.stream().flatMap(operation -> operation.getAllParams().stream())
+    ).flatMap(Function.identity()).collect(toSet());
+    Options options = mapToOptions(allParams);
+
+    StringWriter out = new StringWriter();
+    PrintWriter pw = new PrintWriter(out);
+    HelpFormatter helpFormatter = new HelpFormatter();
+    helpFormatter.printHelp(pw, 999, "ignore", "ignore", options, 0, 4, "ignore");
+    return Stream.of(out.toString().split("\n"))
+        .filter(line -> line.startsWith("-"))
+        .collect(toMap(
+            (String line) -> line.substring(1, line.indexOf(",")),
+            Function.identity()
+        ));
+  }
+
+
+}

--- a/src/org/opendatakit/common/cli/Operation.java
+++ b/src/org/opendatakit/common/cli/Operation.java
@@ -1,0 +1,111 @@
+package org.opendatakit.common.cli;
+
+import static java.util.Collections.emptySet;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * This class represents a Briefcase operation to be executed in a command-line environment
+ * <p>
+ * Uses a {@link Consumer}&lt;{@link Args}&gt; to pass command-line arguments to the logic of this {@link Operation}
+ */
+public class Operation {
+  final Param param;
+  final Consumer<Args> argsConsumer;
+  final Set<Param> requiredParams;
+  final Set<Param> optionalParams;
+
+  private Operation(Param param, Consumer<Args> argsConsumer, Set<Param> requiredParams, Set<Param> optionalParams) {
+    this.param = param;
+    this.argsConsumer = argsConsumer;
+    this.requiredParams = requiredParams;
+    this.optionalParams = optionalParams;
+  }
+
+  /**
+   * Creates a new {@link Operation} without params of any kind (required or optional)
+   *
+   * @param param        main {@link Param} that will trigger the execution of this {@link Operation}, normally a {@link Param#flag(String, String, String)}
+   * @param argsConsumer {@link Consumer}&lt;{@link Args}&gt; with the logic of this {@link Operation}
+   * @return a new {@link Operation} instance
+   */
+  public static Operation of(Param param, Consumer<Args> argsConsumer) {
+    return new Operation(param, argsConsumer, emptySet(), emptySet());
+  }
+
+  /**
+   * Creates a new {@link Operation} with some required params
+   *
+   * @param param          main {@link Param} that will trigger the execution of this {@link Operation}, normally a {@link Param#flag(String, String, String)}
+   * @param argsConsumer   {@link Consumer}&lt;{@link Args}&gt; with the logic of this {@link Operation}
+   * @param requiredParams a {@link Set}&lt;{@link Param}&gt; with the required params for this operation
+   * @return a new {@link Operation} instance
+   */
+  public static Operation of(Param param, Consumer<Args> argsConsumer, List<Param> requiredParams) {
+    return new Operation(param, argsConsumer, new HashSet<>(requiredParams), emptySet());
+  }
+
+  /**
+   * Creates a new {@link Operation} with some required and optional params
+   *
+   * @param param          main {@link Param} that will trigger the execution of this {@link Operation}, normally a {@link Param#flag(String, String, String)}
+   * @param argsConsumer   {@link Consumer}&lt;{@link Args}&gt; with the logic of this {@link Operation}
+   * @param requiredParams a {@link Set}&lt;{@link Param}&gt; with the required params for this operation
+   * @param optionalParams a {@link Set}&lt;{@link Param}&gt; with the optional params for this operation
+   * @return a new {@link Operation} instance
+   */
+  public static Operation of(Param param, Consumer<Args> argsConsumer, List<Param> requiredParams, List<Param> optionalParams) {
+    return new Operation(param, argsConsumer, new HashSet<>(requiredParams), new HashSet<>(optionalParams));
+  }
+
+  Set<Param> getAllParams() {
+    // We need this because java.util.xyz collections are mutable
+    HashSet<Param> allParams = new HashSet<>();
+    allParams.add(param);
+    allParams.addAll(requiredParams);
+    allParams.addAll(optionalParams);
+    return allParams;
+  }
+
+  boolean hasAnyParam() {
+    return hasRequiredParams() || hasOptionalParams();
+  }
+
+  boolean hasOptionalParams() {
+    return !optionalParams.isEmpty();
+  }
+
+  boolean hasRequiredParams() {
+    return !requiredParams.isEmpty();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Operation operation = (Operation) o;
+    return Objects.equals(param, operation.param) &&
+        Objects.equals(argsConsumer, operation.argsConsumer) &&
+        Objects.equals(requiredParams, operation.requiredParams) &&
+        Objects.equals(optionalParams, operation.optionalParams);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(param, argsConsumer, requiredParams, optionalParams);
+  }
+
+  @Override
+  public String toString() {
+    return "Operation{" +
+        "param=" + param +
+        ", argsConsumer=" + argsConsumer +
+        ", requiredParams=" + requiredParams +
+        ", optionalParams=" + optionalParams +
+        '}';
+  }
+}

--- a/src/org/opendatakit/common/cli/Param.java
+++ b/src/org/opendatakit/common/cli/Param.java
@@ -1,0 +1,115 @@
+package org.opendatakit.common.cli;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import org.apache.commons.cli.Option;
+
+/**
+ * This class represents a command-line execution argument. It can be either a flag (without a
+ * value associated to it) or an arg (with some value).
+ * <p>
+ * All params are of type {@link String} by default and they can have a {@link Function}&lt;{@link String}, T&gt; mapper
+ * that can produce values of other types if needed.
+ *
+ * @param <T> the type of the value it holds. {@link String} by default or {@link Void} for flags
+ */
+public class Param<T> {
+  final String shortCode;
+  final Option option;
+  private final Optional<Function<String, T>> mapper;
+
+  private Param(String shortCode, Option option, Optional<Function<String, T>> mapper) {
+    this.shortCode = shortCode;
+    this.option = option;
+    this.mapper = mapper;
+  }
+
+  /**
+   * Creates a new {@link Param}&lt;{@link String}&gt; instance for a command-line arg
+   *
+   * @param shortCode   the shortcode (usually one or two chars)
+   * @param longCode    the longcode (usually some words separated by hyphens)
+   * @param description the description
+   * @return a new {@link Param}&lt;{@link String}&gt; instance
+   */
+  public static Param<String> arg(String shortCode, String longCode, String description) {
+    return new Param<>(
+        shortCode,
+        new Option(shortCode, longCode, true, description),
+        Optional.of(Function.identity())
+    );
+  }
+
+  /**
+   * Creates a new {@link Param}&lt;U&gt; instance for a command-line arg mapping the received {@link String} value
+   *
+   * @param shortCode   the shortcode (usually one or two chars)
+   * @param longCode    the longcode (usually some words separated by hyphens)
+   * @param description the description
+   * @param mapper      a mapper {@link Function}&lt;{@link String}, U&gt; function that will transform the received {@link String} into a value of type <em>U</em>
+   * @param <U>         the type of the resulting value after transforming it with <em>mapper</em>
+   * @return a new {@link Param}&lt;U&gt; instance
+   */
+  public static <U> Param<U> arg(String shortCode, String longCode, String description, Function<String, U> mapper) {
+    return new Param<>(
+        shortCode,
+        new Option(shortCode, longCode, true, description),
+        Optional.of(mapper)
+    );
+  }
+
+  /**
+   * Creates a new {@link Param}&lt;{@link Void}&gt; instance for a command-line flag
+   *
+   * @param shortCode   the shortcode (usually one or two chars)
+   * @param longCode    the longcode (usually some words separated by hyphens)
+   * @param description the description
+   * @return a new {@link Param}&lt;{@link Void}&gt; instance
+   */
+  public static Param<Void> flag(String shortCode, String longCode, String description) {
+    return new Param<>(
+        shortCode,
+        new Option(shortCode, longCode, false, description),
+        Optional.empty()
+    );
+  }
+
+  boolean isArg() {
+    return this.option.hasArg();
+  }
+
+  boolean isFlag() {
+    return !this.option.hasArg();
+  }
+
+  T map(String value) {
+    return this.mapper
+        .orElseThrow(() -> new RuntimeException("No mapper defined for param -" + shortCode))
+        .apply(value);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Param<?> param = (Param<?>) o;
+    return Objects.equals(shortCode, param.shortCode) &&
+        Objects.equals(option, param.option) &&
+        Objects.equals(mapper, param.mapper);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(shortCode, option, mapper);
+  }
+
+  @Override
+  public String toString() {
+    return "Param{" +
+        "shortCode='" + shortCode + '\'' +
+        ", option=" + option +
+        ", mapper=" + mapper +
+        '}';
+  }
+}

--- a/src/org/opendatakit/common/cli/package-info.java
+++ b/src/org/opendatakit/common/cli/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Provides the definition of a {@link org.opendatakit.common.cli.Cli} class that abstracts away the details
+ * of command line operation execution, including params definition
+ */
+package org.opendatakit.common.cli;


### PR DESCRIPTION
This is the first of a series of PRs that will try to solve current coupling problems in Briefcase between logging, command line args parsing, console command execution and console UI concerns.

Currently, there is no clear separation between what can be executed from the command line, required and optional args parsing and the rest of Briefcase's logic. The current code relies heavily on duplication, conditional blocks and comments to give readers hints of what's going on and it's intertwined in code that prepares and launches the GUI.

Although the command line args parsing is not the most pressing issue to be solved, it is the easiest to start with and it will make easier the task of decoupling the rest.

**Warning: this PR bumps the project to Java8** 

#### What has been done to verify that this works as intended?
Run the "pull from Aggregate" and "export form" operations from the new command line interface and from the GUI.

I haven't been able yet to test the "import from sd card" and the "export encrypted form" operations. Will work on this but I wanted to create the PR to start discussion.

#### Why is this the best possible solution? Were any other approaches considered?
By creating a command line adapter in `Cli`, we can define a clear constraint about where to do command line stuff and where not to. 

This change lets us:
- be explicit about what operations can be executed from the command line
- clearly define their required and optional params
- a way to obtain argument values passed from the command line (and even map them from `String` to other types)

Also:
- it doesn't introduce any new library to the project.
- it could be extracted to a lib and be reused in other parts of ODK.

#### Are there any risks to merging this code? If so, what are they?
Any risk related to Java8 migration. I think that, as discussed in #158 and #203, this should be a safe move