### PR TITLE
Issue 334 Reset HTTP context whenever we get an 401 Not Authorized response

### DIFF
--- a/src/org/opendatakit/briefcase/ui/PullTransferPanel.java
+++ b/src/org/opendatakit/briefcase/ui/PullTransferPanel.java
@@ -53,6 +53,7 @@ import org.opendatakit.briefcase.model.TransferFailedEvent;
 import org.opendatakit.briefcase.model.TransferSucceededEvent;
 import org.opendatakit.briefcase.util.FileSystemUtils;
 import org.opendatakit.briefcase.util.TransferAction;
+import org.opendatakit.briefcase.util.WebUtils;
 
 /**
  * Pull forms and data to external locations.
@@ -141,6 +142,8 @@ public class PullTransferPanel extends JPanel {
             (Window) PullTransferPanel.this.getTopLevelAncestor(), originServerInfo, false);
         d.setVisible(true);
         if (d.isSuccessful()) {
+          // We reset the Http context to force next request to authenticate itself
+          WebUtils.resetHttpContext();
           originServerInfo = d.getServerInfo();
           txtOriginName.setText(originServerInfo.getUrl());
           PREFERENCES.put(BriefcasePreferences.AGGREGATE_1_0_URL, originServerInfo.getUrl());
@@ -148,6 +151,12 @@ public class PullTransferPanel extends JPanel {
           if (BriefcasePreferences.getStorePasswordsConsentProperty())
             PREFERENCES.put(BriefcasePreferences.PASSWORD, new String(originServerInfo.getPassword()));
           PullTransferPanel.this.updateFormStatuses();
+        } else {
+          if (!BriefcasePreferences.getStorePasswordsConsentProperty()) {
+            // We need to clear the forms table because we have lost any password
+            // by opening the connection dialog
+            formTransferTable.setFormStatusList(new ArrayList<>());
+          }
         }
       } else if (EndPointType.CUSTOM_ODK_COLLECT_DIRECTORY.equals(selection)) {
         // odkCollect...

--- a/src/org/opendatakit/briefcase/util/AggregateUtils.java
+++ b/src/org/opendatakit/briefcase/util/AggregateUtils.java
@@ -96,9 +96,7 @@ public class AggregateUtils {
    * @throws ClientProtocolException
    * @throws TransmissionException
    */
