### PR TITLE
Issue 384 Sentry metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,6 @@ buildConfig {
     buildConfigField 'String', 'GOOGLE_TRACKING_ID', getValue("googleAnalytics.trackingId", "UA-91951913-3")
     buildConfigField 'Boolean', 'SENTRY_ENABLED', getValue("sentry.enabled", "false")
     buildConfigField 'String', 'SENTRY_DSN', getValue("sentry.dsn", "https://b6f023a5f17e44d9a46447f8827e2a41:1b1f33d68b1b4404b85cd627563d37f9@sentry.io/287258")
-    buildConfigField 'String', 'SENTRY_ENV', getValue("sentry.env", "dev")
 }
 
 mainClassName = 'org.opendatakit.briefcase.Launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,9 @@ buildConfig {
     clsName = 'BuildConfig'
     packageName = 'org.opendatakit.briefcase.buildconfig'
     buildConfigField 'String', 'GOOGLE_TRACKING_ID', getValue("googleAnalytics.trackingId", "UA-91951913-3")
-    buildConfigField 'String', 'SENTRY_DSN', getValue("sentryDsn", "https://b6f023a5f17e44d9a46447f8827e2a41:1b1f33d68b1b4404b85cd627563d37f9@sentry.io/287258")
+    buildConfigField 'Boolean', 'SENTRY_ENABLED', getValue("sentry.enabled", "false")
+    buildConfigField 'String', 'SENTRY_DSN', getValue("sentry.dsn", "https://b6f023a5f17e44d9a46447f8827e2a41:1b1f33d68b1b4404b85cd627563d37f9@sentry.io/287258")
+    buildConfigField 'String', 'SENTRY_ENV', getValue("sentry.env", "dev")
 }
 
 mainClassName = 'org.opendatakit.briefcase.Launcher'

--- a/src/org/opendatakit/briefcase/Launcher.java
+++ b/src/org/opendatakit/briefcase/Launcher.java
@@ -15,13 +15,17 @@
  */
 package org.opendatakit.briefcase;
 
+import static org.opendatakit.briefcase.buildconfig.BuildConfig.SENTRY_DSN;
+import static org.opendatakit.briefcase.buildconfig.BuildConfig.SENTRY_ENABLED;
+import static org.opendatakit.briefcase.buildconfig.BuildConfig.SENTRY_ENV;
+import static org.opendatakit.briefcase.buildconfig.BuildConfig.VERSION;
 import static org.opendatakit.briefcase.operations.ClearPreferences.CLEAR_PREFS;
 import static org.opendatakit.briefcase.operations.Export.EXPORT_FORM;
 import static org.opendatakit.briefcase.operations.ImportFromODK.IMPORT_FROM_ODK;
 import static org.opendatakit.briefcase.operations.PullFormFromAggregate.PULL_FORM_FROM_AGGREGATE;
+import static org.opendatakit.briefcase.util.FindDirectoryStructure.getOsName;
 
 import io.sentry.Sentry;
-import org.opendatakit.briefcase.buildconfig.BuildConfig;
 import org.opendatakit.briefcase.ui.MainBriefcaseWindow;
 import org.opendatakit.common.cli.Cli;
 
@@ -33,7 +37,16 @@ import org.opendatakit.common.cli.Cli;
  */
 public class Launcher {
   public static void main(String[] args) {
-    Sentry.init(BuildConfig.SENTRY_DSN);
+    if (SENTRY_ENABLED)
+      Sentry.init(String.format(
+          "%s?release=%s&environment=%s&stacktrace.app.packages=%s&tags=os:%s,jvm:%s",
+          SENTRY_DSN,
+          VERSION,
+          SENTRY_ENV,
+          "org.opendatakit",
+          getOsName(),
+          System.getProperty("java.version")
+      ));
 
     new Cli()
         .register(PULL_FORM_FROM_AGGREGATE)

--- a/src/org/opendatakit/briefcase/Launcher.java
+++ b/src/org/opendatakit/briefcase/Launcher.java
@@ -17,7 +17,6 @@ package org.opendatakit.briefcase;
 
 import static org.opendatakit.briefcase.buildconfig.BuildConfig.SENTRY_DSN;
 import static org.opendatakit.briefcase.buildconfig.BuildConfig.SENTRY_ENABLED;
-import static org.opendatakit.briefcase.buildconfig.BuildConfig.SENTRY_ENV;
 import static org.opendatakit.briefcase.buildconfig.BuildConfig.VERSION;
 import static org.opendatakit.briefcase.operations.ClearPreferences.CLEAR_PREFS;
 import static org.opendatakit.briefcase.operations.Export.EXPORT_FORM;
@@ -39,11 +38,9 @@ public class Launcher {
   public static void main(String[] args) {
     if (SENTRY_ENABLED)
       Sentry.init(String.format(
-          "%s?release=%s&environment=%s&stacktrace.app.packages=%s&tags=os:%s,jvm:%s",
+          "%s?release=%s&stacktrace.app.packages=org.opendatakit&tags=os:%s,jvm:%s",
           SENTRY_DSN,
           VERSION,
-          SENTRY_ENV,
-          "org.opendatakit",
           getOsName(),
           System.getProperty("java.version")
       ));

--- a/src/org/opendatakit/briefcase/util/FindDirectoryStructure.java
+++ b/src/org/opendatakit/briefcase/util/FindDirectoryStructure.java
@@ -55,6 +55,10 @@ public class FindDirectoryStructure {
     return os.contains("windows");
   }
 
+  public static String getOsName() {
+    return isMac() ? "mac" : isWindows() ? "windows" : "linux";
+  }
+
   /**
    * Searches mounted drives for /odk/instances and returns a list of
    * positive results. Works for Windows, Mac, and Linux operating


### PR DESCRIPTION
Closes #384

This PR configures Sentry appender to tag events with runtime env and release information

Sentry configuration options are:

| Key | Description |
| --- | --- |
| `sentry.enabled` | Enables Sentry configuration (defaults to false) |
| `sentry.dsn` | Sentry client DSN |
| ~`sentry.env`~ | ~Environment (defaults to `dev`)~ |

All these keys can be overwritten with a `gradle.properties` file on the project's root directory.

#### What has been done to verify that this works as intended?
Manually run Briefcase, produce a syntactic error on a form and try to export it to send events to Sentry.
Confirmed that events arrive with all the specified metadata on Sentry dashboard.

#### Why is this the best possible solution? Were any other approaches considered?
Sentry also allows to set metadata through MDC properties, but I haven't been able to get it working.

#### Are there any risks to merging this code? If so, what are they?
None.