### PR TITLE
Less code is better

### DIFF
--- a/src/org/opendatakit/briefcase/ui/export/components/FormsTableViewModel.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/FormsTableViewModel.java
@@ -73,12 +73,7 @@ public class FormsTableViewModel extends AbstractTableModel {
 
     // Ugly hack to be able to use this factory in FormExportTable to compute its Dimension
     if (form != null) {
-      if (forms.hasConfiguration(form)) {
-        button.setForeground(DARK_GRAY);
-      } else {
-        button.setForeground(LIGHT_GRAY);
-      }
-
+      button.setForeground(forms.hasConfiguration(form) ? DARK_GRAY : LIGHT_GRAY);
       button.addActionListener(__ -> {
         button.setEnabled(false);
         try {


### PR DESCRIPTION
Responding to feedback from @dcbriccetti.

Tested by running on macOS and ensuring that forms with configuration are dark gray and forms without are light gray.