### PR TITLE
Issue 261 file folder dialog

### DIFF
--- a/src/org/opendatakit/briefcase/ui/export/FileChooser.java
+++ b/src/org/opendatakit/briefcase/ui/export/FileChooser.java
@@ -3,7 +3,7 @@ package org.opendatakit.briefcase.ui.export;
 import static javax.swing.JFileChooser.DIRECTORIES_ONLY;
 import static javax.swing.JFileChooser.FILES_ONLY;
 import static javax.swing.JFileChooser.OPEN_DIALOG;
-import static org.opendatakit.briefcase.util.FindDirectoryStructure.isMac;
+import static org.opendatakit.briefcase.util.FindDirectoryStructure.isUnix;
 
 import java.awt.Container;
 import java.awt.FileDialog;
@@ -23,17 +23,17 @@ interface FileChooser {
 
     JFileChooser fileChooser = buildFileChooser(initialLocation, "Choose a directory", DIRECTORIES_ONLY, fileFilter);
 
-    return isAWTRequired()
-        ? new NativeFileChooser(parent, buildFileDialog(parent, initialLocation, fileChooser), fileChooser, filter, filterDescription)
-        : new SwingFileChooser(parent, fileChooser, filter, filterDescription);
+    return isUnix()
+        ? new SwingFileChooser(parent, fileChooser, filter, filterDescription)
+        : new NativeFileChooser(parent, buildFileDialog(parent, initialLocation, fileChooser), fileChooser, filter, filterDescription);
   }
 
   static FileChooser file(Container parent, Optional<File> initialFile) {
     JFileChooser fileChooser = buildFileChooser(initialFile, "Choose a file", FILES_ONLY, Optional.empty());
 
-    return isAWTRequired()
-        ? new NativeFileChooser(parent, buildFileDialog(parent, initialFile, fileChooser), fileChooser, __ -> true, "")
-        : new SwingFileChooser(parent, fileChooser, f -> true, "");
+    return isUnix()
+        ? new SwingFileChooser(parent, fileChooser, f -> true, "")
+        : new NativeFileChooser(parent, buildFileDialog(parent, initialFile, fileChooser), fileChooser, __ -> true, "");
   }
 
   static FileDialog buildFileDialog(Container parent, Optional<File> initialLocation, JFileChooser fileChooser) {
@@ -53,19 +53,6 @@ interface FileChooser {
     fileFilter.ifPresent(fileChooser::setFileFilter);
     initialLocation.ifPresent(fileChooser::setSelectedFile);
     return fileChooser;
-  }
-
-  /**
-   * Though the Mac-specific file chooser is very nice, it no longer functions on Oracle's Java 7.
-   * The issue is that the "apple.awt.fileDialogForDirectories" property is no longer supported in
-   * Java 7. See http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=7161437, where the issue is
-   * marked as resolved, but they seem only to have fixed it in JDK 8.
-   *
-   * @return true if Briefcase is running on Java7 on a Mac host
-   */
-  static boolean isAWTRequired() {
-    String javaVersion = System.getProperty("java.version");
-    return (!((javaVersion.compareTo("1.7") >= 0) && javaVersion.compareTo("1.8") < 0)) && isMac();
   }
 
   static FileFilter createFileFilter(Predicate<File> predicate, String description) {

--- a/src/org/opendatakit/briefcase/ui/export/FileChooser.java
+++ b/src/org/opendatakit/briefcase/ui/export/FileChooser.java
@@ -24,7 +24,7 @@ interface FileChooser {
     JFileChooser fileChooser = buildFileChooser(initialLocation, "Choose a directory", DIRECTORIES_ONLY, fileFilter);
 
     return isAWTRequired()
-        ? new AWTFileChooser(parent, buildFileDialog(parent, initialLocation, fileChooser), fileChooser, filter, filterDescription)
+        ? new NativeFileChooser(parent, buildFileDialog(parent, initialLocation, fileChooser), fileChooser, filter, filterDescription)
         : new SwingFileChooser(parent, fileChooser, filter, filterDescription);
   }
 
@@ -32,7 +32,7 @@ interface FileChooser {
     JFileChooser fileChooser = buildFileChooser(initialFile, "Choose a file", FILES_ONLY, Optional.empty());
 
     return isAWTRequired()
-        ? new AWTFileChooser(parent, buildFileDialog(parent, initialFile, fileChooser), fileChooser, __ -> true, "")
+        ? new NativeFileChooser(parent, buildFileDialog(parent, initialFile, fileChooser), fileChooser, __ -> true, "")
         : new SwingFileChooser(parent, fileChooser, f -> true, "");
   }
 

--- a/src/org/opendatakit/briefcase/ui/export/NativeFileChooser.java
+++ b/src/org/opendatakit/briefcase/ui/export/NativeFileChooser.java
@@ -13,14 +13,14 @@ import java.util.function.Predicate;
 import javax.swing.JFileChooser;
 import org.opendatakit.briefcase.ui.ODKOptionPane;
 
-class AWTFileChooser implements FileChooser {
+class NativeFileChooser implements FileChooser {
   private Container parent;
   private final FileDialog fileDialog;
   private JFileChooser fileChooser;
   private Predicate<File> filter;
   private String filterDescription;
 
-  AWTFileChooser(Container parent, FileDialog fileDialog, JFileChooser fileChooser, Predicate<File> filter, String filterDescription) {
+  NativeFileChooser(Container parent, FileDialog fileDialog, JFileChooser fileChooser, Predicate<File> filter, String filterDescription) {
     this.parent = parent;
     this.fileDialog = fileDialog;
     this.fileChooser = fileChooser;

--- a/src/org/opendatakit/briefcase/util/FindDirectoryStructure.java
+++ b/src/org/opendatakit/briefcase/util/FindDirectoryStructure.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2012 University of Washington.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -26,7 +26,7 @@ import org.apache.commons.logging.LogFactory;
 
 /**
  * Originally written by Dylan.  Determines the mounts that have SD Cards attached.
- * 
+ *
  * @author the.dylan.price@gmail.com
  * @author mitchellsundt@gmail.com
  *
@@ -44,12 +44,17 @@ public class FindDirectoryStructure {
     String os = System.getProperty(PROPERTY_OS);
     return os.contains(OS_MAC);
   }
-  
+
+  public static boolean isUnix() {
+    String os = System.getProperty(PROPERTY_OS).toLowerCase();
+    return (os.contains("nix") || os.contains("nux") || os.contains("aix"));
+  }
+
   /**
    * Searches mounted drives for /odk/instances and returns a list of
    * positive results. Works for Windows, Mac, and Linux operating
    * systems.
-   * 
+   *
    * @return a {@link List} of {@link File}  containing matches of currently mounted file systems
    *         which contain the directoryStructureToSearchFor
    */
@@ -72,7 +77,7 @@ public class FindDirectoryStructure {
       File f = new File("/media", username);
       if (f.exists() && f.isDirectory()) {
         mountslist.add(f);
-      } 
+      }
 
       f = new File("/run/media", username);
       if (f.exists() && f.isDirectory()) {
@@ -92,11 +97,11 @@ public class FindDirectoryStructure {
     }
     return false;
   }
-  
+
   /**
    * Checks each given potential directory for existence of odk/instances
    * under it and returns a list of positive matches.
-   * 
+   *
    * @param mounts
    *          the potential mount points to check.
    * @param isDirectChild
@@ -122,7 +127,7 @@ public class FindDirectoryStructure {
               return f.isDirectory();
             }
           });
-          
+
           for ( File s : subdirs ) {
             if ( hasOdkInstancesDirectory(s) ) {
               candidates.add(s);


### PR DESCRIPTION
Closes #261 

I've been able to reproduce the error on a virtualized Mac.

I've been able to fix the problem, just by forcing Briefcase to use Swing's file dialog.

After confirming that this is, indeed, a fix, we should migrate other file dialogs to use the new FileChooser.

#### What has been done to verify that this works as intended?
Manually tested the changes on Linux and a virtualized Mac (High Sierra)

#### Why is this the best possible solution? Were any other approaches considered?
First I thought of making a workaround by debugging what the previous file dialog returned when clicked on "Open" without selecting any item but then I tried to just force Swing's dialog and it worked. ¯\\\_(ツ)\_/¯ 

#### Are there any risks to merging this code? If so, what are they?
I don't think so.
  