### PR TITLE
Issue 258 save settings in preferences

### DIFF
--- a/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
+++ b/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
@@ -81,13 +81,18 @@ public class BriefcasePreferences {
      * Associates the specified value with the specified key in this preference
      * node.
      *
+     * If the value is null, then the key is removed
+     *
      * @param key
      *          key with which the specified value is to be associated.
      * @param value
-     *          value to be associated with the specified key.
+     *          value to be associated with the specified key or null.
      */
     public void put(String key, String value) {
-        preferences.put(key, value);
+        if (value != null)
+            preferences.put(key, value);
+        else
+            remove(key);
     }
 
     /**

--- a/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
+++ b/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
@@ -16,7 +16,9 @@
 
 package org.opendatakit.briefcase.model;
 import java.security.Security;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.prefs.Preferences;
 
 import org.apache.http.HttpHost;
@@ -75,6 +77,28 @@ public class BriefcasePreferences {
      */
     public String get(String key, String defaultValue) {
         return preferences.get(key, defaultValue);
+    }
+
+    /**
+     * Returns the value associated with the specified key in this preference
+     * node mapped by a function that takes a String and returns a value of type T.
+     * Returns the specified default if there is no value associated with
+     * the key, or the backing store is inaccessible.
+     *
+     * @param key
+     *          key whose associated value is to be returned.
+     * @param mapper
+     *          function that takes a String and returns a value of type T
+     * @param defaultValue
+     *          the value to be returned in the event that this preference node
+     *          has no value associated with key.
+     * @param <T>
+     *          type of the output of this method
+     * @return the value associated with key, or defaultValue if no value is associated
+     *         with key, mapped with the mapper function, or the backing store is inaccessible.
+     */
+    public <T> T get(String key, Function<String,T> mapper, T defaultValue) {
+      return Optional.ofNullable(preferences.get(key, null)).map(mapper).orElse(defaultValue);
     }
 
     /**

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -38,6 +38,7 @@ import static org.opendatakit.briefcase.ui.StorageLocation.isUnderBriefcaseFolde
 import static org.opendatakit.briefcase.ui.export.FileChooser.directory;
 import static org.opendatakit.briefcase.ui.export.FileChooser.file;
 import static org.opendatakit.briefcase.util.FileSystemUtils.isUnderODKFolder;
+import static org.threeten.bp.format.DateTimeFormatter.ISO_DATE;
 
 import com.github.lgooddatepicker.components.DatePicker;
 import java.awt.Component;
@@ -68,11 +69,16 @@ import org.opendatakit.briefcase.model.TransferSucceededEvent;
 import org.opendatakit.briefcase.util.ExportAction;
 import org.opendatakit.briefcase.util.FileSystemUtils;
 import org.opendatakit.briefcase.util.StringUtils;
+import org.threeten.bp.LocalDate;
 
 public class ExportPanel extends JPanel {
 
   private static final long serialVersionUID = 7169316129011796197L;
   private static final BriefcasePreferences PREFERENCES = BriefcasePreferences.forClass(ExportPanel.class);
+  private static final String EXPORT_DIR_PREF = "exportDir";
+  private static final String PEM_FILE_PREF = "pemFile";
+  private static final String EXPORT_START_DATE_PREF = "exportStartDate";
+  private static final String EXPORT_END_DATE_PREF = "exportEndDate";
 
   public static final String TAB_NAME = "Export";
 
@@ -108,13 +114,13 @@ public class ExportPanel extends JPanel {
     txtExportDirectory.setFocusable(false);
     txtExportDirectory.setEditable(false);
     txtExportDirectory.setColumns(10);
-    txtExportDirectory.setText(PREFERENCES.get("export_dir", ""));
+    txtExportDirectory.setText(PREFERENCES.get(EXPORT_DIR_PREF, ""));
 
     btnChooseExportDirectory = new JButton("Choose...");
     btnChooseExportDirectory.addActionListener(__ -> getExportDirectoryChooser().choose().ifPresent(file -> {
       txtExportDirectory.setText(file.getAbsolutePath());
       updateExportButton();
-      PREFERENCES.put("export_dir", file.getAbsolutePath());
+      PREFERENCES.put(EXPORT_DIR_PREF, file.getAbsolutePath());
     }));
 
     JLabel lblPemPrivateKey = new JLabel("PEM Private Key File:");
@@ -123,24 +129,28 @@ public class ExportPanel extends JPanel {
     pemPrivateKeyFilePath.setFocusable(false);
     pemPrivateKeyFilePath.setEditable(false);
     pemPrivateKeyFilePath.setColumns(10);
-    pemPrivateKeyFilePath.setText(PREFERENCES.get("pem_file", ""));
+    pemPrivateKeyFilePath.setText(PREFERENCES.get(PEM_FILE_PREF, ""));
 
     btnPemFileChooseButton = new JButton("Choose...");
     btnPemFileChooseButton.addActionListener(__ -> getPemFileChooser().choose().ifPresent(file -> {
       pemPrivateKeyFilePath.setText(file.getAbsolutePath());
       updateExportButton();
-      PREFERENCES.put("pem_file", file.getAbsolutePath());
+      PREFERENCES.put(PEM_FILE_PREF, file.getAbsolutePath());
     }));
 
     JLabel lblDateFrom = new JLabel("Start Date (inclusive):");
     JLabel lblDateTo = new JLabel("End Date (exclusive):");
 
     pickStartDate = createDatePicker();
+    pickStartDate.setDate(PREFERENCES.get(EXPORT_START_DATE_PREF, LocalDate::parse, null));
     pickStartDate.addDateChangeListener(__ -> updateExportButton());
     pickStartDate.addDateChangeListener(__ -> validateDate(pickStartDate));
+    pickStartDate.addDateChangeListener(event -> PREFERENCES.put(EXPORT_START_DATE_PREF, Optional.ofNullable(event.getNewDate()).map(ld -> ld.format(ISO_DATE)).orElse(null)));
     pickEndDate = createDatePicker();
+    pickEndDate.setDate(PREFERENCES.get(EXPORT_END_DATE_PREF, LocalDate::parse, null));
     pickEndDate.addDateChangeListener(__ -> updateExportButton());
     pickEndDate.addDateChangeListener(__ -> validateDate(pickEndDate));
+    pickEndDate.addDateChangeListener(event -> PREFERENCES.put(EXPORT_END_DATE_PREF, Optional.ofNullable(event.getNewDate()).map(ld -> ld.format(ISO_DATE)).orElse(null)));
 
     tableModel = new FormExportTableModel();
     tableModel.onSelectionChange(this::updateExportButton);

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -111,12 +111,11 @@ public class ExportPanel extends JPanel {
     txtExportDirectory.setText(PREFERENCES.get("export_dir", ""));
 
     btnChooseExportDirectory = new JButton("Choose...");
-    btnChooseExportDirectory.addActionListener(__ -> chooseLocation(directory(
-        this,
-        fileFrom(txtExportDirectory),
-        f -> f.exists() && f.isDirectory() && !isUnderBriefcaseFolder(f) && !isUnderODKFolder(f),
-        "Exclude Briefcase & ODK directories"
-    ), txtExportDirectory, "export_dir"));
+    btnChooseExportDirectory.addActionListener(__ -> getExportDirectoryChooser().choose().ifPresent(file -> {
+      txtExportDirectory.setText(file.getAbsolutePath());
+      updateExportButton();
+      PREFERENCES.put("export_dir", file.getAbsolutePath());
+    }));
 
     JLabel lblPemPrivateKey = new JLabel("PEM Private Key File:");
 
@@ -127,10 +126,11 @@ public class ExportPanel extends JPanel {
     pemPrivateKeyFilePath.setText(PREFERENCES.get("pem_file", ""));
 
     btnPemFileChooseButton = new JButton("Choose...");
-    btnPemFileChooseButton.addActionListener(__ -> chooseLocation(file(
-        this,
-        fileFrom(pemPrivateKeyFilePath)
-    ), pemPrivateKeyFilePath, "pem_file"));
+    btnPemFileChooseButton.addActionListener(__ -> getPemFileChooser().choose().ifPresent(file -> {
+      pemPrivateKeyFilePath.setText(file.getAbsolutePath());
+      updateExportButton();
+      PREFERENCES.put("pem_file", file.getAbsolutePath());
+    }));
 
     JLabel lblDateFrom = new JLabel("Start Date (inclusive):");
     JLabel lblDateTo = new JLabel("End Date (exclusive):");
@@ -253,6 +253,22 @@ public class ExportPanel extends JPanel {
     setLayout(groupLayout);
     updateForms();
     setActiveExportState(exportStateActive);
+  }
+
+  private FileChooser getExportDirectoryChooser() {
+    return directory(
+        this,
+        fileFrom(txtExportDirectory),
+        f -> f.exists() && f.isDirectory() && !isUnderBriefcaseFolder(f) && !isUnderODKFolder(f),
+        "Exclude Briefcase & ODK directories"
+    );
+  }
+
+  private FileChooser getPemFileChooser() {
+    return file(
+        this,
+        fileFrom(pemPrivateKeyFilePath)
+    );
   }
 
   private List<String> getErrors() {

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -117,11 +117,12 @@ public class ExportPanel extends JPanel {
     txtExportDirectory.setText(PREFERENCES.get(EXPORT_DIR_PREF, ""));
 
     btnChooseExportDirectory = new JButton("Choose...");
-    btnChooseExportDirectory.addActionListener(__ -> getExportDirectoryChooser().choose().ifPresent(file -> {
-      txtExportDirectory.setText(file.getAbsolutePath());
-      updateExportButton();
-      PREFERENCES.put(EXPORT_DIR_PREF, file.getAbsolutePath());
-    }));
+    btnChooseExportDirectory.addActionListener(__ -> getExportDirectoryChooser().choose()
+        .ifPresent(file -> {
+          txtExportDirectory.setText(file.getAbsolutePath());
+          updateExportButton();
+          PREFERENCES.put(EXPORT_DIR_PREF, file.getAbsolutePath());
+        }));
 
     JLabel lblPemPrivateKey = new JLabel("PEM Private Key File:");
 
@@ -145,12 +146,18 @@ public class ExportPanel extends JPanel {
     pickStartDate.setDate(PREFERENCES.get(EXPORT_START_DATE_PREF, LocalDate::parse, null));
     pickStartDate.addDateChangeListener(__ -> updateExportButton());
     pickStartDate.addDateChangeListener(__ -> validateDate(pickStartDate));
-    pickStartDate.addDateChangeListener(event -> PREFERENCES.put(EXPORT_START_DATE_PREF, Optional.ofNullable(event.getNewDate()).map(ld -> ld.format(ISO_DATE)).orElse(null)));
+    pickStartDate.addDateChangeListener(event -> PREFERENCES.put(
+        EXPORT_START_DATE_PREF,
+        Optional.ofNullable(event.getNewDate()).map(ld -> ld.format(ISO_DATE)).orElse(null)
+    ));
     pickEndDate = createDatePicker();
     pickEndDate.setDate(PREFERENCES.get(EXPORT_END_DATE_PREF, LocalDate::parse, null));
     pickEndDate.addDateChangeListener(__ -> updateExportButton());
     pickEndDate.addDateChangeListener(__ -> validateDate(pickEndDate));
-    pickEndDate.addDateChangeListener(event -> PREFERENCES.put(EXPORT_END_DATE_PREF, Optional.ofNullable(event.getNewDate()).map(ld -> ld.format(ISO_DATE)).orElse(null)));
+    pickEndDate.addDateChangeListener(event -> PREFERENCES.put(
+        EXPORT_END_DATE_PREF,
+        Optional.ofNullable(event.getNewDate()).map(ld -> ld.format(ISO_DATE)).orElse(null))
+    );
 
     tableModel = new FormExportTableModel();
     tableModel.onSelectionChange(this::updateExportButton);
@@ -201,8 +208,14 @@ public class ExportPanel extends JPanel {
         .addComponent(lblDateTo);
 
     GroupLayout.ParallelGroup fields = groupLayout.createParallelGroup(LEADING)
-        .addGroup(groupLayout.createSequentialGroup().addComponent(txtExportDirectory).addPreferredGap(RELATED).addComponent(btnChooseExportDirectory))
-        .addGroup(groupLayout.createSequentialGroup().addComponent(pemPrivateKeyFilePath).addPreferredGap(RELATED).addComponent(btnPemFileChooseButton))
+        .addGroup(groupLayout.createSequentialGroup()
+            .addComponent(txtExportDirectory)
+            .addPreferredGap(RELATED)
+            .addComponent(btnChooseExportDirectory))
+        .addGroup(groupLayout.createSequentialGroup()
+            .addComponent(pemPrivateKeyFilePath)
+            .addPreferredGap(RELATED)
+            .addComponent(btnPemFileChooseButton))
         .addComponent(pickStartDate)
         .addComponent(pickEndDate);
 
@@ -240,11 +253,18 @@ public class ExportPanel extends JPanel {
                 .addComponent(txtExportDirectory, DEFAULT_SIZE, PREFERRED_SIZE, PREFERRED_SIZE)
             )
             .addPreferredGap(RELATED)
-            .addGroup(groupLayout.createParallelGroup(BASELINE).addComponent(lblPemPrivateKey).addComponent(pemPrivateKeyFilePath, DEFAULT_SIZE, PREFERRED_SIZE, PREFERRED_SIZE).addComponent(btnPemFileChooseButton)).addPreferredGap(RELATED)
+            .addGroup(groupLayout.createParallelGroup(BASELINE)
+                .addComponent(lblPemPrivateKey)
+                .addComponent(pemPrivateKeyFilePath, DEFAULT_SIZE, PREFERRED_SIZE, PREFERRED_SIZE)
+                .addComponent(btnPemFileChooseButton)).addPreferredGap(RELATED)
             .addPreferredGap(RELATED)
-            .addGroup(groupLayout.createParallelGroup(BASELINE).addComponent(lblDateFrom).addComponent(pickStartDate))
+            .addGroup(groupLayout.createParallelGroup(BASELINE)
+                .addComponent(lblDateFrom)
+                .addComponent(pickStartDate))
             .addPreferredGap(RELATED)
-            .addGroup(groupLayout.createParallelGroup(BASELINE).addComponent(lblDateTo).addComponent(pickEndDate))
+            .addGroup(groupLayout.createParallelGroup(BASELINE)
+                .addComponent(lblDateTo)
+                .addComponent(pickEndDate))
             .addPreferredGap(ComponentPlacement.UNRELATED, 10, MAX_VALUE)
             .addComponent(separatorFormsList, PREFERRED_SIZE, PREFERRED_SIZE, PREFERRED_SIZE)
             .addPreferredGap(ComponentPlacement.RELATED)
@@ -360,7 +380,11 @@ public class ExportPanel extends JPanel {
 
   private void showErrors(List<String> errors, String headerText, String title) {
     if (!errors.isEmpty()) {
-      String message = String.format("%s\n\n%s", headerText, errors.stream().map(e -> "- " + e).collect(joining("\n")));
+      String message = String.format(
+          "%s\n\n%s",
+          headerText,
+          errors.stream().map(e -> "- " + e).collect(joining("\n"))
+      );
       showErrorDialog(this, message, title);
     }
   }
@@ -431,7 +455,9 @@ public class ExportPanel extends JPanel {
 
   private List<String> export(BriefcaseFormDefinition formDefinition) {
     List<String> errors = new ArrayList<>();
-    Optional<File> pemFile = Optional.ofNullable(pemPrivateKeyFilePath.getText()).map(File::new).filter(File::exists);
+    Optional<File> pemFile = Optional.ofNullable(pemPrivateKeyFilePath.getText())
+        .map(File::new)
+        .filter(File::exists);
     if ((formDefinition.isFileEncryptedForm() || formDefinition.isFieldEncryptedForm()) && !pemFile.isPresent())
       errors.add(formDefinition.getFormName() + " form requires is encrypted and you haven't defined a valid private key file location");
     else

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -355,14 +355,6 @@ public class ExportPanel extends JPanel {
         .collect(toList()));
   }
 
-  private void chooseLocation(FileChooser fileChooser, JTextField locationField, String preferenceKey) {
-    fileChooser.choose().ifPresent(file -> {
-      locationField.setText(file.getAbsolutePath());
-      updateExportButton();
-      PREFERENCES.put(preferenceKey, file.getAbsolutePath());
-    });
-  }
-
   private Optional<File> fileFrom(JTextField textField) {
     return Optional.ofNullable(textField.getText())
         .filter(StringUtils::nullOrEmpty)

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -60,6 +60,7 @@ import javax.swing.LayoutStyle.ComponentPlacement;
 import org.bushe.swing.event.annotation.AnnotationProcessor;
 import org.bushe.swing.event.annotation.EventSubscriber;
 import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
+import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.ExportType;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.TerminationFuture;
@@ -71,6 +72,7 @@ import org.opendatakit.briefcase.util.StringUtils;
 public class ExportPanel extends JPanel {
 
   private static final long serialVersionUID = 7169316129011796197L;
+  private static final BriefcasePreferences PREFERENCES = BriefcasePreferences.forClass(ExportPanel.class);
 
   public static final String TAB_NAME = "Export";
 
@@ -106,6 +108,7 @@ public class ExportPanel extends JPanel {
     txtExportDirectory.setFocusable(false);
     txtExportDirectory.setEditable(false);
     txtExportDirectory.setColumns(10);
+    txtExportDirectory.setText(PREFERENCES.get("export_dir", ""));
 
     btnChooseExportDirectory = new JButton("Choose...");
     btnChooseExportDirectory.addActionListener(__ -> chooseLocation(directory(
@@ -113,7 +116,7 @@ public class ExportPanel extends JPanel {
         fileFrom(txtExportDirectory),
         f -> f.exists() && f.isDirectory() && !isUnderBriefcaseFolder(f) && !isUnderODKFolder(f),
         "Exclude Briefcase & ODK directories"
-    ), txtExportDirectory));
+    ), txtExportDirectory, "export_dir"));
 
     JLabel lblPemPrivateKey = new JLabel("PEM Private Key File:");
 
@@ -121,12 +124,13 @@ public class ExportPanel extends JPanel {
     pemPrivateKeyFilePath.setFocusable(false);
     pemPrivateKeyFilePath.setEditable(false);
     pemPrivateKeyFilePath.setColumns(10);
+    pemPrivateKeyFilePath.setText(PREFERENCES.get("pem_file", ""));
 
     btnPemFileChooseButton = new JButton("Choose...");
     btnPemFileChooseButton.addActionListener(__ -> chooseLocation(file(
         this,
         fileFrom(pemPrivateKeyFilePath)
-    ), pemPrivateKeyFilePath));
+    ), pemPrivateKeyFilePath, "pem_file"));
 
     JLabel lblDateFrom = new JLabel("Start Date (inclusive):");
     JLabel lblDateTo = new JLabel("End Date (exclusive):");
@@ -305,10 +309,11 @@ public class ExportPanel extends JPanel {
         .collect(toList()));
   }
 
-  private void chooseLocation(FileChooser fileChooser, JTextField locationField) {
+  private void chooseLocation(FileChooser fileChooser, JTextField locationField, String preferenceKey) {
     fileChooser.choose().ifPresent(file -> {
       locationField.setText(file.getAbsolutePath());
       updateExportButton();
+      PREFERENCES.put(preferenceKey, file.getAbsolutePath());
     });
   }
 


### PR DESCRIPTION
Partially addresses issue #258

In this PR we set a very basic use of persisted preferences to remember the export configuration between Briefcase launches.

The affected fields are the export dir and the pem file location.

#### What has been done to verify that this works as intended?
Manually tested on my machine.

#### Why is this the best possible solution? Were any other approaches considered?
I've just mirrored what's done in other tabs

#### Are there any risks to merging this code? If so, what are they?
None regarding the app's stability but the lateral effect of this change is that, after setting a pem file location, you can never clear that field. This is due to currently not having a mechanism for clearing these kind of filesystem location fields in Briefcase. Other fields like the date ranges have a button to clear them.
