### PR TITLE
New CLI op to clean prefs

### DIFF
--- a/src/org/opendatakit/briefcase/Launcher.java
+++ b/src/org/opendatakit/briefcase/Launcher.java
@@ -15,6 +15,7 @@
  */
 package org.opendatakit.briefcase;
 
+import static org.opendatakit.briefcase.operations.CleanPreferences.CLEAN_PREFS;
 import static org.opendatakit.briefcase.operations.Export.EXPORT_FORM;
 import static org.opendatakit.briefcase.operations.ImportFromODK.IMPORT_FROM_ODK;
 import static org.opendatakit.briefcase.operations.PullFormFromAggregate.PULL_FORM_FROM_AGGREGATE;
@@ -34,6 +35,7 @@ public class Launcher {
         .register(PULL_FORM_FROM_AGGREGATE)
         .register(IMPORT_FROM_ODK)
         .register(EXPORT_FORM)
+        .register(CLEAN_PREFS)
         .otherwise(() -> MainBriefcaseWindow.main(args))
         .run(args);
   }

--- a/src/org/opendatakit/briefcase/Launcher.java
+++ b/src/org/opendatakit/briefcase/Launcher.java
@@ -15,7 +15,7 @@
  */
 package org.opendatakit.briefcase;
 
-import static org.opendatakit.briefcase.operations.CleanPreferences.CLEAN_PREFS;
+import static org.opendatakit.briefcase.operations.ClearPreferences.CLEAR_PREFS;
 import static org.opendatakit.briefcase.operations.Export.EXPORT_FORM;
 import static org.opendatakit.briefcase.operations.ImportFromODK.IMPORT_FROM_ODK;
 import static org.opendatakit.briefcase.operations.PullFormFromAggregate.PULL_FORM_FROM_AGGREGATE;
@@ -35,7 +35,7 @@ public class Launcher {
         .register(PULL_FORM_FROM_AGGREGATE)
         .register(IMPORT_FROM_ODK)
         .register(EXPORT_FORM)
-        .register(CLEAN_PREFS)
+        .register(CLEAR_PREFS)
         .otherwise(() -> MainBriefcaseWindow.main(args))
         .run(args);
   }

--- a/src/org/opendatakit/briefcase/operations/CleanPreferences.java
+++ b/src/org/opendatakit/briefcase/operations/CleanPreferences.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.opendatakit.briefcase.operations;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.opendatakit.briefcase.model.BriefcasePreferences;
+import org.opendatakit.briefcase.ui.PullTransferPanel;
+import org.opendatakit.briefcase.ui.PushTransferPanel;
+import org.opendatakit.briefcase.ui.export.ExportPanel;
+import org.opendatakit.common.cli.Operation;
+import org.opendatakit.common.cli.Param;
+
+public class CleanPreferences {
+
+  private static Param<Void> CLEAN = Param.flag("c", "clean-prefs", "Clean saved preferences");
+
+  public static Operation CLEAN_PREFS = Operation.of(CLEAN, __ -> clean());
+
+  private static void clean() {
+    flush(BriefcasePreferences.appScoped());
+    Stream.of(
+        PullTransferPanel.class,
+        PushTransferPanel.class,
+        ExportPanel.class
+    ).map(BriefcasePreferences::forClass)
+        .forEach(CleanPreferences::flush);
+  }
+
+  private static void flush(BriefcasePreferences appPreferences) {
+    System.out.println("Cleaning saved keys on " + appPreferences.node);
+    List<String> keys = appPreferences.keys();
+    appPreferences.removeAll(keys);
+    System.out.println("Removed keys:");
+    keys.forEach(key -> System.out.println("\t-" + key));
+  }
+
+}

--- a/src/org/opendatakit/briefcase/operations/ClearPreferences.java
+++ b/src/org/opendatakit/briefcase/operations/ClearPreferences.java
@@ -15,6 +15,8 @@
  */
 package org.opendatakit.briefcase.operations;
 
+import static java.util.Comparator.naturalOrder;
+
 import java.util.List;
 import java.util.stream.Stream;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
@@ -24,28 +26,28 @@ import org.opendatakit.briefcase.ui.export.ExportPanel;
 import org.opendatakit.common.cli.Operation;
 import org.opendatakit.common.cli.Param;
 
-public class CleanPreferences {
+public class ClearPreferences {
 
-  private static Param<Void> CLEAN = Param.flag("c", "clean-prefs", "Clean saved preferences");
+  private static Param<Void> CLEAR = Param.flag("c", "clear_prefs", "Clear saved preferences");
 
-  public static Operation CLEAN_PREFS = Operation.of(CLEAN, __ -> clean());
+  public static Operation CLEAR_PREFS = Operation.of(CLEAR, __ -> clear());
 
-  private static void clean() {
+  private static void clear() {
     flush(BriefcasePreferences.appScoped());
     Stream.of(
         PullTransferPanel.class,
         PushTransferPanel.class,
         ExportPanel.class
     ).map(BriefcasePreferences::forClass)
-        .forEach(CleanPreferences::flush);
+        .forEach(ClearPreferences::flush);
   }
 
   private static void flush(BriefcasePreferences appPreferences) {
-    System.out.println("Cleaning saved keys on " + appPreferences.node);
+    System.out.println("Clearing saved keys on " + appPreferences.node);
     List<String> keys = appPreferences.keys();
     appPreferences.removeAll(keys);
-    System.out.println("Removed keys:");
-    keys.forEach(key -> System.out.println("\t-" + key));
+    keys.sort(naturalOrder());
+    keys.forEach(key -> System.out.println("  " + key));
   }
 
 }


### PR DESCRIPTION
Closes #360

This PR add a CLI command to clean user prefs. The new command is launched with the `-c` flag (also `--clean-prefs`.

#### What has been done to verify that this works as intended?
Manually tested on my linux machine

#### Why is this the best possible solution? Were any other approaches considered?
N/A

#### Are there any risks to merging this code? If so, what are they?
None.