### PR TITLE
Fix size of datepicker components

### DIFF
--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
@@ -75,7 +75,11 @@ public class ConfigurationPanelForm extends JComponent {
     endDatePicker = createDatePicker();
     $$$setupUI$$$();
     startDatePicker.getSettings().setGapBeforeButtonPixels(0);
+    startDatePicker.getComponentDateTextField().setPreferredSize(exportDirField.getPreferredSize());
+    startDatePicker.getComponentToggleCalendarButton().setPreferredSize(exportDirChooseButton.getPreferredSize());
     endDatePicker.getSettings().setGapBeforeButtonPixels(0);
+    endDatePicker.getComponentDateTextField().setPreferredSize(exportDirField.getPreferredSize());
+    endDatePicker.getComponentToggleCalendarButton().setPreferredSize(exportDirChooseButton.getPreferredSize());
 
     exportDirChooseButton.addActionListener(__ ->
         buildExportDirDialog().choose().ifPresent(file -> setExportDir(Paths.get(file.toURI())))


### PR DESCRIPTION
Closes #321

This PR copies the preferred size of normal fields and buttons to the datepicker's components so that they have the same size.

#### What has been done to verify that this works as intended?
Manual tests on ubuntu and win10

#### Why is this the best possible solution? Were any other approaches considered?
N/A

#### Are there any risks to merging this code? If so, what are they?
N/A