### PR TITLE
Issue 258 save preferences

### DIFF
--- a/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
+++ b/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
@@ -16,6 +16,8 @@
 
 package org.opendatakit.briefcase.model;
 import java.security.Security;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.prefs.Preferences;
 
@@ -48,7 +50,11 @@ public class BriefcasePreferences {
 
     private final Preferences preferences;
 
-    private BriefcasePreferences(Class<?> node, PreferenceScope scope) {
+  public BriefcasePreferences(Preferences preferences) {
+    this.preferences = preferences;
+  }
+
+  private BriefcasePreferences(Class<?> node, PreferenceScope scope) {
         this.preferences = scope.preferenceFactory(node);
     }
 
@@ -78,16 +84,45 @@ public class BriefcasePreferences {
     }
 
     /**
+     * Returns an Optional instance with the value associated with the specified key
+     * in this preference node or an Optional.empty() if no value is associated with key,
+     * or the backing store is inaccessible.
+     *
+     * @param key
+     *          key whose associated value is to be returned.
+     * @return an Optional instance with the value associated with key, or Optional.empty()
+     *         if no value is associated with key, or the backing store is inaccessible.
+     */
+    public Optional<String> nullSafeGet(String key) {
+        return Optional.ofNullable(get(key, null));
+    }
+
+    /**
      * Associates the specified value with the specified key in this preference
      * node.
+     *
+     * If the value is null, then the key is removed
      *
      * @param key
      *          key with which the specified value is to be associated.
      * @param value
-     *          value to be associated with the specified key.
+     *          value to be associated with the specified key or null.
      */
     public void put(String key, String value) {
-        preferences.put(key, value);
+        if (value != null)
+            preferences.put(key, value);
+        else
+            remove(key);
+    }
+
+    /**
+     * Associates the specified key/value map in this preference node.
+     *
+     * @param keyValues
+     *          map of keys and values to ve associated.
+     */
+    public void putAll(Map<String,String> keyValues) {
+        keyValues.forEach(this::put);
     }
 
     /**

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -232,7 +232,7 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
         addPane(PushTransferPanel.TAB_NAME, uploadPanel);
 
         exportPanel = new ExportPanel(exportTerminationFuture, BriefcasePreferences.forClass(ExportConfiguration.class));
-        addPane(ExportPanel.TAB_NAME, exportPanel.getForm());
+        addPane(ExportPanel.TAB_NAME, exportPanel.getForm().getContainer());
 
         settingsPanel = new SettingsPanel(this);
         addPane(SettingsPanel.TAB_NAME, settingsPanel);

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -48,7 +48,6 @@ import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.ExportAbortEvent;
 import org.opendatakit.briefcase.model.TerminationFuture;
 import org.opendatakit.briefcase.model.TransferAbortEvent;
-import org.opendatakit.briefcase.ui.export.ExportConfiguration;
 import org.opendatakit.briefcase.ui.export.ExportPanel;
 import org.opendatakit.briefcase.util.FileSystemUtils;
 

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -231,7 +231,7 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
         uploadPanel = new PushTransferPanel(transferTerminationFuture);
         addPane(PushTransferPanel.TAB_NAME, uploadPanel);
 
-        exportPanel = new ExportPanel(exportTerminationFuture, BriefcasePreferences.forClass(ExportConfiguration.class));
+        exportPanel = new ExportPanel(exportTerminationFuture, BriefcasePreferences.forClass(ExportPanel.class));
         addPane(ExportPanel.TAB_NAME, exportPanel.getForm().getContainer());
 
         settingsPanel = new SettingsPanel(this);

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -48,6 +48,7 @@ import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.ExportAbortEvent;
 import org.opendatakit.briefcase.model.TerminationFuture;
 import org.opendatakit.briefcase.model.TransferAbortEvent;
+import org.opendatakit.briefcase.ui.export.ExportConfiguration;
 import org.opendatakit.briefcase.ui.export.ExportPanel;
 import org.opendatakit.briefcase.util.FileSystemUtils;
 
@@ -230,7 +231,7 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
         uploadPanel = new PushTransferPanel(transferTerminationFuture);
         addPane(PushTransferPanel.TAB_NAME, uploadPanel);
 
-        exportPanel = new ExportPanel(exportTerminationFuture);
+        exportPanel = new ExportPanel(exportTerminationFuture, BriefcasePreferences.forClass(ExportConfiguration.class));
         addPane(ExportPanel.TAB_NAME, exportPanel.getForm());
 
         settingsPanel = new SettingsPanel(this);

--- a/src/org/opendatakit/briefcase/ui/export/ExportConfiguration.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportConfiguration.java
@@ -9,13 +9,18 @@ import static org.opendatakit.briefcase.util.FileSystemUtils.isUnderODKFolder;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import org.opendatakit.briefcase.model.BriefcasePreferences;
 
 public class ExportConfiguration {
   private Optional<Path> exportDir;
@@ -32,6 +37,26 @@ public class ExportConfiguration {
 
   public static ExportConfiguration empty() {
     return new ExportConfiguration(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  public static ExportConfiguration load(BriefcasePreferences prefs) {
+    return new ExportConfiguration(
+        prefs.nullSafeGet("exportDir").map(Paths::get),
+        prefs.nullSafeGet("pemFile").map(Paths::get),
+        prefs.nullSafeGet("startDate").map(LocalDate::parse),
+        prefs.nullSafeGet("endDate").map(LocalDate::parse)
+    );
+  }
+
+  public Map<String, String> asMap() {
+    // This should be a stream of tuples that's reduces into a
+    // map but we'll have to wait for that
+    HashMap<String, String> map = new HashMap<>();
+    exportDir.ifPresent(value -> map.put("exportDir", value.toString()));
+    pemFile.ifPresent(value -> map.put("pemFile", value.toString()));
+    startDate.ifPresent(value -> map.put("startDate", value.format(DateTimeFormatter.BASIC_ISO_DATE)));
+    endDate.ifPresent(value -> map.put("endDate", value.format(DateTimeFormatter.BASIC_ISO_DATE)));
+    return map;
   }
 
   public static ExportConfiguration copy(ExportConfiguration other) {

--- a/src/org/opendatakit/briefcase/ui/export/ExportConfiguration.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportConfiguration.java
@@ -23,6 +23,10 @@ import java.util.function.Function;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
 
 public class ExportConfiguration {
+  private static final String EXPORT_DIR = "exportDir";
+  private static final String PEM_FILE = "pemFile";
+  private static final String START_DATE = "startDate";
+  private static final String END_DATE = "endDate";
   private Optional<Path> exportDir;
   private Optional<Path> pemFile;
   private Optional<LocalDate> startDate;
@@ -41,21 +45,34 @@ public class ExportConfiguration {
 
   public static ExportConfiguration load(BriefcasePreferences prefs) {
     return new ExportConfiguration(
-        prefs.nullSafeGet("exportDir").map(Paths::get),
-        prefs.nullSafeGet("pemFile").map(Paths::get),
-        prefs.nullSafeGet("startDate").map(LocalDate::parse),
-        prefs.nullSafeGet("endDate").map(LocalDate::parse)
+        prefs.nullSafeGet(EXPORT_DIR).map(Paths::get),
+        prefs.nullSafeGet(PEM_FILE).map(Paths::get),
+        prefs.nullSafeGet(START_DATE).map(LocalDate::parse),
+        prefs.nullSafeGet(END_DATE).map(LocalDate::parse)
+    );
+  }
+
+  public static ExportConfiguration load(BriefcasePreferences prefs, String keyPrefix) {
+    return new ExportConfiguration(
+        prefs.nullSafeGet(keyPrefix + EXPORT_DIR).map(Paths::get),
+        prefs.nullSafeGet(keyPrefix + PEM_FILE).map(Paths::get),
+        prefs.nullSafeGet(keyPrefix + START_DATE).map(LocalDate::parse),
+        prefs.nullSafeGet(keyPrefix + END_DATE).map(LocalDate::parse)
     );
   }
 
   public Map<String, String> asMap() {
+    return asMap("");
+  }
+
+  public Map<String, String> asMap(String keyPrefix) {
     // This should be a stream of tuples that's reduces into a
     // map but we'll have to wait for that
     HashMap<String, String> map = new HashMap<>();
-    exportDir.ifPresent(value -> map.put("exportDir", value.toString()));
-    pemFile.ifPresent(value -> map.put("pemFile", value.toString()));
-    startDate.ifPresent(value -> map.put("startDate", value.format(DateTimeFormatter.BASIC_ISO_DATE)));
-    endDate.ifPresent(value -> map.put("endDate", value.format(DateTimeFormatter.BASIC_ISO_DATE)));
+    exportDir.ifPresent(value -> map.put(keyPrefix + EXPORT_DIR, value.toString()));
+    pemFile.ifPresent(value -> map.put(keyPrefix + PEM_FILE, value.toString()));
+    startDate.ifPresent(value -> map.put(keyPrefix + START_DATE, value.format(DateTimeFormatter.ISO_DATE)));
+    endDate.ifPresent(value -> map.put(keyPrefix + END_DATE, value.format(DateTimeFormatter.ISO_DATE)));
     return map;
   }
 

--- a/src/org/opendatakit/briefcase/ui/export/ExportForms.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportForms.java
@@ -26,11 +26,10 @@ public class ExportForms {
     // This should be a simple Map filtering block but we'll have to wait for Vavr.io
 
     Map<FormStatus, ExportConfiguration> configurations = new HashMap<>();
-    forms.forEach(form -> {
-      ExportConfiguration configuration = ExportConfiguration.load(preferences, "custom_" + form.getFormName() + "_");
-      if (!configuration.isEmpty() && configuration.isValid())
-        configurations.put(form, configuration);
-    });
+    forms.forEach(form -> configurations.put(
+        form,
+        ExportConfiguration.load(preferences, "custom_" + form.getFormName() + "_")
+    ));
     return new ExportForms(
         forms,
         configurations

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -22,7 +22,6 @@ import static org.opendatakit.briefcase.model.FormStatus.TransferType.EXPORT;
 import static org.opendatakit.briefcase.ui.ODKOptionPane.showErrorDialog;
 
 import java.util.List;
-import javax.swing.JPanel;
 import org.bushe.swing.event.annotation.AnnotationProcessor;
 import org.bushe.swing.event.annotation.EventSubscriber;
 import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
@@ -76,7 +75,7 @@ public class ExportPanel {
             "%s\n\n%s", "We have found some errors while performing the requested export actions:",
             errors.stream().map(e -> "- " + e).collect(joining("\n"))
         );
-        showErrorDialog(form, message, "Export error report");
+        showErrorDialog(form.getContainer(), message, "Export error report");
       }
     }).start());
 
@@ -90,8 +89,8 @@ public class ExportPanel {
     form.refresh();
   }
 
-  public JPanel getForm() {
-    return form.container;
+  public ExportPanelForm getForm() {
+    return form;
   }
 
   private List<String> export(ExportConfiguration defaultConfiguration) {

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -26,6 +26,7 @@ import javax.swing.JPanel;
 import org.bushe.swing.event.annotation.AnnotationProcessor;
 import org.bushe.swing.event.annotation.EventSubscriber;
 import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
+import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.FormStatusEvent;
 import org.opendatakit.briefcase.model.TerminationFuture;
@@ -40,18 +41,21 @@ public class ExportPanel {
   private final ExportForms forms;
   final ExportPanelForm form;
 
-  public ExportPanel(TerminationFuture terminationFuture) {
+  public ExportPanel(TerminationFuture terminationFuture, BriefcasePreferences preferences) {
     AnnotationProcessor.process(this);// if not using AOP
 
     this.terminationFuture = terminationFuture;
 
     forms = new ExportForms();
 
-    ConfigurationPanel confPanel = ConfigurationPanel.from(ExportConfiguration.empty());
+    ConfigurationPanel confPanel = ConfigurationPanel.from(ExportConfiguration.load(preferences));
 
     form = ExportPanelForm.from(forms, confPanel);
 
     form.onChange(() -> {
+      if (confPanel.isValid())
+        preferences.putAll(confPanel.getConfiguration().asMap());
+
       if (forms.someSelected() && (confPanel.isValid() || forms.allSelectedFormsHaveConfiguration()))
         form.enableExport();
       else

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanelForm.form
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanelForm.form
@@ -76,6 +76,7 @@
               <component id="74e1" class="javax.swing.JButton" binding="exportButton">
                 <constraints/>
                 <properties>
+                  <enabled value="false"/>
                   <name value="export"/>
                   <text value="Export"/>
                 </properties>

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanelForm.java
@@ -16,12 +16,12 @@ import org.opendatakit.briefcase.ui.export.components.FormsTable;
 import org.opendatakit.briefcase.ui.export.components.FormsTableView;
 
 @SuppressWarnings("checkstyle:MethodName")
-public class ExportPanelForm extends JComponent {
-  final ConfigurationPanel confPanel;
+public class ExportPanelForm {
+  private final ConfigurationPanel confPanel;
   private final FormsTable formsTable;
-  JPanel container;
-  private ConfigurationPanelForm confPanelForm;
-  private FormsTableView formsTableForm;
+  private final ConfigurationPanelForm confPanelForm;
+  private final FormsTableView formsTableForm;
+  private JPanel container;
   private JLabel formsTableLabel;
   private JSeparator formsTableSeparator;
   private JPanel actions;
@@ -52,6 +52,14 @@ public class ExportPanelForm extends JComponent {
     );
   }
 
+  public JPanel getContainer() {
+    return container;
+  }
+
+  public ConfigurationPanel getConfPanel() {
+    return confPanel;
+  }
+
   void onExport(Runnable callback) {
     exportButton.addActionListener(__ -> callback.run());
   }
@@ -79,7 +87,6 @@ public class ExportPanelForm extends JComponent {
     clearAllButton.setVisible(false);
   }
 
-  @Override
   public void setEnabled(boolean enabled) {
     if (enabled) {
       enableUI();

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanelForm.java
@@ -191,6 +191,7 @@ public class ExportPanelForm {
     gbc.fill = GridBagConstraints.BOTH;
     actions.add(rightActions, gbc);
     exportButton = new JButton();
+    exportButton.setEnabled(false);
     exportButton.setName("export");
     exportButton.setText("Export");
     rightActions.add(exportButton);

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanel.java
@@ -7,7 +7,7 @@ import org.opendatakit.briefcase.ui.export.ExportConfiguration;
 public class ConfigurationPanel {
   private final ExportConfiguration configuration;
   private final List<Runnable> onChangeCallbacks = new ArrayList<>();
-  public final ConfigurationPanelForm form;
+  private final ConfigurationPanelForm form;
 
   ConfigurationPanel(ExportConfiguration initialConfiguration, ConfigurationPanelForm form) {
     this.form = form;

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.form
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.form
@@ -52,6 +52,7 @@
         </constraints>
         <properties>
           <editable value="false"/>
+          <name value="exportDir"/>
         </properties>
       </component>
       <component id="d6296" class="javax.swing.JTextField" binding="pemFileField">

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
@@ -30,17 +30,17 @@ import org.opendatakit.briefcase.util.StringUtils;
 
 @SuppressWarnings("checkstyle:MethodName")
 public class ConfigurationPanelForm extends JComponent {
+  protected final DatePicker startDateField;
+  protected final DatePicker endDateField;
   protected JTextField exportDirField;
   protected JTextField pemFileField;
-  protected DatePicker startDateField;
-  protected DatePicker endDateField;
   private JButton exportDirButton;
   private JButton pemFileButton;
   private JLabel exportDirLabel;
   private JLabel pemFileLabel;
   private JLabel startDateLabel;
   private JLabel endDateLabel;
-  public JPanel container;
+  private JPanel container;
   private final List<Consumer<Path>> onSelectExportDirCallbacks = new ArrayList<>();
   private final List<Consumer<Path>> onSelectPemFileCallbacks = new ArrayList<>();
   private final List<Consumer<LocalDate>> onSelectStartDateCallbacks = new ArrayList<>();
@@ -222,6 +222,7 @@ public class ConfigurationPanelForm extends JComponent {
     container.add(endDateLabel, gbc);
     exportDirField = new JTextField();
     exportDirField.setEditable(false);
+    exportDirField.setName("exportDir");
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
     gbc.gridy = 0;

--- a/test/java/org/opendatakit/briefcase/model/InMemoryPreferences.java
+++ b/test/java/org/opendatakit/briefcase/model/InMemoryPreferences.java
@@ -1,0 +1,197 @@
+package org.opendatakit.briefcase.model;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.NodeChangeListener;
+import java.util.prefs.PreferenceChangeListener;
+import java.util.prefs.Preferences;
+
+public class InMemoryPreferences extends Preferences {
+  private final Map<String, String> storage;
+
+  public InMemoryPreferences(Map<String, String> storage) {
+    this.storage = storage;
+  }
+
+  public static Preferences empty() {
+    return new InMemoryPreferences(new ConcurrentHashMap<>());
+  }
+
+  @Override
+  public void put(String key, String value) {
+    storage.put(key, value);
+  }
+
+  private Optional<String> nullSafeGet(String key) {
+    return Optional.ofNullable(storage.get(key));
+  }
+
+  @Override
+  public String get(String key, String def) {
+    return nullSafeGet(key).orElse(def);
+  }
+
+  @Override
+  public void remove(String key) {
+    storage.remove(key);
+  }
+
+  @Override
+  public void clear() throws BackingStoreException {
+    storage.clear();
+  }
+
+  @Override
+  public void putInt(String key, int value) {
+    storage.put(key, Integer.valueOf(value).toString());
+  }
+
+  @Override
+  public int getInt(String key, int def) {
+    return nullSafeGet(key).map(Integer::parseInt).orElse(def);
+  }
+
+  @Override
+  public long getLong(String key, long def) {
+    return nullSafeGet(key).map(Long::parseLong).orElse(def);
+  }
+
+  @Override
+  public boolean getBoolean(String key, boolean def) {
+    return nullSafeGet(key).map(Boolean::parseBoolean).orElse(def);
+  }
+
+  @Override
+  public float getFloat(String key, float def) {
+    return nullSafeGet(key).map(Float::parseFloat).orElse(def);
+  }
+
+  @Override
+  public double getDouble(String key, double def) {
+    return nullSafeGet(key).map(Double::parseDouble).orElse(def);
+  }
+
+  @Override
+  public byte[] getByteArray(String key, byte[] def) {
+    return nullSafeGet(key).map(String::getBytes).orElse(def);
+  }
+
+  @Override
+  public void putLong(String key, long value) {
+    storage.put(key, Long.valueOf(value).toString());
+  }
+
+  @Override
+  public void putBoolean(String key, boolean value) {
+    storage.put(key, Boolean.valueOf(value).toString());
+  }
+
+  @Override
+  public void putFloat(String key, float value) {
+    storage.put(key, Float.valueOf(value).toString());
+  }
+
+  @Override
+  public void putDouble(String key, double value) {
+    storage.put(key, Double.valueOf(value).toString());
+  }
+
+  @Override
+  public void putByteArray(String key, byte[] value) {
+    storage.put(key, new String(value));
+  }
+
+  @Override
+  public String[] keys() throws BackingStoreException {
+    return storage.keySet().toArray(new String[storage.size()]);
+  }
+
+  @Override
+  public String[] childrenNames() throws BackingStoreException {
+    return storage.keySet().toArray(new String[storage.size()]);
+  }
+
+  @Override
+  public Preferences parent() {
+    return null;
+  }
+
+  @Override
+  public Preferences node(String pathName) {
+    return null;
+  }
+
+  @Override
+  public boolean nodeExists(String pathName) throws BackingStoreException {
+    return false;
+  }
+
+  @Override
+  public void removeNode() throws BackingStoreException {
+
+  }
+
+  @Override
+  public String name() {
+    return null;
+  }
+
+  @Override
+  public String absolutePath() {
+    return null;
+  }
+
+  @Override
+  public boolean isUserNode() {
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return null;
+  }
+
+  @Override
+  public void flush() throws BackingStoreException {
+
+  }
+
+  @Override
+  public void sync() throws BackingStoreException {
+
+  }
+
+  @Override
+  public void addPreferenceChangeListener(PreferenceChangeListener pcl) {
+
+  }
+
+  @Override
+  public void removePreferenceChangeListener(PreferenceChangeListener pcl) {
+
+  }
+
+  @Override
+  public void addNodeChangeListener(NodeChangeListener ncl) {
+
+  }
+
+  @Override
+  public void removeNodeChangeListener(NodeChangeListener ncl) {
+
+  }
+
+  @Override
+  public void exportNode(OutputStream os) throws IOException, BackingStoreException {
+
+  }
+
+  @Override
+  public void exportSubtree(OutputStream os) throws IOException, BackingStoreException {
+
+  }
+}

--- a/test/java/org/opendatakit/briefcase/ui/export/ExportPanelPageObject.java
+++ b/test/java/org/opendatakit/briefcase/ui/export/ExportPanelPageObject.java
@@ -10,6 +10,8 @@ import org.assertj.swing.data.TableCell;
 import org.assertj.swing.edt.GuiActionRunner;
 import org.assertj.swing.fixture.FrameFixture;
 import org.assertj.swing.fixture.JButtonFixture;
+import org.opendatakit.briefcase.model.BriefcasePreferences;
+import org.opendatakit.briefcase.model.InMemoryPreferences;
 import org.opendatakit.briefcase.model.TerminationFuture;
 
 class ExportPanelPageObject {
@@ -22,7 +24,7 @@ class ExportPanelPageObject {
   }
 
   static ExportPanelPageObject setUp(Robot robot) {
-    ExportPanel exportPanel = GuiActionRunner.execute(() -> new ExportPanel(new TerminationFuture()));
+    ExportPanel exportPanel = GuiActionRunner.execute(() -> new ExportPanel(new TerminationFuture(), new BriefcasePreferences(InMemoryPreferences.empty())));
     JFrame testFrame = GuiActionRunner.execute(() -> {
       JFrame f = new JFrame();
       f.add(exportPanel.getForm());

--- a/test/java/org/opendatakit/briefcase/ui/export/ExportPanelPageObject.java
+++ b/test/java/org/opendatakit/briefcase/ui/export/ExportPanelPageObject.java
@@ -16,7 +16,7 @@ import org.opendatakit.briefcase.model.TerminationFuture;
 
 class ExportPanelPageObject {
   private final ExportPanel exportPanel;
-  private FrameFixture window;
+  private final FrameFixture window;
 
   private ExportPanelPageObject(ExportPanel exportPanel, FrameFixture window) {
     this.exportPanel = exportPanel;

--- a/test/java/org/opendatakit/briefcase/ui/export/ExportPanelPageObject.java
+++ b/test/java/org/opendatakit/briefcase/ui/export/ExportPanelPageObject.java
@@ -27,7 +27,7 @@ class ExportPanelPageObject {
     ExportPanel exportPanel = GuiActionRunner.execute(() -> new ExportPanel(new TerminationFuture(), new BriefcasePreferences(InMemoryPreferences.empty())));
     JFrame testFrame = GuiActionRunner.execute(() -> {
       JFrame f = new JFrame();
-      f.add(exportPanel.getForm());
+      f.add(exportPanel.getForm().getContainer());
       return f;
     });
     FrameFixture window = new FrameFixture(robot, testFrame);
@@ -39,7 +39,7 @@ class ExportPanelPageObject {
   }
 
   void setExportDirectory(String value) {
-    GuiActionRunner.execute(() -> exportPanel.form.confPanel.form.setExportDir(Paths.get(value)));
+    GuiActionRunner.execute(() -> exportPanel.getForm().getConfPanel().getForm().setExportDir(Paths.get(value)));
   }
 
   void selectFormATRow(int row) {

--- a/test/java/org/opendatakit/briefcase/ui/export/components/FormsTableTest.java
+++ b/test/java/org/opendatakit/briefcase/ui/export/components/FormsTableTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import org.bushe.swing.event.EventBus;
@@ -27,7 +28,7 @@ import org.opendatakit.briefcase.util.BadFormDefinition;
 public class FormsTableTest {
   @Test
   public void can_select_all_forms() {
-    ExportForms forms = new ExportForms(IntStream.range(0, 10).boxed().map(this::uncheckedFormStatusFactory).collect(toList()));
+    ExportForms forms = new ExportForms(IntStream.range(0, 10).boxed().map(this::uncheckedFormStatusFactory).collect(toList()), new HashMap<>());
     TestFormsTableViewModel viewModel = new TestFormsTableViewModel(forms);
     FormsTable formsTable = new FormsTable(forms, new TestFormsTableView(viewModel), viewModel);
 
@@ -40,7 +41,7 @@ public class FormsTableTest {
 
   @Test
   public void can_clear_selection_of_forms() {
-    ExportForms forms = new ExportForms(IntStream.range(0, 10).boxed().map(this::uncheckedFormStatusFactory).collect(toList()));
+    ExportForms forms = new ExportForms(IntStream.range(0, 10).boxed().map(this::uncheckedFormStatusFactory).collect(toList()), new HashMap<>());
     TestFormsTableViewModel viewModel = new TestFormsTableViewModel(forms);
     FormsTable formsTable = new FormsTable(forms, new TestFormsTableView(viewModel), viewModel);
     formsTable.selectAll();
@@ -54,7 +55,7 @@ public class FormsTableTest {
   @Ignore
   public void appends_to_a_forms_status_history_when_export_events_are_sent() {
     FormStatus theForm = uncheckedFormStatusFactory(1);
-    ExportForms forms = new ExportForms(Collections.singletonList(theForm));
+    ExportForms forms = new ExportForms(Collections.singletonList(theForm), new HashMap<>());
     TestFormsTableViewModel viewModel = new TestFormsTableViewModel(forms);
     new FormsTable(forms, new TestFormsTableView(viewModel), viewModel);
 


### PR DESCRIPTION
Partially addresses #258 

Changes on this PR solve loading and saving export configurations (default and per-form) into user preferences using `BriefcasePreferences` class.

#### What has been done to verify that this works as intended?
Manual tests

#### Why is this the best possible solution? Were any other approaches considered?
N/A

#### Are there any risks to merging this code? If so, what are they?
None I'm aware of.