### PR TITLE
Issue 20 push from cli

### DIFF
--- a/src/org/opendatakit/briefcase/Launcher.java
+++ b/src/org/opendatakit/briefcase/Launcher.java
@@ -21,6 +21,7 @@ import static org.opendatakit.briefcase.buildconfig.BuildConfig.VERSION;
 import static org.opendatakit.briefcase.operations.ClearPreferences.CLEAR_PREFS;
 import static org.opendatakit.briefcase.operations.Export.EXPORT_FORM;
 import static org.opendatakit.briefcase.operations.ImportFromODK.IMPORT_FROM_ODK;
+import static org.opendatakit.briefcase.operations.PullFormFromAggregate.DEPRECATED_PULL_AGGREGATE;
 import static org.opendatakit.briefcase.operations.PullFormFromAggregate.PULL_FORM_FROM_AGGREGATE;
 import static org.opendatakit.briefcase.operations.PushFormToAggregate.PUSH_FORM_TO_AGGREGATE;
 import static org.opendatakit.briefcase.util.FindDirectoryStructure.getOsName;
@@ -47,6 +48,7 @@ public class Launcher {
       ));
 
     new Cli()
+        .deprecate(DEPRECATED_PULL_AGGREGATE, PULL_FORM_FROM_AGGREGATE)
         .register(PULL_FORM_FROM_AGGREGATE)
         .register(PUSH_FORM_TO_AGGREGATE)
         .register(IMPORT_FROM_ODK)

--- a/src/org/opendatakit/briefcase/Launcher.java
+++ b/src/org/opendatakit/briefcase/Launcher.java
@@ -22,6 +22,7 @@ import static org.opendatakit.briefcase.operations.ClearPreferences.CLEAR_PREFS;
 import static org.opendatakit.briefcase.operations.Export.EXPORT_FORM;
 import static org.opendatakit.briefcase.operations.ImportFromODK.IMPORT_FROM_ODK;
 import static org.opendatakit.briefcase.operations.PullFormFromAggregate.PULL_FORM_FROM_AGGREGATE;
+import static org.opendatakit.briefcase.operations.PushFormToAggregate.PUSH_FORM_TO_AGGREGATE;
 import static org.opendatakit.briefcase.util.FindDirectoryStructure.getOsName;
 
 import io.sentry.Sentry;
