### PR TITLE
Issue 423 alphanumeric form versions

### DIFF
--- a/src/org/opendatakit/aggregate/form/XFormParameters.java
+++ b/src/org/opendatakit/aggregate/form/XFormParameters.java
@@ -67,20 +67,17 @@ public final class XFormParameters implements Comparable<XFormParameters>, Seria
   }
 
   @Override
-  public int compareTo(XFormParameters p) {
-    int cmp = formId.compareTo(p.formId);
+  public int compareTo(XFormParameters other) {
+    int cmp = formId.compareTo(other.formId);
     if (cmp != 0)
       return cmp;
-    if (((modelVersion == null) ? (p.modelVersion == null) :
-        (p.modelVersion != null && modelVersion.equals(p.modelVersion)))) {
-      // uiVersion is ignored during comparisons and equality tests
+    if (modelVersion != null && other.modelVersion != null)
+      return modelVersion.compareTo(other.modelVersion);
+    if (modelVersion == null && other.modelVersion == null)
       return 0;
-    } else if (modelVersion == null) {
+    if (modelVersion == null)
       return 1;
-    } else if (p.modelVersion == null) {
-      return -1;
-    } else {
-      return modelVersion.compareTo(p.modelVersion);
-    }
+    // Implies: p.modelVersion == null
+    return -1;
   }
 }

--- a/src/org/opendatakit/aggregate/form/XFormParameters.java
+++ b/src/org/opendatakit/aggregate/form/XFormParameters.java
@@ -16,6 +16,7 @@
 package org.opendatakit.aggregate.form;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Helper class holding the details of a
