### PR TITLE
Fix tests that fail on windows

### DIFF
--- a/test/java/org/opendatakit/briefcase/export/ExportConfigurationTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportConfigurationTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -178,7 +179,7 @@ public class ExportConfigurationTest {
 
   @Test
   public void toString_hashCode_and_equals_for_coverage() {
-    assertThat(validConfig.toString(), Matchers.containsString("some/dir"));
+    assertThat(validConfig.toString(), Matchers.containsString("some" + File.separator + "dir"));
     assertThat(validConfig.toString(), Matchers.containsString("some_key.pem"));
     assertThat(validConfig.toString(), Matchers.containsString("2018"));
     assertThat(validConfig.toString(), Matchers.containsString("2020"));


### PR DESCRIPTION
This PR fixes a test to avoid problems with windows's path separators

#### What has been done to verify that this works as intended?
N/A

#### Why is this the best possible solution? Were any other approaches considered?
N/A

#### Are there any risks to merging this code? If so, what are they?
N/A