### PR TITLE
HTML is supported by default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,6 @@ dependencies {
 jacocoTestReport {
     reports {
         xml.enabled true
-        html.enabled true
     }
 }
 


### PR DESCRIPTION
I confirmed that the HTML report is still there.