### PR TITLE
Issue 330 fix table background colors 

### DIFF
--- a/src/org/opendatakit/briefcase/ui/FormTransferTable.java
+++ b/src/org/opendatakit/briefcase/ui/FormTransferTable.java
@@ -130,13 +130,8 @@ public class FormTransferTable extends JTable {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-      try {
-        final String history = status.getStatusHistory();
-        setEnabled(false);
-        ScrollingStatusListDialog.showDialog(JOptionPane.getFrameForComponent(this), status.getFormDefinition(), history);
-      } finally {
-        setEnabled(true);
-      }
+      if (!status.getStatusHistory().isEmpty())
+        ScrollingStatusListDialog.showDialog(JOptionPane.getFrameForComponent(this), status.getFormDefinition(), status.getStatusHistory());
     }
   }
 

--- a/src/org/opendatakit/briefcase/ui/export/components/FormsTableViewModel.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/FormsTableViewModel.java
@@ -56,7 +56,7 @@ public class FormsTableViewModel extends AbstractTableModel {
   }
 
   void refresh() {
-    detailButtons.forEach((form, button) -> button.setEnabled(!form.getStatusHistory().isEmpty()));
+    detailButtons.forEach((form, button) -> button.setForeground(form.getStatusHistory().isEmpty() ? LIGHT_GRAY : DARK_GRAY));
     fireTableDataChanged();
     triggerChange();
   }
@@ -73,14 +73,10 @@ public class FormsTableViewModel extends AbstractTableModel {
     button.setToolTipText("View this form's status history");
     button.setMargin(new Insets(0, 0, 0, 0));
 
-    button.setEnabled(false);
+    button.setForeground(LIGHT_GRAY);
     button.addActionListener(__ -> {
-      button.setEnabled(false);
-      try {
+      if (!form.getStatusHistory().isEmpty())
         showDialog(getFrameForComponent(button), form.getFormDefinition(), form.getStatusHistory());
-      } finally {
-        button.setEnabled(true);
-      }
     });
     return button;
   }
@@ -95,20 +91,15 @@ public class FormsTableViewModel extends AbstractTableModel {
 
     button.setForeground(forms.hasConfiguration(form) ? DARK_GRAY : LIGHT_GRAY);
     button.addActionListener(__ -> {
-      button.setEnabled(false);
-      try {
-        ConfigurationDialog dialog = ConfigurationDialog.from(forms.getCustomConfiguration(form));
-        dialog.onRemove(() -> removeConfiguration(form));
-        dialog.onOK(configuration -> {
-          if (configuration.isEmpty())
-            removeConfiguration(form);
-          else
-            putConfiguration(form, configuration);
-        });
-        dialog.open();
-      } finally {
-        button.setEnabled(true);
-      }
+      ConfigurationDialog dialog = ConfigurationDialog.from(forms.getCustomConfiguration(form));
+      dialog.onRemove(() -> removeConfiguration(form));
+      dialog.onOK(configuration -> {
+        if (configuration.isEmpty())
+          removeConfiguration(form);
+        else
+          putConfiguration(form, configuration);
+      });
+      dialog.open();
     });
     return button;
   }

--- a/src/org/opendatakit/briefcase/ui/export/components/FormsTableViewModel.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/FormsTableViewModel.java
@@ -56,7 +56,7 @@ public class FormsTableViewModel extends AbstractTableModel {
   }
 
   void refresh() {
-    detailButtons.forEach((form, button) -> button.setForeground(form.getStatusHistory().isEmpty() ? LIGHT_GRAY : DARK_GRAY));
+    detailButtons.forEach(this::updateDetailButton);
     fireTableDataChanged();
     triggerChange();
   }
@@ -89,7 +89,7 @@ public class FormsTableViewModel extends AbstractTableModel {
     button.setToolTipText("Override the export configuration for this form");
     button.setMargin(new Insets(0, 0, 0, 0));
 
-    button.setForeground(forms.hasConfiguration(form) ? DARK_GRAY : LIGHT_GRAY);
+    updateConfButton(form, button);
     button.addActionListener(__ -> {
       ConfigurationDialog dialog = ConfigurationDialog.from(forms.getCustomConfiguration(form));
       dialog.onRemove(() -> removeConfiguration(form));
@@ -106,14 +106,22 @@ public class FormsTableViewModel extends AbstractTableModel {
 
   private void putConfiguration(FormStatus form, ExportConfiguration configuration) {
     forms.putConfiguration(form, configuration);
-    confButtons.get(form).setForeground(DARK_GRAY);
+    updateConfButton(form, confButtons.get(form));
     triggerChange();
   }
 
   private void removeConfiguration(FormStatus form) {
     forms.removeConfiguration(form);
-    confButtons.get(form).setForeground(LIGHT_GRAY);
+    updateConfButton(form, confButtons.get(form));
     triggerChange();
+  }
+
+  private void updateDetailButton(FormStatus form, JButton button) {
+    button.setForeground(form.getStatusHistory().isEmpty() ? LIGHT_GRAY : DARK_GRAY);
+  }
+
+  private void updateConfButton(FormStatus form, JButton button) {
+    button.setForeground(forms.hasConfiguration(form) ? DARK_GRAY : LIGHT_GRAY);
   }
 
   @Override


### PR DESCRIPTION
Closes #330

It turns out that when the button is disabled, the background color set by the cell renderer is ignored.

This PR changes the strategy from enabling/disabling buttons to changing their foreground color and conditionally launching dialogs when clicked.

**Note**: On a Mac, it will only paint the background when a button is disabled (we don't know why). This PR, at least, makes the background color of cells with buttons on selected rows consistent across the different parts of the application.

#### What has been done to verify that this works as intended?
Manually tested and verified on Linux and Win10

#### Why is this the best possible solution? Were any other approaches considered?
It seems to be some kind of limitation on what Swing's capable to do on tables...

#### Are there any risks to merging this code? If so, what are they?
None