### PR TITLE
Fix shortcodes for cli operations

### DIFF
--- a/src/org/opendatakit/briefcase/operations/Common.java
+++ b/src/org/opendatakit/briefcase/operations/Common.java
@@ -12,7 +12,7 @@ class Common {
   private static final Log LOGGER = LogFactory.getLog(Common.class);
 
   static final Param<String> STORAGE_DIR = Param.arg("sd", "storage_directory", "Briefcase storage directory");
-  static final Param<String> FORM_ID = Param.arg("f", "form_id", "Form ID");
+  static final Param<String> FORM_ID = Param.arg("id", "form_id", "Form ID");
 
   static void bootCache(String storageDir) {
     BriefcasePreferences.setBriefcaseDirectoryProperty(storageDir);

--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -44,9 +44,9 @@ public class Export {
   private static final Param<String> FILE = Param.arg("file", "export_filename", "Filename for export operation");
   private static final Param<Date> START = Param.arg("start", "export_start_date", "Export start date", Export::toDate);
   private static final Param<Date> END = Param.arg("end", "export_end_date", "Export end date", Export::toDate);
-  private static final Param<Void> EXCLUDE_MEDIA = Param.flag("exme", "exclude_media_export", "Exclude media in export");
-  private static final Param<Void> OVERWRITE = Param.flag("ow", "overwrite_csv_export", "Overwrite files during export");
-  private static final Param<String> PEM_FILE = Param.arg("pem", "pem_file", "PEM file for form decryption");
+  private static final Param<Void> EXCLUDE_MEDIA = Param.flag("em", "exclude_media_export", "Exclude media in export");
+  private static final Param<Void> OVERWRITE = Param.flag("oc", "overwrite_csv_export", "Overwrite files during export");
+  private static final Param<String> PEM_FILE = Param.arg("pf", "pem_file", "PEM file for form decryption");
 
   public static Date toDate(String s) {
     try {

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -25,7 +25,7 @@ public class PullFormFromAggregate {
   private static final Param<Void> PULL_AGGREGATE = Param.flag("pa", "pull-aggregate", "Pull form from an Aggregate instance");
   private static final Param<String> ODK_USERNAME = Param.arg("u", "odk_username", "ODK Username");
   private static final Param<String> ODK_PASSWORD = Param.arg("p", "odk_password", "ODK Password");
-  private static final Param<String> AGGREGATE_SERVER = Param.arg("s", "aggregate_url", "Aggregate server URL");
+  private static final Param<String> AGGREGATE_SERVER = Param.arg("url", "aggregate_url", "Aggregate server URL");
 
   public static Operation PULL_FORM_FROM_AGGREGATE = Operation.of(
       PULL_AGGREGATE,


### PR DESCRIPTION
Closes #304 

This PR fixes the shortcodes for the cli args to be the same as before. The help now gives this:
```
$ java -jar build/libs/ODK\ Briefcase\ v1.8.0-209-gdf57487.jar -h
Usage: java -jar briefcase.jar <params>

Available operations:
-e,--export                         Export a form
-h,--help                           Show help
-i,--import-odk                     Import from ODK
-pa,--pull-aggregate                Pull form from an Aggregate instance
-v,--version                        Show version

Params for -e operation:
  -ed,--export_directory <arg>        Export directory
  -file,--export_filename <arg>       Filename for export operation
  -id,--form_id <arg>                 Form ID
  -sd,--storage_directory <arg>       Briefcase storage directory
  (optionally)
  -em,--exclude_media_export          Exclude media in export
  -end,--export_end_date <arg>        Export end date
  -oc,--overwrite_csv_export          Overwrite files during export
  -pf,--pem_file <arg>                PEM file for form decryption
  -start,--export_start_date <arg>    Export start date

Params for -pa operation:
  -id,--form_id <arg>                 Form ID
  -p,--odk_password <arg>             ODK Password
  -sd,--storage_directory <arg>       Briefcase storage directory
  -u,--odk_username <arg>             ODK Username
  -url,--aggregate_url <arg>          Aggregate server URL

Params for -i operation:
  -od,--odk_directory <arg>           ODK directory
  -sd,--storage_directory <arg>       Briefcase storage directory
```

#### What has been done to verify that this works as intended?
N/A

#### Why is this the best possible solution? Were any other approaches considered?
N/A

#### Are there any risks to merging this code? If so, what are they?
N/A