### PR TITLE
Issue 265 clear PEM file field

### DIFF
--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.form
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.form
@@ -88,15 +88,6 @@
           <text value="Choose..."/>
         </properties>
       </component>
-      <component id="97f45" class="javax.swing.JButton" binding="pemFileButton">
-        <constraints>
-          <grid row="1" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-          <gridbag weightx="0.0" weighty="0.0"/>
-        </constraints>
-        <properties>
-          <text value="Choose..."/>
-        </properties>
-      </component>
       <hspacer id="2c121">
         <constraints>
           <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
@@ -121,6 +112,30 @@
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
       </hspacer>
+      <grid id="e840f" binding="pemFileButtons" layout-manager="FlowLayout" hgap="0" vgap="0" flow-align="1">
+        <constraints>
+          <grid row="1" column="3" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <gridbag weightx="0.0" weighty="0.0"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="97f45" class="javax.swing.JButton" binding="pemFileChooseButton">
+            <constraints/>
+            <properties>
+              <text value="Choose..."/>
+              <visible value="true"/>
+            </properties>
+          </component>
+          <component id="78a85" class="javax.swing.JButton" binding="pemFileClearButton">
+            <constraints/>
+            <properties>
+              <text value="Clear"/>
+              <visible value="false"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
     </children>
   </grid>
 </form>

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.form
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.form
@@ -113,7 +113,7 @@
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
       </hspacer>
-      <grid id="e840f" binding="pemFileButtons" layout-manager="FlowLayout" hgap="0" vgap="0" flow-align="1">
+      <grid id="e840f" binding="pemFileButtons" layout-manager="FlowLayout" hgap="0" vgap="0" flow-align="0">
         <constraints>
           <grid row="1" column="3" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
@@ -9,6 +9,7 @@ import static org.opendatakit.briefcase.util.FileSystemUtils.isUnderODKFolder;
 import com.github.lgooddatepicker.components.DatePicker;
 import com.github.lgooddatepicker.zinternaltools.DateChangeEvent;
 import java.awt.Component;
+import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -30,17 +31,19 @@ import org.opendatakit.briefcase.util.StringUtils;
 
 @SuppressWarnings("checkstyle:MethodName")
 public class ConfigurationPanelForm extends JComponent {
+  public JPanel container;
   protected JTextField exportDirField;
   protected JTextField pemFileField;
   protected DatePicker startDateField;
   protected DatePicker endDateField;
   private JButton exportDirButton;
-  private JButton pemFileButton;
   private JLabel exportDirLabel;
   private JLabel pemFileLabel;
   private JLabel startDateLabel;
   private JLabel endDateLabel;
-  public JPanel container;
+  private JPanel pemFileButtons;
+  private JButton pemFileChooseButton;
+  private JButton pemFileClearButton;
   private final List<Consumer<Path>> onSelectExportDirCallbacks = new ArrayList<>();
   private final List<Consumer<Path>> onSelectPemFileCallbacks = new ArrayList<>();
   private final List<Consumer<LocalDate>> onSelectStartDateCallbacks = new ArrayList<>();
@@ -54,9 +57,10 @@ public class ConfigurationPanelForm extends JComponent {
     exportDirButton.addActionListener(__ ->
         buildExportDirDialog().choose().ifPresent(file -> setExportDir(Paths.get(file.toURI())))
     );
-    pemFileButton.addActionListener(__ ->
+    pemFileChooseButton.addActionListener(__ ->
         buildPemFileDialog().choose().ifPresent(file -> setPemFile(Paths.get(file.toURI())))
     );
+    pemFileClearButton.addActionListener(__ -> clearPemFile());
     startDateField.addDateChangeListener(event -> {
       if (!isDateRangeValid()) {
         showError("Invalid date range: \"From\" date must be before \"To\" date.", "Export configuration error");
@@ -100,6 +104,15 @@ public class ConfigurationPanelForm extends JComponent {
   void setPemFile(Path path) {
     pemFileField.setText(path.toString());
     onSelectPemFileCallbacks.forEach(consumer -> consumer.accept(path));
+    pemFileChooseButton.setVisible(false);
+    pemFileClearButton.setVisible(true);
+  }
+
+  private void clearPemFile() {
+    pemFileField.setText(null);
+    onSelectPemFileCallbacks.forEach(consumer -> consumer.accept(null));
+    pemFileChooseButton.setVisible(true);
+    pemFileClearButton.setVisible(false);
   }
 
   void setStartDate(LocalDate date) {
@@ -259,13 +272,6 @@ public class ConfigurationPanelForm extends JComponent {
     gbc.gridy = 0;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     container.add(exportDirButton, gbc);
-    pemFileButton = new JButton();
-    pemFileButton.setText("Choose...");
-    gbc = new GridBagConstraints();
-    gbc.gridx = 3;
-    gbc.gridy = 1;
-    gbc.fill = GridBagConstraints.HORIZONTAL;
-    container.add(pemFileButton, gbc);
     final JPanel spacer1 = new JPanel();
     gbc = new GridBagConstraints();
     gbc.gridx = 1;
@@ -290,6 +296,21 @@ public class ConfigurationPanelForm extends JComponent {
     gbc.gridy = 3;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     container.add(spacer4, gbc);
+    pemFileButtons = new JPanel();
+    pemFileButtons.setLayout(new FlowLayout(FlowLayout.CENTER, 0, 0));
+    gbc = new GridBagConstraints();
+    gbc.gridx = 3;
+    gbc.gridy = 1;
+    gbc.fill = GridBagConstraints.BOTH;
+    container.add(pemFileButtons, gbc);
+    pemFileChooseButton = new JButton();
+    pemFileChooseButton.setText("Choose...");
+    pemFileChooseButton.setVisible(true);
+    pemFileButtons.add(pemFileChooseButton);
+    pemFileClearButton = new JButton();
+    pemFileClearButton.setText("Clear");
+    pemFileClearButton.setVisible(false);
+    pemFileButtons.add(pemFileClearButton);
   }
 
   /**

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
@@ -300,7 +300,7 @@ public class ConfigurationPanelForm extends JComponent {
     gbc.fill = GridBagConstraints.HORIZONTAL;
     container.add(spacer4, gbc);
     pemFileButtons = new JPanel();
-    pemFileButtons.setLayout(new FlowLayout(FlowLayout.CENTER, 0, 0));
+    pemFileButtons.setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
     gbc = new GridBagConstraints();
     gbc.gridx = 3;
     gbc.gridy = 1;

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
@@ -53,6 +53,8 @@ public class ConfigurationPanelForm extends JComponent {
     startDateField = createDatePicker();
     endDateField = createDatePicker();
     $$$setupUI$$$();
+    startDateField.getSettings().setGapBeforeButtonPixels(0);
+    endDateField.getSettings().setGapBeforeButtonPixels(0);
 
     exportDirButton.addActionListener(__ ->
         buildExportDirDialog().choose().ifPresent(file -> setExportDir(Paths.get(file.toURI())))


### PR DESCRIPTION
Closes #265

![briefcase_clear_buttonb](https://user-images.githubusercontent.com/205913/35041052-b97fb44a-fb83-11e7-8d87-19b00df52717.png)

After setting the location for a PEM file, the button switches to a 'Clear' button that will clear the field.

#### What has been done to verify that this works as intended?
Manual tests

#### Why is this the best possible solution? Were any other approaches considered?
N/A 

#### Are there any risks to merging this code? If so, what are they?
None I'm aware of