### PR TITLE
Issue 258 last export date

### DIFF
--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -1,8 +1,10 @@
 package org.opendatakit.briefcase.operations;
 
+import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 import static org.opendatakit.briefcase.operations.Common.FORM_ID;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 import static org.opendatakit.briefcase.operations.Common.bootCache;
+import static org.opendatakit.briefcase.ui.export.ExportForms.buildExportDatePrefix;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -14,6 +16,7 @@ import java.security.PrivateKey;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -23,9 +26,11 @@ import org.apache.commons.logging.LogFactory;
 import org.bouncycastle.openssl.PEMReader;
 import org.bushe.swing.event.EventBus;
 import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
+import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.ExportFailedEvent;
 import org.opendatakit.briefcase.model.ExportProgressEvent;
 import org.opendatakit.briefcase.model.TerminationFuture;
+import org.opendatakit.briefcase.ui.export.ExportPanel;
 import org.opendatakit.briefcase.util.ExportToCsv;
 import org.opendatakit.briefcase.util.FileSystemUtils;
 import org.opendatakit.common.cli.Operation;
@@ -153,5 +158,6 @@ public class Export {
     LOGGER.info("exporting to : " + dir.getAbsolutePath());
     ExportToCsv exp = new ExportToCsv(dir, formDefinition, terminationFuture, fileName, exportMedia, overwrite, startDateString, endDateString);
     exp.doAction();
+    BriefcasePreferences.forClass(ExportPanel.class).put(buildExportDatePrefix(formDefinition), LocalDateTime.now().format(ISO_DATE_TIME));
   }
 }

--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -4,7 +4,7 @@ import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 import static org.opendatakit.briefcase.operations.Common.FORM_ID;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 import static org.opendatakit.briefcase.operations.Common.bootCache;
-import static org.opendatakit.briefcase.ui.export.ExportForms.buildExportDatePrefix;
+import static org.opendatakit.briefcase.ui.export.ExportForms.buildExportDateTimePrefix;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -158,6 +158,6 @@ public class Export {
     LOGGER.info("exporting to : " + dir.getAbsolutePath());
     ExportToCsv exp = new ExportToCsv(dir, formDefinition, terminationFuture, fileName, exportMedia, overwrite, startDateString, endDateString);
     exp.doAction();
-    BriefcasePreferences.forClass(ExportPanel.class).put(buildExportDatePrefix(formDefinition), LocalDateTime.now().format(ISO_DATE_TIME));
+    BriefcasePreferences.forClass(ExportPanel.class).put(buildExportDateTimePrefix(formDefinition), LocalDateTime.now().format(ISO_DATE_TIME));
   }
 }

--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -158,6 +158,6 @@ public class Export {
     LOGGER.info("exporting to : " + dir.getAbsolutePath());
     ExportToCsv exp = new ExportToCsv(dir, formDefinition, terminationFuture, fileName, exportMedia, overwrite, startDateString, endDateString);
     exp.doAction();
-    BriefcasePreferences.forClass(ExportPanel.class).put(buildExportDateTimePrefix(formDefinition), LocalDateTime.now().format(ISO_DATE_TIME));
+    BriefcasePreferences.forClass(ExportPanel.class).put(buildExportDateTimePrefix(formDefinition.getFormId()), LocalDateTime.now().format(ISO_DATE_TIME));
   }
 }

--- a/src/org/opendatakit/briefcase/ui/export/ExportForms.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportForms.java
@@ -13,6 +13,7 @@ import java.util.function.BiConsumer;
 import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
