### PR TITLE
Fix #323 - Add date range limit to date pickers.

### DIFF
--- a/test/java/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelPageObject.java
+++ b/test/java/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelPageObject.java
@@ -19,6 +19,7 @@ import static javax.swing.SwingUtilities.invokeLater;
 import static org.assertj.swing.edt.GuiActionRunner.execute;
 import static org.assertj.swing.timing.Timeout.timeout;
 
+import com.github.lgooddatepicker.components.DatePicker;
 import java.awt.event.ActionEvent;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -89,12 +90,12 @@ class ConfigurationPanelPageObject {
     return component.form.pemFileField;
   }
 
-  public JTextComponent startDateField() {
-    return component.form.startDatePicker.getComponentDateTextField();
+  public DatePicker startDatePicker() {
+    return component.form.startDatePicker;
   }
 
-  public JTextComponent endDateField() {
-    return component.form.endDatePicker.getComponentDateTextField();
+  public DatePicker endDatePicker() {
+    return component.form.endDatePicker;
   }
 
   public void setSomePemFile() {
@@ -124,10 +125,6 @@ class ConfigurationPanelPageObject {
     uncheckedSleep(50);
   }
 
-  private DialogFixture errorDialog() {
-    return errorDialog(50);
-  }
-
   public DialogFixture errorDialog(int timeoutMillis) {
     // Similar to buttonByName(name) or textFieldByName(name), we won't
     // throw when exhausting the timeout for obtaining a dialog and we will
@@ -154,14 +151,6 @@ class ConfigurationPanelPageObject {
     } catch (WaitTimedOutError e) {
       return null;
     }
-  }
-
-  public void acceptErrorDialog() {
-    // We need to be sure that the dialog is rendered before trying to click its button
-    waitFor(() -> errorDialog(500) != null && errorDialog().button() != null);
-    errorDialog().button().click();
-    // We wait for the dialog to disappear before handing over the thread
-    waitFor(() -> errorDialog() == null);
   }
 
   public void cancelFileDialog() {

--- a/test/java/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelTest.java
+++ b/test/java/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelTest.java
@@ -17,6 +17,7 @@ package org.opendatakit.briefcase.ui.export.components;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.opendatakit.briefcase.ui.matchers.SwingMatchers.empty;
 import static org.opendatakit.briefcase.ui.matchers.SwingMatchers.visible;
@@ -68,20 +69,14 @@ public class ConfigurationPanelTest extends AssertJSwingJUnitTestCase {
   }
 
   @Test
-  public void shows_error_and_clears_field_after_inserting_an_invalid_start_date() {
-    component.setEndDate(LocalDate.of(2018, 1, 1));
-    component.setStartDate(LocalDate.of(2020, 1, 1));
-    assertThat(component.errorDialog(500), is(GenericUIMatchers.visible()));
-    component.acceptErrorDialog();
-    assertThat(component.startDateField(), is(empty()));
+  public void cannot_insert_an_end_date_before_the_set_start_date() {
+    component.setStartDate(LocalDate.of(2017, 1, 30));
+    assertFalse(component.endDatePicker().isDateAllowed(LocalDate.of(2017, 1, 28)));
   }
 
   @Test
-  public void shows_error_and_clears_field_after_inserting_an_invalid_end_date() {
-    component.setStartDate(LocalDate.of(2020, 1, 1));
-    component.setEndDate(LocalDate.of(2018, 1, 1));
-    assertThat(component.errorDialog(500), is(GenericUIMatchers.visible()));
-    component.acceptErrorDialog();
-    assertThat(component.endDateField(), is(empty()));
+  public void cannot_insert_a_start_date_after_the_set_end_date() {
+    component.setEndDate(LocalDate.of(2017,1,25));
+    assertFalse(component.startDatePicker().isDateAllowed(LocalDate.of(2017,1,27)));
   }
 }

--- a/test/java/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelUnitTest.java
+++ b/test/java/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelUnitTest.java
@@ -15,10 +15,8 @@
  */
 package org.opendatakit.briefcase.ui.export.components;
 
-import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
@@ -62,34 +60,6 @@ public class ConfigurationPanelUnitTest {
     assertThat(view.getPemFile(), is(initialConfiguration.getPemFile().get()));
     assertThat(view.getDateRangeStart(), is(initialConfiguration.getStartDate().get()));
     assertThat(view.getDateRangeEnd(), is(initialConfiguration.getEndDate().get()));
-  }
-
-  @Test
-  public void shows_an_error_and_resets_the_field_when_the_UI_tries_to_set_a_date_range_end_that_is_before_its_start() {
-    FakeConfigurationPanelForm view = new FakeConfigurationPanelForm(false);
-    ConfigurationPanel panel = new ConfigurationPanel(ExportConfiguration.empty(), view);
-    view.setStartDate(LocalDate.of(2019, 1, 1));
-
-    // Trigger the error
-    view.setEndDate(LocalDate.of(2018, 1, 1));
-
-    assertThat(view.errorShown, is(true));
-    assertThat(view.endDatePicker.getDate(), nullValue());
-    assertThat(panel.getConfiguration().getEndDate(), isEmpty());
-  }
-
-  @Test
-  public void shows_an_error_and_resets_the_field_when_the_UI_tries_to_set_a_date_range_start_that_is_after_its_end() {
-    FakeConfigurationPanelForm view = new FakeConfigurationPanelForm(false);
-    ConfigurationPanel configurationPanel = new ConfigurationPanel(ExportConfiguration.empty(), view);
-    view.setEndDate(LocalDate.of(2018, 1, 1));
-
-    // Trigger the error
-    view.setStartDate(LocalDate.of(2019, 1, 1));
-
-    assertThat(view.errorShown, is(true));
-    assertThat(view.startDatePicker.getDate(), nullValue());
-    assertThat(configurationPanel.getConfiguration().getStartDate(), isEmpty());
   }
 
   @Test

--- a/test/java/org/opendatakit/briefcase/ui/export/components/FakeConfigurationPanelForm.java
+++ b/test/java/org/opendatakit/briefcase/ui/export/components/FakeConfigurationPanelForm.java
@@ -28,11 +28,6 @@ class FakeConfigurationPanelForm extends ConfigurationPanelForm {
   }
 
   @Override
-  protected void showError(String message, String title) {
-    errorShown = true;
-  }
-
-  @Override
   public void setEnabled(boolean enabled) {
     this.enabled = enabled;
   }


### PR DESCRIPTION
Closes #323 

#### What has been done to verify that this works as intended?
Built and ran the program.

#### Why is this the best possible solution? Were any other approaches considered?
It is best to disable end date till you enter start date, thus eliminating one logical error.

#### Are there any risks to merging this code? If so, what are they?
I tested for all possible logical scenarios that I could think of and it works.