-  public static final void commonDownloadFile(ServerConnectionInfo serverInfo, File f,
-      String downloadUrl) throws URISyntaxException, ClientProtocolException, IOException,
-      TransmissionException {
+  public static final void commonDownloadFile(ServerConnectionInfo serverInfo, File f, String downloadUrl) throws URISyntaxException, IOException, TransmissionException {
 
     // OK. We need to download it because we either:
     // (1) don't have it
@@ -129,7 +127,11 @@ public class AggregateUtils {
       response = httpclient.execute(req, localContext);
       int statusCode = response.getStatusLine().getStatusCode();
 
-      if (statusCode != 200) {
+      if (statusCode == 401) {
+        // We reset the Http context to force next request to authenticate itself
+        WebUtils.resetHttpContext();
+        throw new TransmissionException("Authentication failure");
+      } else if (statusCode != 200) {
         String errMsg = String.format(FETCH_FAILED_DETAILED_REASON, f.getAbsolutePath())
             + response.getStatusLine().getReasonPhrase() + " (" + statusCode + ")";
         log.error(errMsg);
@@ -157,8 +159,6 @@ public class AggregateUtils {
    * the body of the response entity and should be xml.
    * 
    * @param urlString
-   * @param localContext
-   * @param httpclient
    * @return
    */
   public static final DocumentFetchResult getXmlDocument(String urlString,
@@ -215,9 +215,6 @@ public class AggregateUtils {
    * context and client objects involved in the web connection. The document is
    * the body of the response entity and should be xml.
    * 
-   * @param urlString
-   * @param localContext
-   * @param httpclient
    * @return
    */
   private static final DocumentFetchResult httpRetrieveXmlDocument(HttpUriRequest request,
@@ -260,7 +257,11 @@ public class AggregateUtils {
       if (!statusCodeValid) {
         String webError = response.getStatusLine().getReasonPhrase() + " (" + statusCode + ")";
 
-        if (statusCode == 400) {
+        if (statusCode == 401) {
+          // We reset the Http context to force next request to authenticate itself
+          WebUtils.resetHttpContext();
+          ex = new XmlDocumentFetchException("Authentication failure");
+        } else if (statusCode == 400) {
           ex = new XmlDocumentFetchException(description.getFetchDocFailed() + webError + " while accessing: "
               + uri.toString() + "\nPlease verify that the " + description.getDocumentDescriptionType()
               + " that is being uploaded is well-formed.");
@@ -446,7 +447,11 @@ public class AggregateUtils {
       try {
         response = httpClient.execute(httpHead, localContext);
         int statusCode = response.getStatusLine().getStatusCode();
-        if (statusCode == 204) {
+        if (statusCode == 401) {
+          // We reset the Http context to force next request to authenticate itself
+          WebUtils.resetHttpContext();
+          throw new TransmissionException("Authentication failure");
+        } else if (statusCode == 204) {
           Header[] openRosaVersions = response.getHeaders(WebUtils.OPEN_ROSA_VERSION_HEADER);
           if (openRosaVersions == null || openRosaVersions.length == 0) {
             String msg = "Url: " + u.toString()

--- a/src/org/opendatakit/briefcase/util/WebUtils.java
+++ b/src/org/opendatakit/briefcase/util/WebUtils.java
@@ -27,6 +27,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
 
@@ -35,6 +36,7 @@ import org.apache.http.HttpRequest;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpClient;
@@ -119,6 +121,17 @@ public final class WebUtils {
             threadSafeContext.set(httpContext);
         }
         return httpContext;
+    }
+
+    /**
+     * Resets the context clearing cookies and aith parameters and residual information
+     * from previous requests
+     */
+    public static void resetHttpContext() {
+      getHttpContext().getCookieStore().clear();
+      getHttpContext().getTargetAuthState().reset();
+      Optional.ofNullable(getHttpContext().getAuthCache()).ifPresent(AuthCache::clear);
+      getHttpContext().getCredentialsProvider().clear();
     }
 
     /**


### PR DESCRIPTION
Closes #334

This PR changes the HTTP requests engine to reset any HTTP context whenever we get a 401 Not Authorized response from the servers.

This fix prevents the effects of the current coupling problems that exist between the different business operations that require HTTP interaction in Briefcase but a deeper redesign is required (as I explain on [a comment on the issue](https://github.com/opendatakit/briefcase/issues/334#issuecomment-364908421)).

This PR also fixes a previous situation where the user cancels the server connection settings dialog after having successfully pulled some forms. If the user hasn't checked the "remember passwords" setting, the forms table must be cleared because pulling again will fail (we remove the password stored in memory when opening the dialog for the second time).

#### What has been done to verify that this works as intended?
Manual tests on  Linux, Mac and Windows 10:
- On the connection dialog (both pull and push tabs):
  - Write the settings and use a wrong password. Clicking on connect should fail
  - Fix the password and click on connect. Now it should work.
  - On master, it should continue failing
- Pull tab:
  - With "remember" passwords off
    - Open the connection dialog, configure correctly a connection to a server using username and password, click on connect. Some forms should show in the forms table.
    - Open the connection dialog again and click on cancel
    - The forms table should be empty
    - On master, you should continue seeing the forms table and pulling a form should fail.
  - Same thing with "remember" passwords on
    - The forms table should stay

#### Why is this the best possible solution? Were any other approaches considered?
This is the fastest solution, not the best. We need to redesign the business operations that interact with HTTP to be self-contained.

#### Are there any risks to merging this code? If so, what are they?
None I can think of