### PR TITLE
Provide a human-friendly error message

### DIFF
--- a/src/org/opendatakit/common/cli/Cli.java
+++ b/src/org/opendatakit/common/cli/Cli.java
@@ -26,6 +26,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.MissingArgumentException;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.UnrecognizedOptionException;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
@@ -131,8 +132,9 @@ public class Cli {
   private CommandLine getCli(String[] args, Set<Param> params) {
     try {
       return new DefaultParser().parse(mapToOptions(params), args, false);
-    } catch (UnrecognizedOptionException e) {
+    } catch (UnrecognizedOptionException | MissingArgumentException e) {
       System.err.println(e.getMessage());
+      log.error("Error", e);
       printHelp(requiredOperations, operations);
       System.exit(1);
       return null;


### PR DESCRIPTION
Provide human-friendly error message for MissingArgumentException in CLI

Closes #380

#### What has been done to verify that this works as intended?
`./gradlew check` runs successfully

#### Why is this the best possible solution? Were any other approaches considered?

#### Are there any risks to merging this code? If so, what are they?
None