@@ -41,29 +42,28 @@ public final class XFormParameters implements Comparable<Object>, Serializable {
 
   @Override
   public String toString() {
-    // TODO Replace with IntelliJ's templated toString()
-    return "XFormParameters[formId=" + formId + " and version=" +
-        (modelVersion == null ? "null" : modelVersion) +
-        " and uiVersion=null]";
+    return "XFormParameters{" +
+        "formId='" + formId + '\'' +
+        ", versionString='" + versionString + '\'' +
+        ", modelVersion='" + modelVersion + '\'' +
+        '}';
   }
 
   @Override
-  // TODO Replace with Objects.equals()
-  public boolean equals(Object obj) {
-    if (obj == null || !(obj instanceof XFormParameters))
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
       return false;
-    XFormParameters p = (XFormParameters) obj;
-    // uiVersion is ignored during equality tests...
-    return formId.equals(p.formId) &&
-        ((modelVersion == null) ? p.modelVersion == null :
-            ((p.modelVersion != null) && modelVersion.equals(p.modelVersion)));
+    XFormParameters that = (XFormParameters) o;
+    return Objects.equals(formId, that.formId) &&
+        Objects.equals(versionString, that.versionString) &&
+        Objects.equals(modelVersion, that.modelVersion);
   }
 
   @Override
   public int hashCode() {
-    // TODO Replace with Objects.hash()
-    return Long.valueOf(formId.hashCode() +
-        ((modelVersion == null) ? 20480L : modelVersion.hashCode())).hashCode();
+    return Objects.hash(formId, versionString, modelVersion);
   }
 
   @Override

--- a/src/org/opendatakit/aggregate/form/XFormParameters.java
+++ b/src/org/opendatakit/aggregate/form/XFormParameters.java
@@ -28,7 +28,7 @@ public final class XFormParameters implements Comparable<Object>, Serializable {
 
   public final String formId;
   public final String versionString;
-  public final Long modelVersion;
+  public final String modelVersion;
 
   public XFormParameters(String formId, String versionString) {
     if (formId == null) {
@@ -36,17 +36,19 @@ public final class XFormParameters implements Comparable<Object>, Serializable {
     }
     this.formId = formId;
     this.versionString = (versionString == null || versionString.length() == 0) ? null : versionString;
-    this.modelVersion = (this.versionString == null) ? null : Long.valueOf(versionString);
+    this.modelVersion = this.versionString;
   }
 
   @Override
   public String toString() {
+    // TODO Replace with IntelliJ's templated toString()
     return "XFormParameters[formId=" + formId + " and version=" +
-        (modelVersion == null ? "null" : Long.toString(modelVersion)) +
+        (modelVersion == null ? "null" : modelVersion) +
         " and uiVersion=null]";
   }
 
   @Override
+  // TODO Replace with Objects.equals()
   public boolean equals(Object obj) {
     if (obj == null || !(obj instanceof XFormParameters))
       return false;
@@ -59,8 +61,9 @@ public final class XFormParameters implements Comparable<Object>, Serializable {
 
   @Override
   public int hashCode() {
+    // TODO Replace with Objects.hash()
     return Long.valueOf(formId.hashCode() +
-        ((modelVersion == null) ? 20480L : 37 * modelVersion)).hashCode();
+        ((modelVersion == null) ? 20480L : modelVersion.hashCode())).hashCode();
   }
 
   @Override

--- a/src/org/opendatakit/aggregate/form/XFormParameters.java
+++ b/src/org/opendatakit/aggregate/form/XFormParameters.java
@@ -18,76 +18,78 @@ package org.opendatakit.aggregate.form;
 import java.io.Serializable;
 
 /**
- * Helper class holding the details of a 
+ * Helper class holding the details of a
  * specific version of a form.
- * 
+ *
  * @author mitchellsundt@gmail.com
  * @author wbrunette@gmail.com
- * 
  */
 public final class XFormParameters implements Comparable<Object>, Serializable {
 
-    public final String formId;
-    public final String versionString;
-    public final Long modelVersion;
+  public final String formId;
+  public final String versionString;
+  public final Long modelVersion;
 
-    public XFormParameters(String formId, String versionString) {
-        if ( formId == null ) {
-            throw new IllegalArgumentException("formId cannot be null");
-        }
-        this.formId = formId;
-        this.versionString = (versionString == null || versionString.length() == 0) ? null : versionString;
-        this.modelVersion = (this.versionString == null) ? null : Long.valueOf(versionString);
+  public XFormParameters(String formId, String versionString) {
+    if (formId == null) {
+      throw new IllegalArgumentException("formId cannot be null");
     }
+    this.formId = formId;
+    this.versionString = (versionString == null || versionString.length() == 0) ? null : versionString;
+    this.modelVersion = (this.versionString == null) ? null : Long.valueOf(versionString);
+  }
 
-   public XFormParameters(String formId, Long modelVersion) {
-      if ( formId == null ) {
-         throw new IllegalArgumentException("formId cannot be null");
-      }
-      this.formId = formId;
-      this.versionString = null;
-      this.modelVersion = modelVersion;
-   }
-
-    @Override
-    public String toString() {
-        return "XFormParameters[formId=" + formId + " and version=" +
-                    (modelVersion == null ? "null" : Long.toString(modelVersion)) +
-                    " and uiVersion=null]";
+  public XFormParameters(String formId, Long modelVersion) {
+    if (formId == null) {
+      throw new IllegalArgumentException("formId cannot be null");
     }
+    this.formId = formId;
+    this.versionString = null;
+    this.modelVersion = modelVersion;
+  }
 
-    @Override
-    public boolean equals(Object obj) {
-        if ( obj == null || !(obj instanceof XFormParameters) ) return false;
-        XFormParameters p = (XFormParameters) obj;
-        // uiVersion is ignored during equality tests...
-        return formId.equals(p.formId) &&
-            ((modelVersion == null) ? p.modelVersion == null :
-                ((p.modelVersion != null) && modelVersion.equals(p.modelVersion)));
-    }
+  @Override
+  public String toString() {
+    return "XFormParameters[formId=" + formId + " and version=" +
+        (modelVersion == null ? "null" : Long.toString(modelVersion)) +
+        " and uiVersion=null]";
+  }
 
-    @Override
-    public int hashCode() {
-        return Long.valueOf(formId.hashCode() +
-                ((modelVersion == null) ? 20480L : 37 * modelVersion)).hashCode();
-    }
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null || !(obj instanceof XFormParameters))
+      return false;
+    XFormParameters p = (XFormParameters) obj;
+    // uiVersion is ignored during equality tests...
+    return formId.equals(p.formId) &&
+        ((modelVersion == null) ? p.modelVersion == null :
+            ((p.modelVersion != null) && modelVersion.equals(p.modelVersion)));
+  }
 
-    @Override
-    public int compareTo(Object obj) {
-        if ( obj == null || !(obj instanceof XFormParameters) ) return -1;
-        XFormParameters p = (XFormParameters) obj;
-        int cmp = formId.compareTo(p.formId);
-        if ( cmp != 0 ) return cmp;
-        if ( ((modelVersion == null) ? (p.modelVersion == null) :
-                (p.modelVersion != null && modelVersion.equals(p.modelVersion))) ) {
-            // uiVersion is ignored during comparisons and equality tests
-            return 0;
-        } else if ( modelVersion == null ) {
-            return 1;
-        } else if ( p.modelVersion == null ) {
-            return -1;
-        } else {
-            return modelVersion.compareTo(p.modelVersion);
-        }
+  @Override
+  public int hashCode() {
+    return Long.valueOf(formId.hashCode() +
+        ((modelVersion == null) ? 20480L : 37 * modelVersion)).hashCode();
+  }
+
+  @Override
+  public int compareTo(Object obj) {
+    if (obj == null || !(obj instanceof XFormParameters))
+      return -1;
+    XFormParameters p = (XFormParameters) obj;
+    int cmp = formId.compareTo(p.formId);
+    if (cmp != 0)
+      return cmp;
+    if (((modelVersion == null) ? (p.modelVersion == null) :
+        (p.modelVersion != null && modelVersion.equals(p.modelVersion)))) {
+      // uiVersion is ignored during comparisons and equality tests
+      return 0;
+    } else if (modelVersion == null) {
+      return 1;
+    } else if (p.modelVersion == null) {
+      return -1;
+    } else {
+      return modelVersion.compareTo(p.modelVersion);
     }
+  }
 }

--- a/src/org/opendatakit/aggregate/form/XFormParameters.java
+++ b/src/org/opendatakit/aggregate/form/XFormParameters.java
@@ -25,7 +25,7 @@ import java.util.Objects;
  * @author mitchellsundt@gmail.com
  * @author wbrunette@gmail.com
  */
-public final class XFormParameters implements Comparable<Object>, Serializable {
+public final class XFormParameters implements Comparable<XFormParameters>, Serializable {
 
   public final String formId;
   public final String versionString;
@@ -67,10 +67,7 @@ public final class XFormParameters implements Comparable<Object>, Serializable {
   }
 
   @Override
-  public int compareTo(Object obj) {
-    if (obj == null || !(obj instanceof XFormParameters))
-      return -1;
-    XFormParameters p = (XFormParameters) obj;
+  public int compareTo(XFormParameters p) {
     int cmp = formId.compareTo(p.formId);
     if (cmp != 0)
       return cmp;

--- a/src/org/opendatakit/aggregate/form/XFormParameters.java
+++ b/src/org/opendatakit/aggregate/form/XFormParameters.java
@@ -39,15 +39,6 @@ public final class XFormParameters implements Comparable<Object>, Serializable {
     this.modelVersion = (this.versionString == null) ? null : Long.valueOf(versionString);
   }
 
-  public XFormParameters(String formId, Long modelVersion) {
-    if (formId == null) {
-      throw new IllegalArgumentException("formId cannot be null");
-    }
-    this.formId = formId;
-    this.versionString = null;
-    this.modelVersion = modelVersion;
-  }
-
   @Override
   public String toString() {
     return "XFormParameters[formId=" + formId + " and version=" +

--- a/src/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -562,8 +562,7 @@ public class BaseFormParserForJavaRosa implements Serializable {
             Reason.ID_MISSING);
       }
     }
-    if (!allowLegacy && rootElementDefn.modelVersion != null
-        && (rootElementDefn.modelVersion > Long.valueOf(Integer.MAX_VALUE))) {
+    if (!allowLegacy && rootElementDefn.modelVersion != null) {
       // for some reason, the datastore is not persisting Long values correctly?
       throw new ODKIncompleteSubmissionData(
           "The version string must be an integer less than 2147483648", Reason.ID_MALFORMED);

--- a/src/org/opendatakit/briefcase/util/FileSystemUtils.java
+++ b/src/org/opendatakit/briefcase/util/FileSystemUtils.java
@@ -600,7 +600,7 @@ public class FileSystemUtils {
     StringBuilder b = new StringBuilder();
     appendElementSignatureSource(b, fim.xparam.formId);
     if (fim.xparam.modelVersion != null) {
-      appendElementSignatureSource(b, Long.toString(fim.xparam.modelVersion));
+      appendElementSignatureSource(b, fim.xparam.modelVersion);
     }
     appendElementSignatureSource(b, base64EncryptedSymmetricKey);
 

--- a/test/java/org/opendatakit/aggregate/form/XFormParametersTest.java
+++ b/test/java/org/opendatakit/aggregate/form/XFormParametersTest.java
@@ -1,62 +1,90 @@
 package org.opendatakit.aggregate.form;
 
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.opendatakit.aggregate.form.XFormParametersTest.MatcherProvider.EQUAL_TO;
+import static org.opendatakit.aggregate.form.XFormParametersTest.MatcherProvider.GREATER_THAN;
+import static org.opendatakit.aggregate.form.XFormParametersTest.MatcherProvider.LESS_THAN;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Function;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(value = Parameterized.class)
 public class XFormParametersTest {
-  XFormParameters aa = new XFormParameters("a", "a");
-  XFormParameters ab = new XFormParameters("a", "b");
-  XFormParameters aNull = new XFormParameters("a", null);
-  XFormParameters aEmpty = new XFormParameters("a", "");
-  XFormParameters ba = new XFormParameters("b", "a");
+  private static final XFormParameters formAVersionA = new XFormParameters("a", "a");
+  private static final XFormParameters formAVersionB = new XFormParameters("a", "b");
+  private static final XFormParameters formAVersionNull = new XFormParameters("a", null);
+  private static final XFormParameters formAVersionEmpty = new XFormParameters("a", "");
+  private static final XFormParameters formBVersionA = new XFormParameters("b", "a");
+
+  @Parameterized.Parameter(value = 0)
+  public String testCase;
+
+  @Parameterized.Parameter(value = 1)
+  public XFormParameters left;
+
+  @Parameterized.Parameter(value = 2)
+  public XFormParameters right;
+
+  @Parameterized.Parameter(value = 3)
+  // We can't use a method reference with Parameterized members
+  // That's why we need the enum
+  public MatcherProvider matcherProvider;
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+        {"{a, a} is equal to {a, a}", formAVersionA, formAVersionA, EQUAL_TO},
+        {"{a, a} is less than {a, a}", formAVersionA, formAVersionB, LESS_THAN},
+        {"{a, b} is greater than {a, b}", formAVersionB, formAVersionA, GREATER_THAN},
+        {"{a, a} is less than {a, a}", formAVersionA, formAVersionNull, LESS_THAN},
+        {"{a, null} is greater than {a, null}", formAVersionNull, formAVersionA, GREATER_THAN},
+        {"{a, a} is less than {a, a}", formAVersionA, formAVersionEmpty, LESS_THAN},
+        {"{a, empty} is greater than {a, empty}", formAVersionEmpty, formAVersionA, GREATER_THAN},
+        {"{a, a} is less than {a, a}", formAVersionA, formBVersionA, LESS_THAN},
+        {"{b, a} is greater than {b, a}", formBVersionA, formAVersionA, GREATER_THAN},
+        {"{a, b} is equal to {a, b}", formAVersionB, formAVersionB, EQUAL_TO},
+        {"{a, b} is less than {a, b}", formAVersionB, formAVersionNull, LESS_THAN},
+        {"{a, null} is greater than {a, null}", formAVersionNull, formAVersionB, GREATER_THAN},
+        {"{a, b} is less than {a, b}", formAVersionB, formAVersionEmpty, LESS_THAN},
+        {"{a, empty} is greater than {a, empty}", formAVersionEmpty, formAVersionB, GREATER_THAN},
+        {"{a, b} is less than {a, b}", formAVersionB, formBVersionA, LESS_THAN},
+        {"{b, a} is greater than {b, a}", formBVersionA, formAVersionB, GREATER_THAN},
+        {"{a, null} is equal to {a, null}", formAVersionNull, formAVersionNull, EQUAL_TO},
+        {"{a, null} is equal to {a, null}", formAVersionNull, formAVersionEmpty, EQUAL_TO},
+        {"{a, empty} is equal to {a, empty}", formAVersionEmpty, formAVersionNull, EQUAL_TO},
+        {"{a, null} is less than {a, null}", formAVersionNull, formBVersionA, LESS_THAN},
+        {"{b, a} is greater than {b, a}", formBVersionA, formAVersionNull, GREATER_THAN},
+        {"{a, empty} is equal to {a, empty}", formAVersionEmpty, formAVersionEmpty, EQUAL_TO},
+        {"{a, empty} is less than {a, empty}", formAVersionEmpty, formBVersionA, LESS_THAN},
+        {"{b, a} is greater than {b, a}", formBVersionA, formAVersionEmpty, GREATER_THAN},
+        {"{b, a} is equal to {b, a}", formBVersionA, formBVersionA, EQUAL_TO}
+    });
+  }
 
   @Test
   public void compareTo() {
-    // aa
-    assertThat(aa.compareTo(aa), is(0));
+    assertThat(left, matcherProvider.apply(right));
+  }
 
-    assertThat(aa.compareTo(ab), is(-1));
-    assertThat(ab.compareTo(aa), is(1));
+  public enum MatcherProvider {
+    EQUAL_TO(Matchers::comparesEqualTo),
+    GREATER_THAN(Matchers::greaterThan),
+    LESS_THAN(Matchers::lessThan);
 
-    assertThat(aa.compareTo(aNull), is(-1));
-    assertThat(aNull.compareTo(aa), is(1));
+    private final Function<XFormParameters, Matcher<XFormParameters>> matcherProvider;
 
-    assertThat(aa.compareTo(aEmpty), is(-1));
-    assertThat(aEmpty.compareTo(aa), is(1));
+    MatcherProvider(Function<XFormParameters, Matcher<XFormParameters>> matcherProvider) {
+      this.matcherProvider = matcherProvider;
+    }
 
-    assertThat(aa.compareTo(ba), is(-1));
-    assertThat(ba.compareTo(aa), is(1));
-
-    // ab
-    assertThat(ab.compareTo(ab), is(0));
-
-    assertThat(ab.compareTo(aNull), is(-1));
-    assertThat(aNull.compareTo(ab), is(1));
-
-    assertThat(ab.compareTo(aEmpty), is(-1));
-    assertThat(aEmpty.compareTo(ab), is(1));
-
-    assertThat(ab.compareTo(ba), is(-1));
-    assertThat(ba.compareTo(ab), is(1));
-
-    // aNull
-    assertThat(aNull.compareTo(aNull), is(0));
-
-    assertThat(aNull.compareTo(aEmpty), is(0));
-    assertThat(aEmpty.compareTo(aNull), is(0));
-
-    assertThat(aNull.compareTo(ba), is(-1));
-    assertThat(ba.compareTo(aNull), is(1));
-
-    // aEmpty
-    assertThat(aEmpty.compareTo(aEmpty), is(0));
-
-    assertThat(aEmpty.compareTo(ba), is(-1));
-    assertThat(ba.compareTo(aEmpty), is(1));
-
-    // ba
-    assertThat(ba.compareTo(ba), is(0));
+    public Matcher<XFormParameters> apply(XFormParameters value) {
+      return matcherProvider.apply(value);
+    }
   }
 }

--- a/test/java/org/opendatakit/aggregate/form/XFormParametersTest.java
+++ b/test/java/org/opendatakit/aggregate/form/XFormParametersTest.java
@@ -1,0 +1,62 @@
+package org.opendatakit.aggregate.form;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class XFormParametersTest {
+  XFormParameters aa = new XFormParameters("a", "a");
+  XFormParameters ab = new XFormParameters("a", "b");
+  XFormParameters aNull = new XFormParameters("a", null);
+  XFormParameters aEmpty = new XFormParameters("a", "");
+  XFormParameters ba = new XFormParameters("b", "a");
+
+  @Test
+  public void compareTo() {
+    // aa
+    assertThat(aa.compareTo(aa), is(0));
+
+    assertThat(aa.compareTo(ab), is(-1));
+    assertThat(ab.compareTo(aa), is(1));
+
+    assertThat(aa.compareTo(aNull), is(-1));
+    assertThat(aNull.compareTo(aa), is(1));
+
+    assertThat(aa.compareTo(aEmpty), is(-1));
+    assertThat(aEmpty.compareTo(aa), is(1));
+
+    assertThat(aa.compareTo(ba), is(-1));
+    assertThat(ba.compareTo(aa), is(1));
+
+    // ab
+    assertThat(ab.compareTo(ab), is(0));
+
+    assertThat(ab.compareTo(aNull), is(-1));
+    assertThat(aNull.compareTo(ab), is(1));
+
+    assertThat(ab.compareTo(aEmpty), is(-1));
+    assertThat(aEmpty.compareTo(ab), is(1));
+
+    assertThat(ab.compareTo(ba), is(-1));
+    assertThat(ba.compareTo(ab), is(1));
+
+    // aNull
+    assertThat(aNull.compareTo(aNull), is(0));
+
+    assertThat(aNull.compareTo(aEmpty), is(0));
+    assertThat(aEmpty.compareTo(aNull), is(0));
+
+    assertThat(aNull.compareTo(ba), is(-1));
+    assertThat(ba.compareTo(aNull), is(1));
+
+    // aEmpty
+    assertThat(aEmpty.compareTo(aEmpty), is(0));
+
+    assertThat(aEmpty.compareTo(ba), is(-1));
+    assertThat(ba.compareTo(aEmpty), is(1));
+
+    // ba
+    assertThat(ba.compareTo(ba), is(0));
+  }
+}

--- a/test/java/org/opendatakit/briefcase/model/BriefcaseFormDefinitionTest.java
+++ b/test/java/org/opendatakit/briefcase/model/BriefcaseFormDefinitionTest.java
@@ -1,6 +1,5 @@
 package org.opendatakit.briefcase.model;
 
-
 import static java.nio.file.Files.createTempDirectory;
 import static java.nio.file.Files.delete;
 import static java.nio.file.Files.readAllBytes;

--- a/test/java/org/opendatakit/briefcase/model/BriefcaseFormDefinitionTest.java
+++ b/test/java/org/opendatakit/briefcase/model/BriefcaseFormDefinitionTest.java
@@ -1,0 +1,68 @@
+package org.opendatakit.briefcase.model;
+
+
+import static java.nio.file.Files.createTempDirectory;
+import static java.nio.file.Files.delete;
+import static java.nio.file.Files.readAllBytes;
+import static java.nio.file.Files.write;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.opendatakit.briefcase.ui.SwingTestRig.classPath;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.opendatakit.briefcase.util.BadFormDefinition;
+
+@RunWith(value = Parameterized.class)
+public class BriefcaseFormDefinitionTest {
+  @Parameterized.Parameter(value = 0)
+  public String testCase;
+
+  @Parameterized.Parameter(value = 1)
+  public String expectedVersion;
+  private Path formsDir;
+  private Path form;
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+        {"Null version", null},
+        {"Numeric version", "1"},
+        {"Alphanumeric version", "vHG9gooNbDqA2DxdU9cP5Q"},
+    });
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    formsDir = createTempDirectory("briefcase_test");
+    form = formsDir.resolve("form.xml");
+    String tpl = new String(readAllBytes(classPath("org/opendatakit/aggregate/parser/test-version.tpl.xml")), Charset.defaultCharset());
+    write(form, String.format(
+        tpl,
+        expectedVersion != null ? "version=\"" + expectedVersion + "\"" : ""
+    ).getBytes());
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    delete(form);
+    delete(formsDir);
+  }
+
+  @Test
+  public void accepts_null_version() throws BadFormDefinition {
+    BriefcaseFormDefinition bfd = new BriefcaseFormDefinition(form.getParent().toFile(), form.toFile());
+
+    assertThat(bfd.getVersionString(), is(expectedVersion));
+  }
+
+
+}

--- a/test/java/org/opendatakit/briefcase/ui/SwingTestRig.java
+++ b/test/java/org/opendatakit/briefcase/ui/SwingTestRig.java
@@ -50,7 +50,8 @@ public class SwingTestRig {
   }
 
   public static Path classPath(String location) {
-    return Paths.get(uncheckedURLtoURI(SwingTestRig.class.getResource(location)));
+    String absoluteLocation = location.startsWith("/") ? location : "/" + location;
+    return Paths.get(uncheckedURLtoURI(SwingTestRig.class.getResource(absoluteLocation)));
   }
 
   public static void createInMemoryCache() {

--- a/test/resources/org/opendatakit/aggregate/parser/test-version.tpl.xml
+++ b/test/resources/org/opendatakit/aggregate/parser/test-version.tpl.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+  <h:head>
+    <h:title>test versions</h:title>
+    <model>
+      <instance>
+        <data id="test-versions" %s>
+          <name/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </data>
+      </instance>
+      <bind nodeset="/data/name" type="string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/data/name">
+      <label>name</label>
+    </input>
+  </h:body>
+</h:html>


### PR DESCRIPTION
Closes #423 


#### What has been done to verify that this works as intended?
Created new unit tests that verify the change in behavior:
- A new test that parses an XForm with different version values (null, numeric and alphanumeric)
- (collateral) A new test that shows and verifies `XFormParameters.compareTo()` method

Also installed manually a form with alphanumeric version into Briefcase's storage directory and checked that Briefcase launches and is able to export the form. This is the form I've used: 
[alphanumericversion.xml.txt](https://github.com/opendatakit/briefcase/files/1871367/alphanumericversion.xml.txt)

Tested pulling and pushing forms with alphanumeric versions from/to a Kobo server.

#### Why is this the best possible solution? Were any other approaches considered?
This is the smallest change I could think of: just avoid making any type change of the incoming version string.

#### Are there any risks to merging this code? If so, what are they?
None I can't think of. This change relaxes prior constraints.