### PR TITLE
Fix wrong config

### DIFF
--- a/src/org/opendatakit/briefcase/ui/export/ExportForms.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportForms.java
@@ -58,7 +58,8 @@ public class ExportForms {
   }
 
   public Optional<ExportConfiguration> getConfiguration(BriefcaseFormDefinition formDefinition) {
-    return Optional.ofNullable(configurations.get(getForm(formDefinition)));
+    return Optional.ofNullable(configurations.get(getForm(formDefinition)))
+        .filter(ExportConfiguration::isValid);
   }
 
   public void removeConfiguration(FormStatus form) {

--- a/src/org/opendatakit/briefcase/ui/export/components/FormsTableView.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/FormsTableView.java
@@ -13,9 +13,12 @@ import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.opendatakit.briefcase.ui.reused.MouseListenerBuilder;
 
 public class FormsTableView extends JTable {
+  private static final Log LOG = LogFactory.getLog(FormsTableView.class);
   static final String[] HEADERS = new String[]{"Selected", "⚙", "Form Name", "Export Status", "Detail"};
   static final Class[] TYPES = new Class[]{Boolean.class, JButton.class, String.class, String.class, JButton.class};
   static final boolean[] EDITABLE_COLS = new boolean[]{true, false, false, false, false};
@@ -80,10 +83,15 @@ public class FormsTableView extends JTable {
 
   private static TableCellRenderer cellWithButton() {
     return (table, value, isSelected, hasFocus, row, column) -> {
-      JButton button = (JButton) value;
-      button.setOpaque(true);
-      button.setBackground(isSelected ? table.getSelectionBackground() : table.getBackground());
-      return button;
+      if (value == null) {
+        LOG.error("TableCellRenderer for button columns has received a null value");
+        return null;
+      } else {
+        JButton button = (JButton) value;
+        button.setOpaque(true);
+        button.setBackground(isSelected ? table.getSelectionBackground() : table.getBackground());
+        return button;
+      }
     };
   }
 


### PR DESCRIPTION
Fixes an issue regarding custom and default export configurations that will produce an error:

```
Exception in thread "Thread-7" java.lang.RuntimeException: Wrong export configuration
        at org.opendatakit.briefcase.util.ExportAction.lambda$export$0(ExportAction.java:172)
        at java.util.Optional.orElseThrow(Optional.java:290)
        at org.opendatakit.briefcase.util.ExportAction.export(ExportAction.java:172)
        at org.opendatakit.briefcase.ui.export.ExportPanel.lambda$export$7(ExportPanel.java:108)
        at java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:267)
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
        at java.util.stream.ReferencePipeline$11$1.accept(ReferencePipeline.java:373)
        at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382)
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
        at java.util.stream.ReduceOps$ReduceTask.doLeaf(ReduceOps.java:747)
        at java.util.stream.ReduceOps$ReduceTask.doLeaf(ReduceOps.java:721)
        at java.util.stream.AbstractTask.compute(AbstractTask.java:316)
        at java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:731)
        at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
        at java.util.concurrent.ForkJoinTask.doInvoke(ForkJoinTask.java:401)
        at java.util.concurrent.ForkJoinTask.invoke(ForkJoinTask.java:734)
        at java.util.stream.ReduceOps$ReduceOp.evaluateParallel(ReduceOps.java:714)
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:233)
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
        at org.opendatakit.briefcase.ui.export.ExportPanel.export(ExportPanel.java:109)
        at org.opendatakit.briefcase.ui.export.ExportPanel.lambd
```

Also adds a log trace for another suspected error regarding a cell renderer receiving a null value:

```
[AWT-EventQueue-0] WARN org.bushe.swing.event.EventService - Exception thrown by;EventService subscriber:BaseProxySubscriber{subscription=class org.opendatakit.briefcase.model.ExportSucceededEventveto=falserealSubscriber=org.opendatakit.briefcase.ui.export.components.FormsTable@55fa34cf, subscriptionMethod=public void org.opendatakit.briefcase.ui.export.components.FormsTable.onExportSucceededEvent(org.opendatakit.briefcase.model.ExportSucceededEvent), referenceStrength=WEAK, eventService=org.bushe.swing.event.SwingEventService@5e60e69a}.  Subscriber class:class org.bushe.swing.event.annotation.BaseProxySubscriber
org.bushe.swing.exception.SwingException: Exception handling event topic event class=org.opendatakit.briefcase.model.ExportSucceededEvent, event=org.opendatakit.briefcase.model.ExportSucceededEvent@3f27e41d, topic=null, eventObj=null
org.bushe.swing.exception.SwingException: Exception handling event topic event class=org.opendatakit.briefcase.model.ExportSucceededEvent, event=org.opendatakit.briefcase.model.ExportSucceededEvent@3f27e41d, topic=null, eventObj=null
        at org.bushe.swing.event.ThreadSafeEventService.handleException(ThreadSafeEventService.java:2021)
        at org.bushe.swing.event.ThreadSafeEventService.handleException(ThreadSafeEventService.java:2009)
        at org.bushe.swing.event.ThreadSafeEventService.publish(ThreadSafeEventService.java:975)
        at org.bushe.swing.event.SwingEventService.access$001(SwingEventService.java:31)
        at org.bushe.swing.event.SwingEventService$1.run(SwingEventService.java:88)
        at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
        at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:756)
        at java.awt.EventQueue.access$500(EventQueue.java:97)
        at java.awt.EventQueue$3.run(EventQueue.java:709)
        at java.awt.EventQueue$3.run(EventQueue.java:703)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
        at java.awt.EventQueue.dispatchEvent(EventQueue.java:726)
        at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
        at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
        at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
        at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
Caused by: java.lang.RuntimeException: InvocationTargetException when invoking annotated method from EventService publication.  Event class:class org.opendatakit.briefcase.model.ExportSucceededEvent, Event:org.opendatakit.briefcase.model.ExportSucceededEvent@3f27e41d, subscriber:org.opendatakit.briefcase.ui.export.components.FormsTable@55fa34cf, subscription Method=public void org.opendatakit.briefcase.ui.export.components.FormsTable.onExportSucceededEvent(org.opendatakit.briefcase.model.ExportSucceededEvent)
        at org.bushe.swing.event.annotation.BaseProxySubscriber.onEvent(BaseProxySubscriber.java:74)
        at org.bushe.swing.event.ThreadSafeEventService.publish(ThreadSafeEventService.java:971)
        ... 16 more
Caused by: java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.bushe.swing.event.annotation.BaseProxySubscriber.onEvent(BaseProxySubscriber.java:69)
        ... 17 more
Caused by: java.lang.NullPointerException
        at org.opendatakit.briefcase.ui.export.components.FormsTableView.lambda$cellWithButton$0(FormsTableView.java:84)
        at javax.swing.JTable$AccessibleJTable.getAccessibleChild(JTable.java:7031)
        at javax.swing.JTable$AccessibleJTable.getAccessibleAt(JTable.java:7418)
        at javax.swing.JTable$AccessibleJTable.valueChanged(JTable.java:6932)
        at javax.swing.DefaultListSelectionModel.fireValueChanged(DefaultListSelectionModel.java:184)
        at javax.swing.DefaultListSelectionModel.fireValueChanged(DefaultListSelectionModel.java:164)
        at javax.swing.DefaultListSelectionModel.fireValueChanged(DefaultListSelectionModel.java:211)
        at javax.swing.DefaultListSelectionModel.setAnchorSelectionIndex(DefaultListSelectionModel.java:738)
        at javax.swing.JTable.clearSelectionAndLeadAnchor(JTable.java:2127)
        at javax.swing.JTable.sortedTableChanged(JTable.java:4147)
        at javax.swing.JTable.tableChanged(JTable.java:4395)
        at javax.swing.table.AbstractTableModel.fireTableChanged(AbstractTableModel.java:296)
        at javax.swing.table.AbstractTableModel.fireTableDataChanged(AbstractTableModel.java:198)
        at org.opendatakit.briefcase.ui.export.components.FormsTableViewModel.refresh(FormsTableViewModel.java:38)
        at org.opendatakit.briefcase.ui.export.components.FormsTable.onExportSucceededEvent(FormsTable.java:65)
        ... 22 more
```

#### What has been done to verify that this works as intended?
Manual tests

#### Why is this the best possible solution? Were any other approaches considered?
N/A 

#### Are there any risks to merging this code? If so, what are they?
N/A