### PR TITLE
Fix #378 - Allow yyyy/MM/dd and yyyy-MM-dd for start and end dates.

### DIFF
--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -52,8 +52,8 @@ public class Export {
   private static final Param<Void> EXPORT = Param.flag("e", "export", "Export a form");
   private static final Param<Path> EXPORT_DIR = Param.arg("ed", "export_directory", "Export directory", Paths::get);
   private static final Param<String> FILE = Param.arg("f", "export_filename", "Filename for export operation");
-  private static final Param<LocalDate> START = Param.arg("start", "export_start_date", "Export start date", LocalDate::parse);
-  private static final Param<LocalDate> END = Param.arg("end", "export_end_date", "Export end date", LocalDate::parse);
+  private static final Param<LocalDate> START = Param.localDate("start", "export_start_date", "Export start date");
+  private static final Param<LocalDate> END = Param.localDate("end", "export_end_date", "Export end date");
   private static final Param<Void> EXCLUDE_MEDIA = Param.flag("em", "exclude_media_export", "Exclude media in export");
   private static final Param<Void> OVERWRITE = Param.flag("oc", "overwrite_csv_export", "Overwrite files during export");
   private static final Param<Path> PEM_FILE = Param.arg("pf", "pem_file", "PEM file for form decryption", Paths::get);

--- a/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
+++ b/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
@@ -76,8 +76,8 @@ public class BriefcaseCLI {
             fileName,
             exportMedia,
             overwrite,
-            Optional.ofNullable(startDateString).map(LocalDate::parse),
-            Optional.ofNullable(endDateString).map(LocalDate::parse),
+            Optional.ofNullable(startDateString).map(s -> LocalDate.parse(s.replaceAll("/", "-"))),
+            Optional.ofNullable(endDateString).map(s -> LocalDate.parse(s.replaceAll("/", "-"))),
             Optional.ofNullable(pemKeyFile).map(Paths::get)
         );
     } catch (BriefcaseException e) {

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -67,7 +67,8 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
   final StorageLocation storageLocation;
 
   public static final String AGGREGATE_URL = "aggregate_url";
-  public static final String DATE_FORMAT = "yyyy/MM/dd";
+  public static final String DATE_FORMAT1 = "yyyy-MM-dd";
+  public static final String DATE_FORMAT2 = "yyyy/MM/dd";
   public static final String EXCLUDE_MEDIA_EXPORT = "exclude_media_export";
   public static final String EXPORT_DIRECTORY = "export_directory";
   public static final String EXPORT_END_DATE = "export_end_date";
@@ -354,14 +355,14 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
         .build();
 
     Option startDate = Option.builder("start")
-        .argName(DATE_FORMAT)
+        .argName(DATE_FORMAT1 + " or " + DATE_FORMAT2)
         .hasArg()
         .longOpt(EXPORT_START_DATE)
         .desc("Include submission dates after (inclusive) this date in export to CSV")
         .build();
 
     Option endDate = Option.builder("end")
-        .argName(DATE_FORMAT)
+        .argName(DATE_FORMAT1 + " or " + DATE_FORMAT2)
         .hasArg()
         .longOpt(EXPORT_END_DATE)
         .desc("Include submission dates before (exclusive) this date in export to CSV")
@@ -422,9 +423,10 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
     return options;
   }
 
-  static boolean testDateFormat(String date) {
+  private static boolean testDateFormat(String date) {
+    date = date.replaceAll("/", "-");
     try {
-      DateFormat df = new SimpleDateFormat(DATE_FORMAT);
+      DateFormat df = new SimpleDateFormat(DATE_FORMAT1);
       df.parse(date);
     } catch (java.text.ParseException e) {
       return false;

--- a/src/org/opendatakit/common/cli/Param.java
+++ b/src/org/opendatakit/common/cli/Param.java
@@ -1,9 +1,12 @@
 package org.opendatakit.common.cli;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import org.apache.commons.cli.Option;
+import org.opendatakit.briefcase.reused.BriefcaseException;
 
 /**
  * This class represents a command-line execution argument. It can be either a flag (without a
@@ -56,6 +59,29 @@ public class Param<T> {
         shortCode,
         new Option(shortCode, longCode, true, description),
         Optional.of(mapper)
+    );
+  }
+
+  /**
+   * Creates a new {@link Param}&lt;{@link LocalDate}&gt; instance for a command-line arg
+   *
+   * @param shortCode   the shortcode (usually one or two chars)
+   * @param longCode    the longcode (usually some words separated by hyphens)
+   * @param description the description
+   * @return a new {@link Param}&lt;{@link LocalDate}&gt; instance
+   */
+  public static Param<LocalDate> localDate(String shortCode, String longCode, String description) {
+    return Param.arg(
+        shortCode,
+        longCode,
+        description + "(yyyy-MM-dd or yyyy/MM/dd)",
+        dateAsText -> {
+          try {
+            return LocalDate.parse(dateAsText.replaceAll("/", "-"));
+          } catch (DateTimeParseException e) {
+            throw new BriefcaseException("Invalid date format.");
+          }
+        }
     );
   }
 

--- a/test/java/org/opendatakit/common/cli/ParamTest.java
+++ b/test/java/org/opendatakit/common/cli/ParamTest.java
@@ -1,0 +1,29 @@
+package org.opendatakit.common.cli;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.time.LocalDate;
+import org.junit.Test;
+import org.opendatakit.briefcase.reused.BriefcaseException;
+
+public class ParamTest {
+
+  @Test(expected = BriefcaseException.class)
+  public void throwBriefcaseExceptionForInvalidDateFormat() {
+      Param<LocalDate> localDate = Param.localDate("start", "export_start_date", "Export start date");
+      localDate.map("2018.01.20");
+  }
+
+  @Test
+  public void acceptsIso8601Dates () {
+      Param<LocalDate> localDate = Param.localDate("start", "export_start_date", "Export start date");
+      assertThat(localDate.map("2018-01-20"), is(LocalDate.of(2018, 1,20)));
+  }
+
+  @Test
+  public void normalizesInputSlashesToHyphens() {
+      Param<LocalDate> localDate = Param.localDate("start", "export_start_date", "Export start date");
+      assertThat(localDate.map("2018/01/20"), is(LocalDate.of(2018, 1, 20)));
+  }
+}


### PR DESCRIPTION
Closes #378 

#### What has been done to verify that this works as intended?
Manually ran the following two commands - 
1) java -jar ODK\ Briefcase\ v1.9.0-102-g4d7e2ff-dirty.jar -e -id all-widgets --storage_directory /home/mayank/ --export_directory /home/mayank/ODKExport/ --export_filename abcd.csv -start 2018/01/20

2) java -jar ODK\ Briefcase\ v1.9.0-102-g4d7e2ff-dirty.jar -e -id all-widgets --storage_directory /home/mayank/ --export_directory /home/mayank/ODKExport/ --export_filename abcd.csv -start 2018-01-20

Positive results for both the tests.

#### Why is this the best possible solution? Were any other approaches considered?
This way we are supporting both the date formats "/" and "-".

#### Are there any risks to merging this code? If so, what are they?
None that I am aware of.