### PR TITLE
Fixes all compilation warnings

### DIFF
--- a/src/org/opendatakit/briefcase/ui/CharsetConverterDialog.java
+++ b/src/org/opendatakit/briefcase/ui/CharsetConverterDialog.java
@@ -369,31 +369,26 @@ public class CharsetConverterDialog extends JDialog implements ActionListener {
 
     final Window pleaseWaitWindow = ODKOptionPane.showMessageDialog(this, "Creating preview, please wait...");
 
-    SwingUtilities.invokeLater(new Runnable() {
-      @Override
-      public void run() {
-        try (BufferedReader bufferedReader =
-                     new BufferedReader(new InputStreamReader(new FileInputStream(filePath), getCharsetName()))) {
-          List<String> lines = new ArrayList<>();
-          int N = 100;
-          String line;
-          int c = 0;
-          while ((line = bufferedReader.readLine()) != null && c < N) {
-            lines.add(line);
-          }
-
-          previewArea.setText(join(lines, LINE_SEPARATOR));
-          previewArea.setCaretPosition(0);
-
-        } catch (Exception ex) {
-          log.error("failed to create preview", ex);
-          JOptionPane.showMessageDialog(CharsetConverterDialog.this,
-                  ex.getMessage(),
-                  "Error reading file...", JOptionPane.ERROR_MESSAGE);
-        } finally {
-          pleaseWaitWindow.setVisible(false);
-          pleaseWaitWindow.dispose();
+    SwingUtilities.invokeLater(() -> {
+      try (BufferedReader bufferedReader =
+                   new BufferedReader(new InputStreamReader(new FileInputStream(filePath), getCharsetName()))) {
+        List<String> lines = new ArrayList<>();
+        String line;
+        while ((line = bufferedReader.readLine()) != null) {
+          lines.add(line);
         }
+
+        previewArea.setText(join(lines, LINE_SEPARATOR));
+        previewArea.setCaretPosition(0);
+
+      } catch (Exception ex) {
+        log.error("failed to create preview", ex);
+        JOptionPane.showMessageDialog(CharsetConverterDialog.this,
+                ex.getMessage(),
+                "Error reading file...", JOptionPane.ERROR_MESSAGE);
+      } finally {
+        pleaseWaitWindow.setVisible(false);
+        pleaseWaitWindow.dispose();
       }
     });
   }

--- a/src/org/opendatakit/briefcase/ui/CharsetConverterDialog.java
+++ b/src/org/opendatakit/briefcase/ui/CharsetConverterDialog.java
@@ -62,7 +62,6 @@ import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -373,11 +372,9 @@ public class CharsetConverterDialog extends JDialog implements ActionListener {
     SwingUtilities.invokeLater(new Runnable() {
       @Override
       public void run() {
-        File file = new File(filePath);
-        BufferedReader bufferedReader = null;
-        try {
-          bufferedReader = new BufferedReader(new InputStreamReader(new FileInputStream(file), getCharsetName()));
-          List<String> lines = new ArrayList<String>();
+        try (BufferedReader bufferedReader =
+                     new BufferedReader(new InputStreamReader(new FileInputStream(filePath), getCharsetName()))) {
+          List<String> lines = new ArrayList<>();
           int N = 100;
           String line;
           int c = 0;
@@ -394,8 +391,6 @@ public class CharsetConverterDialog extends JDialog implements ActionListener {
                   ex.getMessage(),
                   "Error reading file...", JOptionPane.ERROR_MESSAGE);
         } finally {
-          IOUtils.closeQuietly(bufferedReader);
-
           pleaseWaitWindow.setVisible(false);
           pleaseWaitWindow.dispose();
         }

--- a/src/org/opendatakit/briefcase/ui/FormTransferTable.java
+++ b/src/org/opendatakit/briefcase/ui/FormTransferTable.java
@@ -362,7 +362,7 @@ public class FormTransferTable extends JTable {
     sorter.sort();
   }
 
-  private class FormNameColumnTableRowSorter extends TableRowSorter {
+  private class FormNameColumnTableRowSorter extends TableRowSorter<TableModel> {
 
     private final List<RowSorter.SortKey> sortKeys = new ArrayList<>(1);
 

--- a/src/org/opendatakit/briefcase/util/FormCache.java
+++ b/src/org/opendatakit/briefcase/util/FormCache.java
@@ -17,13 +17,14 @@ public class FormCache implements FormCacheable {
     private Map<String, String> pathToMd5Map = new HashMap<>();
     private Map<String, BriefcaseFormDefinition> pathToDefinitionMap = new HashMap<>();
 
+    @SuppressWarnings("unchecked")
     public FormCache(File storagePath) {
         cacheFile = new File(storagePath, "cache.ser");
         if (cacheFile.exists() && cacheFile.canRead()) {
             try (ObjectInputStream objectInputStream = new ObjectInputStream(new FileInputStream(cacheFile))) {
                 pathToMd5Map = (Map) objectInputStream.readObject();
                 pathToDefinitionMap = (Map) objectInputStream.readObject();
-            } catch (IOException | ClassNotFoundException e) {
+            } catch (IOException | ClassNotFoundException | ClassCastException e) {
                 e.printStackTrace();
             }
         }


### PR DESCRIPTION
Closes #355 

#### What has been done to verify that this works as intended?
Running `./gradlew clean compileJava` produces no compilation error.

#### Why is this the best possible solution? Were any other approaches considered?
1. The main point of `try-with-resources` is to make sure resources are closed, without requiring the application code to do it. 
2. For fixing the `unchecked cast` warning, I added the appropriate casts in one place and for the other place I suppressed the warnings and added the `ClassCastException` to the catch for catching any exceptions. 

#### Are there any risks to merging this code? If so, what are they?
No