@@ -47,6 +48,7 @@ public class Launcher {
 
     new Cli()
         .register(PULL_FORM_FROM_AGGREGATE)
+        .register(PUSH_FORM_TO_AGGREGATE)
         .register(IMPORT_FROM_ODK)
         .register(EXPORT_FORM)
         .register(CLEAR_PREFS)

--- a/src/org/opendatakit/briefcase/operations/Common.java
+++ b/src/org/opendatakit/briefcase/operations/Common.java
@@ -28,6 +28,9 @@ class Common {
 
   static final Param<String> STORAGE_DIR = Param.arg("sd", "storage_directory", "Briefcase storage directory");
   static final Param<String> FORM_ID = Param.arg("id", "form_id", "Form ID");
+  static final Param<String> ODK_USERNAME = Param.arg("u", "odk_username", "ODK Username");
+  static final Param<String> ODK_PASSWORD = Param.arg("p", "odk_password", "ODK Password");
+  static final Param<String> AGGREGATE_SERVER = Param.arg("url", "aggregate_url", "Aggregate server URL");
 
   static void bootCache(String storageDir) {
     BriefcasePreferences.setBriefcaseDirectoryProperty(storageDir);

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -15,7 +15,10 @@
  */
 package org.opendatakit.briefcase.operations;
 
+import static org.opendatakit.briefcase.operations.Common.AGGREGATE_SERVER;
 import static org.opendatakit.briefcase.operations.Common.FORM_ID;
+import static org.opendatakit.briefcase.operations.Common.ODK_PASSWORD;
+import static org.opendatakit.briefcase.operations.Common.ODK_USERNAME;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 import static org.opendatakit.briefcase.operations.Common.bootCache;
 
@@ -35,9 +38,6 @@ import org.slf4j.LoggerFactory;
 public class PullFormFromAggregate {
   private static final Logger log = LoggerFactory.getLogger(PullFormFromAggregate.class);
   private static final Param<Void> PULL_AGGREGATE = Param.flag("pa", "pull_aggregate", "Pull form from an Aggregate instance");
-  private static final Param<String> ODK_USERNAME = Param.arg("u", "odk_username", "ODK Username");
-  private static final Param<String> ODK_PASSWORD = Param.arg("p", "odk_password", "ODK Password");
-  private static final Param<String> AGGREGATE_SERVER = Param.arg("url", "aggregate_url", "Aggregate server URL");
 
   public static Operation PULL_FORM_FROM_AGGREGATE = Operation.of(
       PULL_AGGREGATE,

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -37,7 +37,8 @@ import org.slf4j.LoggerFactory;
 
 public class PullFormFromAggregate {
   private static final Logger log = LoggerFactory.getLogger(PullFormFromAggregate.class);
-  private static final Param<Void> PULL_AGGREGATE = Param.flag("pa", "pull_aggregate", "Pull form from an Aggregate instance");
+  public static final Param<Void> DEPRECATED_PULL_AGGREGATE = Param.flag("pa", "pull_aggregate", "Pull form from an Aggregate instance");
+  private static final Param<Void> PULL_AGGREGATE = Param.flag("plla", "pull_aggregate", "Pull form from an Aggregate instance");
 
   public static Operation PULL_FORM_FROM_AGGREGATE = Operation.of(
       PULL_AGGREGATE,

--- a/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.opendatakit.briefcase.operations;
+
+import static org.opendatakit.briefcase.operations.Common.FORM_ID;
+import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
+import static org.opendatakit.briefcase.operations.Common.bootCache;
+
+import java.util.Arrays;
+import java.util.Optional;
+import org.opendatakit.briefcase.model.FormStatus;
+import org.opendatakit.briefcase.model.ServerConnectionInfo;
+import org.opendatakit.briefcase.util.FileSystemUtils;
+import org.opendatakit.briefcase.util.ServerConnectionTest;
+import org.opendatakit.briefcase.util.TransferToServer;
+import org.opendatakit.common.cli.Operation;
+import org.opendatakit.common.cli.Param;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PushFormToAggregate {
+  private static final Logger log = LoggerFactory.getLogger(PushFormToAggregate.class);
+  private static final Param<Void> PUSH_AGGREGATE = Param.flag("psha", "push_aggregate", "Push form to an Aggregate instance");
+  private static final Param<String> ODK_USERNAME = Param.arg("u", "odk_username", "ODK Username");
+  private static final Param<String> ODK_PASSWORD = Param.arg("p", "odk_password", "ODK Password");
+  private static final Param<String> AGGREGATE_SERVER = Param.arg("url", "aggregate_url", "Aggregate server URL");
+
+  public static Operation PUSH_FORM_TO_AGGREGATE = Operation.of(
+      PUSH_AGGREGATE,
+      args -> pushFormToAggregate(
+          args.get(STORAGE_DIR),
+          args.get(FORM_ID),
+          args.get(ODK_USERNAME),
+          args.get(ODK_PASSWORD),
+          args.get(AGGREGATE_SERVER)
+      ),
+      Arrays.asList(STORAGE_DIR, FORM_ID, ODK_USERNAME, ODK_PASSWORD, AGGREGATE_SERVER)
+  );
+
+  private static void pushFormToAggregate(String storageDir, String formid, String username, String password, String server) {
+    CliEventsCompanion.attach(log);
+    bootCache(storageDir);
+    Optional<FormStatus> maybeFormStatus = FileSystemUtils.getBriefcaseFormList().stream()
+        .filter(form -> form.getFormId().equals(formid))
+        .map(formDef -> new FormStatus(FormStatus.TransferType.UPLOAD, formDef))
+        .findFirst();
+
+    FormStatus form = maybeFormStatus.orElseThrow(() -> new FormNotFoundException(formid));
+
+    ServerConnectionInfo transferSettings = new ServerConnectionInfo(server, username, password.toCharArray());
+
+    ServerConnectionTest.testPush(transferSettings);
+
+    TransferToServer.push(transferSettings, form);
+  }
+
+}

--- a/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
@@ -15,7 +15,10 @@
  */
 package org.opendatakit.briefcase.operations;
 
+import static org.opendatakit.briefcase.operations.Common.AGGREGATE_SERVER;
 import static org.opendatakit.briefcase.operations.Common.FORM_ID;
+import static org.opendatakit.briefcase.operations.Common.ODK_PASSWORD;
+import static org.opendatakit.briefcase.operations.Common.ODK_USERNAME;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 import static org.opendatakit.briefcase.operations.Common.bootCache;
 
@@ -34,9 +37,6 @@ import org.slf4j.LoggerFactory;
 public class PushFormToAggregate {
   private static final Logger log = LoggerFactory.getLogger(PushFormToAggregate.class);
   private static final Param<Void> PUSH_AGGREGATE = Param.flag("psha", "push_aggregate", "Push form to an Aggregate instance");
-  private static final Param<String> ODK_USERNAME = Param.arg("u", "odk_username", "ODK Username");
-  private static final Param<String> ODK_PASSWORD = Param.arg("p", "odk_password", "ODK Password");
-  private static final Param<String> AGGREGATE_SERVER = Param.arg("url", "aggregate_url", "Aggregate server URL");
 
   public static Operation PUSH_FORM_TO_AGGREGATE = Operation.of(
       PUSH_AGGREGATE,

--- a/src/org/opendatakit/briefcase/reused/BriefcaseException.java
+++ b/src/org/opendatakit/briefcase/reused/BriefcaseException.java
@@ -1,9 +1,11 @@
 package org.opendatakit.briefcase.reused;
 
 public class BriefcaseException extends RuntimeException {
-  public final String message;
-
   public BriefcaseException(String message) {
-    this.message = message;
+    super(message);
+  }
+
+  public BriefcaseException(String message, Throwable cause) {
+    super(message, cause);
   }
 }

--- a/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
+++ b/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
@@ -81,7 +81,7 @@ public class BriefcaseCLI {
             Optional.ofNullable(pemKeyFile).map(Paths::get)
         );
     } catch (BriefcaseException e) {
-      System.err.println("Error: " + e.message);
+      System.err.println("Error: " + e.getMessage());
       log.error("Error", e);
       System.exit(1);
     } catch (Throwable t) {

--- a/src/org/opendatakit/briefcase/util/PushFromServerException.java
+++ b/src/org/opendatakit/briefcase/util/PushFromServerException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.opendatakit.briefcase.util;
+
+import static java.util.stream.Collectors.joining;
+
+import java.util.List;
+import org.opendatakit.briefcase.model.FormStatus;
+import org.opendatakit.briefcase.reused.BriefcaseException;
+
+public class PushFromServerException extends BriefcaseException {
+  public PushFromServerException(List<FormStatus> forms) {
+    super("Failure pushing forms to server. FormIds: " + forms.stream().map(f -> f.getFormDefinition().getFormId()).collect(joining(", ")));
+  }
+}

--- a/src/org/opendatakit/briefcase/util/ServerConnectionTest.java
+++ b/src/org/opendatakit/briefcase/util/ServerConnectionTest.java
@@ -42,6 +42,13 @@ public class ServerConnectionTest implements Runnable {
       throw new ServerConnectionTestException();
   }
 
+  public static void testPush(ServerConnectionInfo transferSettings) {
+    ServerConnectionTest test = new ServerConnectionTest(transferSettings, new TerminationFuture(), true);
+    test.run();
+    if (!test.isSuccessful())
+      throw new ServerConnectionTestException();
+  }
+
   @Override
   public void run() {
     try {

--- a/src/org/opendatakit/briefcase/util/TransferToServer.java
+++ b/src/org/opendatakit/briefcase/util/TransferToServer.java
@@ -16,11 +16,15 @@
 
 package org.opendatakit.briefcase.util;
 
+import java.util.Arrays;
 import java.util.List;
 
+import org.bushe.swing.event.EventBus;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.ServerConnectionInfo;
 import org.opendatakit.briefcase.model.TerminationFuture;
+import org.opendatakit.briefcase.model.TransferFailedEvent;
+import org.opendatakit.briefcase.model.TransferSucceededEvent;
 
 public class TransferToServer implements ITransferToDestAction {
   ServerConnectionInfo destServerInfo;
@@ -39,6 +43,23 @@ public class TransferToServer implements ITransferToDestAction {
     ServerUploader uploader = new ServerUploader(destServerInfo, terminationFuture);
     
     return uploader.uploadFormAndSubmissionFiles( formsToTransfer);
+  }
+
+  public static void push(ServerConnectionInfo transferSettings, FormStatus... forms) {
+    List<FormStatus> formList = Arrays.asList(forms);
+    TransferToServer action = new TransferToServer(transferSettings, new TerminationFuture(), formList);
+
+    try {
+      boolean allSuccessful = action.doAction();
+      if (allSuccessful)
+        EventBus.publish(new TransferSucceededEvent(false, formList, transferSettings));
+
+      if (!allSuccessful)
+        throw new PushFromServerException(formList);
+    } catch (Exception e) {
+      EventBus.publish(new TransferFailedEvent(false, formList));
+      throw new PushFromServerException(formList);
+    }
   }
 
   @Override

--- a/src/org/opendatakit/common/cli/Cli.java
+++ b/src/org/opendatakit/common/cli/Cli.java
@@ -54,6 +54,17 @@ public class Cli {
     register(Operation.of(SHOW_VERSION, args -> printVersion()));
   }
 
+  /**
+   * Marks a Param for deprecation and assigns an alternative operation.
+   *
+   * When Briefcase detects this param, it will show a message, output the help and
+   * exit with a non-zero status
+   *
+   * @param oldParam the {@link Param} to mark as deprecated
+   * @param alternative the alternative {@link Operation} that Briefcase will suggest to be
+   *                    used instead of the deprecated Param
+   * @return self {@link Cli} instance to chain more method calls
+   */
   public Cli deprecate(Param<?> oldParam, Operation alternative) {
     operations.add(Operation.of(oldParam, __ -> {
       log.warn("Trying to run deprecated param -{}", oldParam.shortCode);
@@ -158,8 +169,8 @@ public class Cli {
   private void checkForMissingParams(CommandLine cli, Set<Param> paramsToCheck) {
     Set<Param> missingParams = paramsToCheck.stream().filter(param -> !cli.hasOption(param.shortCode)).collect(toSet());
     if (!missingParams.isEmpty()) {
-      System.out.printf("Missing params: ");
-      System.out.printf(missingParams.stream().map(param -> "-" + param.shortCode).collect(joining(", ")));
+      System.out.print("Missing params: ");
+      System.out.print(missingParams.stream().map(param -> "-" + param.shortCode).collect(joining(", ")));
       System.out.println("");
       printHelp(requiredOperations, operations);
       System.exit(1);

--- a/src/org/opendatakit/common/cli/Cli.java
+++ b/src/org/opendatakit/common/cli/Cli.java
@@ -103,7 +103,7 @@ public class Cli {
       if (executedOperations.isEmpty())
         otherwiseRunnables.forEach(Runnable::run);
     } catch (BriefcaseException e) {
-      System.err.println("Error: " + e.message);
+      System.err.println("Error: " + e.getMessage());
       log.error("Error", e);
       System.exit(1);
     } catch (Throwable t) {

--- a/src/org/opendatakit/common/cli/Cli.java
+++ b/src/org/opendatakit/common/cli/Cli.java
@@ -54,6 +54,16 @@ public class Cli {
     register(Operation.of(SHOW_VERSION, args -> printVersion()));
   }
 
+  public Cli deprecate(Param<?> oldParam, Operation alternative) {
+    operations.add(Operation.of(oldParam, __ -> {
+      log.warn("Trying to run deprecated param -{}", oldParam.shortCode);
+      System.out.println("The param -" + oldParam.shortCode + " has been deprecated. Run Briefcase again with -" + alternative.param.shortCode + " instead");
+      printHelp(requiredOperations, operations);
+      System.exit(1);
+    }));
+    return this;
+  }
+
   /**
    * Register an {@link Operation}
    *


### PR DESCRIPTION
Closes #20

#### What has been done to verify that this works as intended?
Manually executed the new CLI operation forcing errors (wrong form_id, wrong credentials, etc.) and actually getting some forms to my GAE instance

Manually executed `-pa` flag and veryfied that it outputs the expected messages and that exits with a non-zero status

#### Why is this the best possible solution? Were any other approaches considered?
This solution mirrors what we are currently doing for pushing forms.

#### Are there any risks to merging this code? If so, what are they?
This PR deprecates `-pa` flag in favor of `-plla` to be more symetric with `-psha`.

Running Briefcase with `-pa` will show a message, show help and exit with non-zero status:
```
The param -pa has been deprecated. Run Briefcase again with -plla instead
```