+import org.opendatakit.briefcase.model.IFormDefinition;
 
 public class ExportForms {
   private static final String EXPORT_DATE_PREFIX = "export_date_";
@@ -48,7 +49,12 @@ public class ExportForms {
   }
 
   static String buildExportDatePrefix(FormStatus form) {
-    return EXPORT_DATE_PREFIX + form.getFormDefinition().getFormId();
+    IFormDefinition formDefinition = form.getFormDefinition();
+    return buildExportDatePrefix(formDefinition);
+  }
+
+  public static String buildExportDatePrefix(IFormDefinition formDefinition) {
+    return EXPORT_DATE_PREFIX + formDefinition.getFormId();
   }
 
   static String buildCustomConfPrefix(FormStatus form) {

--- a/src/org/opendatakit/briefcase/ui/export/ExportForms.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportForms.java
@@ -15,6 +15,8 @@ import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
 
 public class ExportForms {
+  private static final String EXPORT_DATE_PREFIX = "export_date_";
+  private static final String CUSTOM_CONF_PREFIX = "custom_";
   private final List<FormStatus> forms;
   private final Map<FormStatus, ExportConfiguration> configurations;
   private final Map<FormStatus, LocalDateTime> lastExportDates;
@@ -34,19 +36,23 @@ public class ExportForms {
     Map<FormStatus, ExportConfiguration> configurations = new HashMap<>();
     Map<FormStatus, LocalDateTime> exportDates = new HashMap<>();
     forms.forEach(form -> {
-      configurations.put(
-          form,
-          ExportConfiguration.load(preferences, "custom_" + form.getFormName() + "_")
-      );
-      Optional<LocalDateTime> exportDate = preferences.nullSafeGet("export_date_" + form.getFormDefinition().getFormId())
-          .map(LocalDateTime::parse);
-      exportDate.ifPresent(dateTime -> exportDates.put(form, dateTime));
+      configurations.put(form, ExportConfiguration.load(preferences, buildCustomConfPrefix(form)));
+      preferences.nullSafeGet(buildExportDatePrefix(form))
+          .map(LocalDateTime::parse).ifPresent(dateTime -> exportDates.put(form, dateTime));
     });
     return new ExportForms(
         forms,
         configurations,
         exportDates
     );
+  }
+
+  static String buildExportDatePrefix(FormStatus form) {
+    return EXPORT_DATE_PREFIX + form.getFormDefinition().getFormId();
+  }
+
+  static String buildCustomConfPrefix(FormStatus form) {
+    return CUSTOM_CONF_PREFIX + form.getFormName() + "_";
   }
 
   public void merge(List<FormStatus> forms) {

--- a/src/org/opendatakit/briefcase/ui/export/ExportForms.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportForms.java
@@ -74,7 +74,7 @@ public class ExportForms {
   }
 
   public boolean hasConfiguration(FormStatus form) {
-    return configurations.containsKey(getFormId(form));
+    return configurations.containsKey(getFormId(form)) && configurations.get(getFormId(form)).isValid();
   }
 
   public ExportConfiguration getConfiguration(FormStatus form) {

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -52,8 +52,8 @@ public class ExportPanel {
     ConfigurationPanel confPanel = ConfigurationPanel.from(ExportConfiguration.load(preferences));
 
     forms = ExportForms.load(getFormsFromStorage(), preferences);
-    forms.onSuccessfulExport((FormStatus form, LocalDateTime exportDateTime) ->
-        preferences.put(ExportForms.buildExportDateTimePrefix(form), exportDateTime.format(ISO_DATE_TIME))
+    forms.onSuccessfulExport((String formId, LocalDateTime exportDateTime) ->
+        preferences.put(ExportForms.buildExportDateTimePrefix(formId), exportDateTime.format(ISO_DATE_TIME))
     );
 
     form = ExportPanelForm.from(forms, confPanel);
@@ -62,8 +62,8 @@ public class ExportPanel {
       if (confPanel.isValid())
         preferences.putAll(confPanel.getConfiguration().asMap());
 
-      forms.getValidConfigurations().forEach((form, configuration) ->
-          preferences.putAll(configuration.asMap(buildCustomConfPrefix(form)))
+      forms.getValidConfigurations().forEach((formId, configuration) ->
+          preferences.putAll(configuration.asMap(buildCustomConfPrefix(formId)))
       );
 
       if (forms.someSelected() && (confPanel.isValid() || forms.allSelectedFormsHaveConfiguration()))

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -22,7 +22,6 @@ import static java.util.stream.Collectors.toList;
 import static org.opendatakit.briefcase.model.FormStatus.TransferType.EXPORT;
 import static org.opendatakit.briefcase.ui.ODKOptionPane.showErrorDialog;
 import static org.opendatakit.briefcase.ui.export.ExportForms.buildCustomConfPrefix;
-import static org.opendatakit.briefcase.ui.export.ExportForms.buildExportDateTimePrefix;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -16,11 +16,13 @@
 
 package org.opendatakit.briefcase.ui.export;
 
+import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static org.opendatakit.briefcase.model.FormStatus.TransferType.EXPORT;
 import static org.opendatakit.briefcase.ui.ODKOptionPane.showErrorDialog;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import org.bushe.swing.event.annotation.AnnotationProcessor;
 import org.bushe.swing.event.annotation.EventSubscriber;
@@ -48,6 +50,9 @@ public class ExportPanel {
     ConfigurationPanel confPanel = ConfigurationPanel.from(ExportConfiguration.load(preferences));
 
     forms = ExportForms.load(getFormsFromStorage(), preferences);
+    forms.onSuccessfulExport((FormStatus form, LocalDateTime exportDate) ->
+        preferences.put("export_date_" + form.getFormDefinition().getFormId(), exportDate.format(ISO_DATE_TIME))
+    );
 
     form = ExportPanelForm.from(forms, confPanel);
 

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -22,7 +22,7 @@ import static java.util.stream.Collectors.toList;
 import static org.opendatakit.briefcase.model.FormStatus.TransferType.EXPORT;
 import static org.opendatakit.briefcase.ui.ODKOptionPane.showErrorDialog;
 import static org.opendatakit.briefcase.ui.export.ExportForms.buildCustomConfPrefix;
-import static org.opendatakit.briefcase.ui.export.ExportForms.buildExportDatePrefix;
+import static org.opendatakit.briefcase.ui.export.ExportForms.buildExportDateTimePrefix;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -52,8 +52,8 @@ public class ExportPanel {
     ConfigurationPanel confPanel = ConfigurationPanel.from(ExportConfiguration.load(preferences));
 
     forms = ExportForms.load(getFormsFromStorage(), preferences);
-    forms.onSuccessfulExport((FormStatus form, LocalDateTime exportDate) ->
-        preferences.put(buildExportDatePrefix(form), exportDate.format(ISO_DATE_TIME))
+    forms.onSuccessfulExport((FormStatus form, LocalDateTime exportDateTime) ->
+        preferences.put(ExportForms.buildExportDateTimePrefix(form), exportDateTime.format(ISO_DATE_TIME))
     );
 
     form = ExportPanelForm.from(forms, confPanel);

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -21,6 +21,8 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static org.opendatakit.briefcase.model.FormStatus.TransferType.EXPORT;
 import static org.opendatakit.briefcase.ui.ODKOptionPane.showErrorDialog;
+import static org.opendatakit.briefcase.ui.export.ExportForms.buildCustomConfPrefix;
+import static org.opendatakit.briefcase.ui.export.ExportForms.buildExportDatePrefix;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -51,7 +53,7 @@ public class ExportPanel {
 
     forms = ExportForms.load(getFormsFromStorage(), preferences);
     forms.onSuccessfulExport((FormStatus form, LocalDateTime exportDate) ->
-        preferences.put("export_date_" + form.getFormDefinition().getFormId(), exportDate.format(ISO_DATE_TIME))
+        preferences.put(buildExportDatePrefix(form), exportDate.format(ISO_DATE_TIME))
     );
 
     form = ExportPanelForm.from(forms, confPanel);
@@ -61,7 +63,7 @@ public class ExportPanel {
         preferences.putAll(confPanel.getConfiguration().asMap());
 
       forms.getValidConfigurations().forEach((form, configuration) ->
-          preferences.putAll(configuration.asMap("custom_" + form.getFormName() + "_"))
+          preferences.putAll(configuration.asMap(buildCustomConfPrefix(form)))
       );
 
       if (forms.someSelected() && (confPanel.isValid() || forms.allSelectedFormsHaveConfiguration()))

--- a/src/org/opendatakit/briefcase/ui/export/components/FormsTableView.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/FormsTableView.java
@@ -4,8 +4,6 @@ import static javax.swing.SortOrder.ASCENDING;
 
 import java.awt.Dimension;
 import java.awt.event.MouseEvent;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Collections;
 import javax.swing.JButton;
 import javax.swing.JLabel;

--- a/src/org/opendatakit/briefcase/ui/export/components/FormsTableView.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/FormsTableView.java
@@ -4,8 +4,10 @@ import static javax.swing.SortOrder.ASCENDING;
 
 import java.awt.Dimension;
 import java.awt.event.MouseEvent;
+import java.time.LocalDate;
 import java.util.Collections;
 import javax.swing.JButton;
+import javax.swing.JLabel;
 import javax.swing.JTable;
 import javax.swing.RowSorter;
 import javax.swing.SortOrder;
@@ -16,15 +18,16 @@ import javax.swing.table.TableRowSorter;
 import org.opendatakit.briefcase.ui.reused.MouseListenerBuilder;
 
 public class FormsTableView extends JTable {
-  static final String[] HEADERS = new String[]{"Selected", "⚙", "Form Name", "Export Status", "Detail"};
-  static final Class[] TYPES = new Class[]{Boolean.class, JButton.class, String.class, String.class, JButton.class};
-  static final boolean[] EDITABLE_COLS = new boolean[]{true, false, false, false, false};
+  static final String[] HEADERS = new String[]{"Selected", "⚙", "Form Name", "Export Status", "Last Export", "Detail"};
+  static final Class[] TYPES = new Class[]{Boolean.class, JButton.class, String.class, String.class, LocalDate.class, JButton.class};
+  static final boolean[] EDITABLE_COLS = new boolean[]{true, false, false, false, false, false};
 
   public static final int SELECTED_CHECKBOX_COL = 0;
   static final int OVERRIDE_CONF_COL = 1;
   static final int FORM_NAME_COL = 2;
   static final int EXPORT_STATUS_COL = 3;
-  static final int DETAIL_BUTTON_COL = 4;
+  static final int LAST_EXPORT_COL = 4;
+  static final int DETAIL_BUTTON_COL = 5;
 
   FormsTableView(FormsTableViewModel model) {
     super(model);
@@ -37,6 +40,10 @@ public class FormsTableView extends JTable {
         .getTableCellRendererComponent(null, HEADERS[SELECTED_CHECKBOX_COL], false, false, 0, 0)
         .getPreferredSize();
     Dimension detailButtonDims = model.buildDetailButton(null).getPreferredSize();
+    Dimension lastExportDims = getTableHeader()
+        .getDefaultRenderer()
+        .getTableCellRendererComponent(null, HEADERS[LAST_EXPORT_COL], false, false, 0, 0)
+        .getPreferredSize();
     Dimension overrideConfButtonDims = model.buildOverrideConfButton(null).getPreferredSize();
 
     setRowHeight(detailButtonDims.height);
@@ -49,6 +56,9 @@ public class FormsTableView extends JTable {
     columns.getColumn(OVERRIDE_CONF_COL).setMinWidth(overrideConfButtonDims.width + 5);
     columns.getColumn(OVERRIDE_CONF_COL).setMaxWidth(overrideConfButtonDims.width + 5);
     columns.getColumn(OVERRIDE_CONF_COL).setPreferredWidth(overrideConfButtonDims.width + 5);
+    columns.getColumn(LAST_EXPORT_COL).setMinWidth(lastExportDims.width + 5);
+    columns.getColumn(LAST_EXPORT_COL).setMaxWidth(lastExportDims.width + 5);
+    columns.getColumn(LAST_EXPORT_COL).setPreferredWidth(lastExportDims.width + 5);
     columns.getColumn(DETAIL_BUTTON_COL).setCellRenderer(cellWithButton());
     columns.getColumn(DETAIL_BUTTON_COL).setMinWidth(detailButtonDims.width);
     columns.getColumn(DETAIL_BUTTON_COL).setMaxWidth(detailButtonDims.width);

--- a/src/org/opendatakit/briefcase/ui/export/components/FormsTableView.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/FormsTableView.java
@@ -35,15 +35,9 @@ public class FormsTableView extends JTable {
 
     addMouseListener(new MouseListenerBuilder().onClick(this::relayClickToButton).build());
 
-    Dimension checkboxDims = getTableHeader()
-        .getDefaultRenderer()
-        .getTableCellRendererComponent(null, HEADERS[SELECTED_CHECKBOX_COL], false, false, 0, 0)
-        .getPreferredSize();
+    Dimension checkboxDims = getHeaderDimension(HEADERS[SELECTED_CHECKBOX_COL]);
     Dimension detailButtonDims = model.buildDetailButton(null).getPreferredSize();
-    Dimension lastExportDims = getTableHeader()
-        .getDefaultRenderer()
-        .getTableCellRendererComponent(null, HEADERS[LAST_EXPORT_COL], false, false, 0, 0)
-        .getPreferredSize();
+    Dimension lastExportDims = getHeaderDimension(HEADERS[LAST_EXPORT_COL]);
     Dimension overrideConfButtonDims = model.buildOverrideConfButton(null).getPreferredSize();
 
     setRowHeight(detailButtonDims.height);
@@ -69,6 +63,13 @@ public class FormsTableView extends JTable {
     TableRowSorter<FormsTableViewModel> sorter = sortBy(getModel(), FORM_NAME_COL, ASCENDING);
     setRowSorter(sorter);
     sorter.sort();
+  }
+
+  private Dimension getHeaderDimension(String header) {
+    return getTableHeader()
+        .getDefaultRenderer()
+        .getTableCellRendererComponent(null, header, false, false, 0, 0)
+        .getPreferredSize();
   }
 
 

--- a/src/org/opendatakit/briefcase/ui/export/components/FormsTableView.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/FormsTableView.java
@@ -5,6 +5,7 @@ import static javax.swing.SortOrder.ASCENDING;
 import java.awt.Dimension;
 import java.awt.event.MouseEvent;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -19,7 +20,7 @@ import org.opendatakit.briefcase.ui.reused.MouseListenerBuilder;
 
 public class FormsTableView extends JTable {
   static final String[] HEADERS = new String[]{"Selected", "⚙", "Form Name", "Export Status", "Last Export", "Detail"};
-  static final Class[] TYPES = new Class[]{Boolean.class, JButton.class, String.class, String.class, LocalDate.class, JButton.class};
+  static final Class[] TYPES = new Class[]{Boolean.class, JButton.class, String.class, String.class, String.class, JButton.class};
   static final boolean[] EDITABLE_COLS = new boolean[]{true, false, false, false, false, false};
 
   public static final int SELECTED_CHECKBOX_COL = 0;
@@ -37,7 +38,7 @@ public class FormsTableView extends JTable {
 
     Dimension checkboxDims = getHeaderDimension(HEADERS[SELECTED_CHECKBOX_COL]);
     Dimension detailButtonDims = model.buildDetailButton(null).getPreferredSize();
-    Dimension lastExportDims = getHeaderDimension(HEADERS[LAST_EXPORT_COL]);
+    Dimension lastExportDims = new JLabel("Not exported yet").getPreferredSize();
     Dimension overrideConfButtonDims = model.buildOverrideConfButton(null).getPreferredSize();
 
     setRowHeight(detailButtonDims.height);
@@ -50,9 +51,9 @@ public class FormsTableView extends JTable {
     columns.getColumn(OVERRIDE_CONF_COL).setMinWidth(overrideConfButtonDims.width + 5);
     columns.getColumn(OVERRIDE_CONF_COL).setMaxWidth(overrideConfButtonDims.width + 5);
     columns.getColumn(OVERRIDE_CONF_COL).setPreferredWidth(overrideConfButtonDims.width + 5);
-    columns.getColumn(LAST_EXPORT_COL).setMinWidth(lastExportDims.width + 5);
-    columns.getColumn(LAST_EXPORT_COL).setMaxWidth(lastExportDims.width + 5);
-    columns.getColumn(LAST_EXPORT_COL).setPreferredWidth(lastExportDims.width + 5);
+    columns.getColumn(LAST_EXPORT_COL).setMinWidth(lastExportDims.width + 10);
+    columns.getColumn(LAST_EXPORT_COL).setMaxWidth(lastExportDims.width + 10);
+    columns.getColumn(LAST_EXPORT_COL).setPreferredWidth(lastExportDims.width + 10);
     columns.getColumn(DETAIL_BUTTON_COL).setCellRenderer(cellWithButton());
     columns.getColumn(DETAIL_BUTTON_COL).setMinWidth(detailButtonDims.width);
     columns.getColumn(DETAIL_BUTTON_COL).setMaxWidth(detailButtonDims.width);

--- a/src/org/opendatakit/briefcase/ui/export/components/FormsTableViewModel.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/FormsTableViewModel.java
@@ -8,6 +8,7 @@ import static org.opendatakit.briefcase.ui.export.components.FormsTableView.EDIT
 import static org.opendatakit.briefcase.ui.export.components.FormsTableView.HEADERS;
 import static org.opendatakit.briefcase.ui.export.components.FormsTableView.TYPES;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -116,6 +117,8 @@ class FormsTableViewModel extends AbstractTableModel {
         return form.getFormName();
       case FormsTableView.EXPORT_STATUS_COL:
         return form.getStatusString();
+      case FormsTableView.LAST_EXPORT_COL:
+        return LocalDate.now();
       case FormsTableView.DETAIL_BUTTON_COL:
         return detailButtons.computeIfAbsent(form, this::buildDetailButton);
       default:

--- a/src/org/opendatakit/briefcase/ui/export/components/FormsTableViewModel.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/FormsTableViewModel.java
@@ -65,10 +65,10 @@ class FormsTableViewModel extends AbstractTableModel {
   JButton buildOverrideConfButton(FormStatus form) {
     JButton button = new JButton("⚙");
     button.setEnabled(false);
-    if (forms.hasConfiguration(form))
-      button.setForeground(GREEN);
     // Ugly hack to be able to use this factory in FormExportTable to compute its Dimension
     if (form != null) {
+      if (forms.hasConfiguration(form))
+        button.setForeground(GREEN);
       button.addActionListener(__ -> {
         button.setEnabled(false);
         try {

--- a/src/org/opendatakit/briefcase/ui/export/components/FormsTableViewModel.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/FormsTableViewModel.java
@@ -2,13 +2,14 @@ package org.opendatakit.briefcase.ui.export.components;
 
 import static java.awt.Color.DARK_GRAY;
 import static java.awt.Color.GREEN;
+import static java.time.format.DateTimeFormatter.ofLocalizedDateTime;
+import static java.time.format.FormatStyle.SHORT;
 import static javax.swing.JOptionPane.getFrameForComponent;
 import static org.opendatakit.briefcase.ui.ScrollingStatusListDialog.showDialog;
 import static org.opendatakit.briefcase.ui.export.components.FormsTableView.EDITABLE_COLS;
 import static org.opendatakit.briefcase.ui.export.components.FormsTableView.HEADERS;
 import static org.opendatakit.briefcase.ui.export.components.FormsTableView.TYPES;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -118,7 +119,9 @@ class FormsTableViewModel extends AbstractTableModel {
       case FormsTableView.EXPORT_STATUS_COL:
         return form.getStatusString();
       case FormsTableView.LAST_EXPORT_COL:
-        return LocalDate.now();
+        return forms.getLastExportDateTime(form)
+            .map(dateTime -> dateTime.format(ofLocalizedDateTime(SHORT, SHORT)))
+            .orElse("Not exported yet");
       case FormsTableView.DETAIL_BUTTON_COL:
         return detailButtons.computeIfAbsent(form, this::buildDetailButton);
       default:

--- a/test/java/org/opendatakit/briefcase/ui/export/components/FormsTableTest.java
+++ b/test/java/org/opendatakit/briefcase/ui/export/components/FormsTableTest.java
@@ -28,7 +28,7 @@ import org.opendatakit.briefcase.util.BadFormDefinition;
 public class FormsTableTest {
   @Test
   public void can_select_all_forms() {
-    ExportForms forms = new ExportForms(IntStream.range(0, 10).boxed().map(this::uncheckedFormStatusFactory).collect(toList()), new HashMap<>());
+    ExportForms forms = new ExportForms(IntStream.range(0, 10).boxed().map(this::uncheckedFormStatusFactory).collect(toList()), new HashMap<>(), new HashMap<>());
     TestFormsTableViewModel viewModel = new TestFormsTableViewModel(forms);
     FormsTable formsTable = new FormsTable(forms, new TestFormsTableView(viewModel), viewModel);
 
@@ -41,7 +41,7 @@ public class FormsTableTest {
 
   @Test
   public void can_clear_selection_of_forms() {
-    ExportForms forms = new ExportForms(IntStream.range(0, 10).boxed().map(this::uncheckedFormStatusFactory).collect(toList()), new HashMap<>());
+    ExportForms forms = new ExportForms(IntStream.range(0, 10).boxed().map(this::uncheckedFormStatusFactory).collect(toList()), new HashMap<>(), new HashMap<>());
     TestFormsTableViewModel viewModel = new TestFormsTableViewModel(forms);
     FormsTable formsTable = new FormsTable(forms, new TestFormsTableView(viewModel), viewModel);
     formsTable.selectAll();
@@ -55,7 +55,7 @@ public class FormsTableTest {
   @Ignore
   public void appends_to_a_forms_status_history_when_export_events_are_sent() {
     FormStatus theForm = uncheckedFormStatusFactory(1);
-    ExportForms forms = new ExportForms(Collections.singletonList(theForm), new HashMap<>());
+    ExportForms forms = new ExportForms(Collections.singletonList(theForm), new HashMap<>(), new HashMap<>());
     TestFormsTableViewModel viewModel = new TestFormsTableViewModel(forms);
     new FormsTable(forms, new TestFormsTableView(viewModel), viewModel);
 


### PR DESCRIPTION
Partially addresses #258 

This PR is built on top of #272 because it uses the Preferences saving/loading infrastructure for the Export tab

![briefcase_last_export_date](https://user-images.githubusercontent.com/205913/35040217-9b11906c-fb80-11e7-9b6b-ee2414b5fb95.png)

Now the forms table has a new column that will track the last export date between launches.

Export dates will be tracked while using both the GUI and CLI command.

The export date will be formatted according to the user's locale.

#### What has been done to verify that this works as intended?
Manual tests

#### Why is this the best possible solution? Were any other approaches considered?
N/A

#### Are there any risks to merging this code? If so, what are they?
None I'm aware of