### PR TITLE
Issue 401 sentry sensitive info

### DIFF
--- a/src/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -125,12 +125,13 @@ public class BaseFormParserForJavaRosa implements Serializable {
 
   private static void redirectOutput() {
     File jrLogFile = new File(new StorageLocation().getBriefcaseFolder(), ".briefcase-javarosa.log");
+    log.info("Redirecting javarosa output to {}", jrLogFile);
     try {
       PrintStream jrOut = new PrintStream(jrLogFile);
       Std.setOut(jrOut);
       Std.setErr(jrOut);
     } catch (FileNotFoundException e) {
-      log.warn("failed to redirect javarosa output to " + jrLogFile);
+      log.warn("Failed to redirect javarosa output");
     }
   }
 

--- a/src/org/opendatakit/briefcase/model/XmlDocumentFetchException.java
+++ b/src/org/opendatakit/briefcase/model/XmlDocumentFetchException.java
@@ -17,13 +17,13 @@
 package org.opendatakit.briefcase.model;
 
 public class XmlDocumentFetchException extends Exception {
-
-  /**
-   * 
-   */
   private static final long serialVersionUID = -2163850446028219296L;
 
   public XmlDocumentFetchException(String message) {
     super(message);
+  }
+
+  public XmlDocumentFetchException(String message, Throwable cause) {
+    super(message, cause);
   }
 }

--- a/src/org/opendatakit/briefcase/operations/Common.java
+++ b/src/org/opendatakit/briefcase/operations/Common.java
@@ -33,19 +33,15 @@ class Common {
     BriefcasePreferences.setBriefcaseDirectoryProperty(storageDir);
     File f = new StorageLocation().getBriefcaseFolder();
 
+    LOGGER.info("Trying to use {} as storage directory", f);
     if (!f.exists()) {
-      boolean success = f.mkdirs();
-      if (success) {
-        LOGGER.info("Successfully created directory. Using: " + f.getAbsolutePath());
-      } else {
-        LOGGER.error("Unable to create directory: " + f.getAbsolutePath());
+      if (!f.mkdirs()) {
+        LOGGER.error("Unable to create directory");
         System.exit(1);
       }
     } else if (f.exists() && !f.isDirectory()) {
-      LOGGER.error("Not a directory.  " + f.getAbsolutePath());
+      LOGGER.error("Not a directory");
       System.exit(1);
-    } else if (f.exists() && f.isDirectory()) {
-      LOGGER.info("Directory found, using " + f.getAbsolutePath());
     }
 
     if (BriefcasePreferences.appScoped().getBriefcaseDirectoryOrNull() != null) {

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -129,42 +129,42 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
 
       // required for all operations
       if (!cmd.hasOption(FORM_ID) || !cmd.hasOption(STORAGE_DIRECTORY)) {
-        log.error(FORM_ID + " and " + STORAGE_DIRECTORY + " are required");
+        System.err.println(FORM_ID + " and " + STORAGE_DIRECTORY + " are required");
         showHelp(options);
         System.exit(1);
       }
 
       // pull from collect or aggregate, not both
       if (cmd.hasOption(ODK_DIR) && cmd.hasOption(AGGREGATE_URL)) {
-        log.error("Can only have one of " + ODK_DIR + " or " + AGGREGATE_URL);
+        System.err.println("Can only have one of " + ODK_DIR + " or " + AGGREGATE_URL);
         showHelp(options);
         System.exit(1);
       }
 
       // pull from aggregate
       if (cmd.hasOption(AGGREGATE_URL) && (!(cmd.hasOption(ODK_USERNAME) && cmd.hasOption(ODK_PASSWORD)))) {
-        log.error(ODK_USERNAME + " and " + ODK_PASSWORD + " required when " + AGGREGATE_URL + " is specified");
+        System.err.println(ODK_USERNAME + " and " + ODK_PASSWORD + " required when " + AGGREGATE_URL + " is specified");
         showHelp(options);
         System.exit(1);
       }
 
       // export files
       if (cmd.hasOption(EXPORT_DIRECTORY) && !cmd.hasOption(EXPORT_FILENAME) || !cmd.hasOption(EXPORT_DIRECTORY) && cmd.hasOption(EXPORT_FILENAME)) {
-        log.error(EXPORT_DIRECTORY + " and " + EXPORT_FILENAME + " are both required to export");
+        System.err.println(EXPORT_DIRECTORY + " and " + EXPORT_FILENAME + " are both required to export");
         showHelp(options);
         System.exit(1);
       }
 
       if (cmd.hasOption(EXPORT_END_DATE)) {
         if (!testDateFormat(cmd.getOptionValue(EXPORT_END_DATE))) {
-          log.error("Invalid date format in " + EXPORT_END_DATE);
+          System.err.println("Invalid date format in " + EXPORT_END_DATE);
           showHelp(options);
           System.exit(1);
         }
       }
       if (cmd.hasOption(EXPORT_START_DATE)) {
         if (!testDateFormat(cmd.getOptionValue(EXPORT_START_DATE))) {
-          log.error("Invalid date format in " + EXPORT_START_DATE);
+          System.err.println("Invalid date format in " + EXPORT_START_DATE);
           showHelp(options);
           System.exit(1);
         }

--- a/src/org/opendatakit/briefcase/ui/StorageLocation.java
+++ b/src/org/opendatakit/briefcase/ui/StorageLocation.java
@@ -53,10 +53,11 @@ public class StorageLocation {
       if (dir.exists() && dir.isDirectory()) {
         if (BriefcaseFolderChooser.testAndMessageBadBriefcaseStorageLocationParentFolder(dir, errorParentWindow)) {
           try {
+            log.info("Trying {} as briefcase storage location", dir);
             assertBriefcaseStorageLocationParentFolder(dir);
             enableUi = true;
           } catch (FileSystemException e1) {
-            String msg = "Unable to create " + StorageLocation.BRIEFCASE_DIR;
+            String msg = "Unable to create briefcase storage location";
             log.error(msg, e1);
             ODKOptionPane.showErrorDialog(errorParentWindow, msg, "Failed to Create " + StorageLocation.BRIEFCASE_DIR);
           }

--- a/src/org/opendatakit/briefcase/util/AggregateUtils.java
+++ b/src/org/opendatakit/briefcase/util/AggregateUtils.java
@@ -165,20 +165,20 @@ public class AggregateUtils {
                                                          DocumentDescription description, ResponseAction action)
       throws XmlDocumentFetchException {
 
+    log.info("Parsing URL {}", urlString);
     URI u = null;
     try {
       URL url = new URL(urlString);
       u = url.toURI();
     } catch (MalformedURLException e) {
-      String msg = description.getFetchDocFailed() + "Invalid url: " + urlString + ".\nFailed with error: " + e.getMessage();
+      String msg = description.getFetchDocFailed() + "Invalid url. Failed with error: " + e.getMessage();
       if (!urlString.toLowerCase().startsWith("http://") && !urlString.toLowerCase().startsWith("https://")) {
-        msg += "\nDid you forget to prefix the address with 'http://' or 'https://' ?";
+        msg += ". Did you forget to prefix the address with 'http://' or 'https://' ?";
       }
       log.warn(msg, e);
       throw new XmlDocumentFetchException(msg);
     } catch (URISyntaxException e) {
-      String msg = description.getFetchDocFailed() + "Invalid uri: " + urlString + ".\nFailed with error: "
-          + e.getMessage();
+      String msg = description.getFetchDocFailed() + "Invalid uri. Failed with error: " + e.getMessage();
       log.warn(msg, e);
       throw new XmlDocumentFetchException(msg);
     }
@@ -227,6 +227,7 @@ public class AggregateUtils {
     HttpClientContext localContext = WebUtils.getHttpContext();
 
     URI uri = request.getURI();
+    log.info("Attempting URI {}", uri);
 
     WebUtils.setCredentials(localContext, serverInfo, uri, alwaysResetCredentials);
 
@@ -273,16 +274,14 @@ public class AggregateUtils {
                   + "\nPlease verify that the URL, your user credentials and your permissions are all correct.");
         }
       } else if (entity == null) {
-        log.warn("No entity body returned from: " + uri.toString() + " is not text/xml");
+        log.warn("No entity body returned");
         ex = new XmlDocumentFetchException(description.getFetchDocFailed()
-            + " Server unexpectedly returned no content while accessing: " + uri.toString());
+            + " Server unexpectedly returned no content");
       } else if (!(lcContentType.contains(HTTP_CONTENT_TYPE_TEXT_XML) || lcContentType
           .contains(HTTP_CONTENT_TYPE_APPLICATION_XML))) {
-        log.warn("ContentType: " + entity.getContentType().getValue() + "returned from: "
-            + uri.toString() + " is not text/xml");
+        log.warn("Wrong ContentType: " + entity.getContentType().getValue() + "returned");
         ex = new XmlDocumentFetchException(description.getFetchDocFailed()
-            + "A non-XML document was returned while accessing: " + uri.toString()
-            + "\nA network login screen may be interfering with the transmission to the server.");
+            + "A non-XML document was returned. A network login screen may be interfering with the transmission to the server.");
       }
 
       if (ex != null) {
@@ -323,7 +322,7 @@ public class AggregateUtils {
         }
       } catch (Exception e) {
         log.warn("Parsing failed with " + e.getMessage(), e);
-        throw new XmlDocumentFetchException(description.getFetchDocFailed() + " while accessing: " + uri.toString());
+        throw new XmlDocumentFetchException(description.getFetchDocFailed());
       }
 
       // examine header fields...
@@ -358,6 +357,7 @@ public class AggregateUtils {
         try {
           URL url = new URL(locations[0].getValue());
           URI uNew = url.toURI();
+          log.info("Redirection to URI {}", uNew);
           if (uri.getHost().equalsIgnoreCase(uNew.getHost())) {
             // trust the server to tell us a new location
             // ... and possibly to use https instead.
@@ -367,8 +367,7 @@ public class AggregateUtils {
           } else {
             // Don't follow a redirection attempt to a different host.
             // We can't tell if this is a spoof or not.
-            String msg = description.getFetchDocFailed() + "Unexpected redirection attempt to a different host: "
-                + uNew.toString();
+            String msg = description.getFetchDocFailed() + "Unexpected redirection attempt";
             log.warn(msg);
             throw new XmlDocumentFetchException(msg);
           }
@@ -384,7 +383,7 @@ public class AggregateUtils {
       }
       return result;
     } catch (UnknownHostException e) {
-      String msg = description.getFetchDocFailed() + "Unknown host: " + e.getMessage();
+      String msg = description.getFetchDocFailed() + "Unknown host";
       log.warn(msg, e);
       throw new XmlDocumentFetchException(msg);
     } catch (IOException | MetadataUpdateException e) {
@@ -413,19 +412,20 @@ public class AggregateUtils {
       urlString = urlString + "/" + actionAddr;
     }
 
+    log.info("Parsing URL {}", urlString);
     URI u;
     try {
       URL url = new URL(urlString);
       u = url.toURI();
     } catch (MalformedURLException e) {
-      String msg = "Invalid url: " + urlString + " for " + actionAddr + ".\nFailed with error: " + e.getMessage();
+      String msg = "Invalid url for " + actionAddr + ". Failed with error: " + e.getMessage();
       if (!urlString.toLowerCase().startsWith("http://") && !urlString.toLowerCase().startsWith("https://")) {
-        msg += "\nDid you forget to prefix the address with 'http://' or 'https://' ?";
+        msg += ". Did you forget to prefix the address with 'http://' or 'https://' ?";
       }
       log.warn(msg, e);
       throw new TransmissionException(msg);
     } catch (URISyntaxException e) {
-      String msg = "Invalid uri: " + urlString + " for " + actionAddr + ".\nFailed with error: " + e.getMessage();
+      String msg = "Invalid uri for " + actionAddr + ". Failed with error: " + e.getMessage();
       log.warn(msg, e);
       throw new TransmissionException(msg);
     }
@@ -453,8 +453,7 @@ public class AggregateUtils {
         } else if (statusCode == 204) {
           Header[] openRosaVersions = response.getHeaders(WebUtils.OPEN_ROSA_VERSION_HEADER);
           if (openRosaVersions == null || openRosaVersions.length == 0) {
-            String msg = "Url: " + u.toString()
-                + ", header missing: " + WebUtils.OPEN_ROSA_VERSION_HEADER;
+            String msg = "Header missing: " + WebUtils.OPEN_ROSA_VERSION_HEADER;
             log.warn(msg);
             throw new TransmissionException(msg);
           }
@@ -463,6 +462,7 @@ public class AggregateUtils {
             try {
               URL url = new URL(locations[0].getValue());
               URI uNew = url.toURI();
+              log.info("Redirection to URI {}", uNew);
               if (u.getHost().equalsIgnoreCase(uNew.getHost())) {
                 // trust the server to tell us a new location
                 // ... and possibly to use https instead.
@@ -475,19 +475,17 @@ public class AggregateUtils {
               } else {
                 // Don't follow a redirection attempt to a different host.
                 // We can't tell if this is a spoof or not.
-                String msg = "Starting url: " + u.toString()
-                    + " unexpected redirection attempt to a different host: " + uNew.toString();
+                String msg = "Unexpected redirection attempt";
                 log.warn(msg);
                 throw new TransmissionException(msg);
               }
             } catch (Exception e) {
-              String msg = "Starting url: " + u + " unexpected exception: " + e.getLocalizedMessage();
+              String msg = "Unexpected exception: " + e.getLocalizedMessage();
               log.warn(msg, e);
               throw new TransmissionException(msg);
             }
           } else {
-            String msg = "The url: " + u.toString()
-                + " is not ODK Aggregate - status code on Head request: " + statusCode;
+            String msg = "The url is not ODK Aggregate - status code on Head request: " + statusCode;
             log.warn(msg);
             throw new TransmissionException(msg);
           }
@@ -506,13 +504,12 @@ public class AggregateUtils {
               log.error("failed to process http stream", e);
             }
           }
-          String msg = "The username or password may be incorrect or the url: " + u.toString()
-              + " is not ODK Aggregate - status code on Head request: " + statusCode;
+          String msg = "The username or password may be incorrect or the url is not ODK Aggregate - status code on Head request: " + statusCode;
           log.warn(msg);
           throw new TransmissionException(msg);
         }
       } catch (Exception e) {
-        String msg = "Starting url: " + u.toString() + " unexpected exception: " + e.getLocalizedMessage();
+        String msg = "Unexpected exception: " + e.getLocalizedMessage();
         log.warn(msg, e);
         throw new TransmissionException(msg);
       }
@@ -557,6 +554,7 @@ public class AggregateUtils {
 
       for (; j < files.size(); j++) {
         File f = files.get(j);
+        log.info("Trying file {}", f);
         String fileName = f.getName();
         int idx = fileName.lastIndexOf(".");
         String extension = "";
@@ -605,7 +603,7 @@ public class AggregateUtils {
           fb = new FileBody(f, ContentType.create("application/octet-stream"));
           builder.addPart(f.getName(), fb);
           byteCount += f.length();
-          log.warn("added unrecognized file (application/octet-stream) " + f.getName());
+          log.warn("added unrecognized file (application/octet-stream)");
         }
 
         // we've added at least one attachment to the request...

--- a/src/org/opendatakit/briefcase/util/AggregateUtils.java
+++ b/src/org/opendatakit/briefcase/util/AggregateUtils.java
@@ -67,8 +67,6 @@ public class AggregateUtils {
 
   private static final CharSequence HTTP_CONTENT_TYPE_APPLICATION_XML = "application/xml";
 
-  private static final String FETCH_FAILED_DETAILED_REASON = "Fetch of %1$s failed. Detailed reason: ";
-
   public static interface ResponseAction {
     void doAction(DocumentFetchResult result) throws MetadataUpdateException;
   }
@@ -97,18 +95,23 @@ public class AggregateUtils {
    */
   public static final void commonDownloadFile(ServerConnectionInfo serverInfo, File f, String downloadUrl) throws URISyntaxException, IOException, TransmissionException {
 
+    log.info("Downloading URL {} into {}", downloadUrl, f);
+
     // OK. We need to download it because we either:
     // (1) don't have it
     // (2) don't know if it is changed because the hash is not md5
     // (3) know it is changed
     URI u = null;
     try {
+      log.info("Parsing URL {}", downloadUrl);
       URL uurl = new URL(downloadUrl);
       u = uurl.toURI();
     } catch (MalformedURLException | URISyntaxException e) {
-      log.error("bad download url " + downloadUrl, e);
+      log.warn("bad download url", e);
       throw e;
     }
+
+
 
     HttpClient httpclient = WebUtils.createHttpClient();
 
@@ -131,8 +134,7 @@ public class AggregateUtils {
         WebUtils.resetHttpContext();
         throw new TransmissionException("Authentication failure");
       } else if (statusCode != 200) {
-        String errMsg = String.format(FETCH_FAILED_DETAILED_REASON, f.getAbsolutePath())
-            + response.getStatusLine().getReasonPhrase() + " (" + statusCode + ")";
+        String errMsg = "Fetch failed. Detailed reason: " + response.getStatusLine().getReasonPhrase() + " (" + statusCode + ")";
         log.error(errMsg);
         flushEntityBytes(response.getEntity());
         throw new TransmissionException(errMsg);

--- a/src/org/opendatakit/briefcase/util/BadXMLFixer.java
+++ b/src/org/opendatakit/briefcase/util/BadXMLFixer.java
@@ -46,7 +46,7 @@ public final class BadXMLFixer {
   private static final String ENCODING = "UTF-8";
 
   public static Document fixBadXML(File xmlFile) throws CannotFixXMLException {
-    log.warn("Trying to fix the submission " + xmlFile.getAbsolutePath());
+    log.info("Trying to fix the submission {} ", xmlFile.getAbsolutePath());
 
     try {
       String originalXML = FileUtils.readFileToString(xmlFile, ENCODING);
@@ -54,15 +54,9 @@ public final class BadXMLFixer {
       File tempFile = File.createTempFile(xmlFile.getName(), ".fixed.xml");
       FileUtils.writeStringToFile(tempFile, fixedXML, ENCODING);
       return XmlManipulationUtils.parseXml(tempFile);
-    } catch (IOException e) {
-      log.error(e.getMessage(), e);
-      throw new CannotFixXMLException("Cannot fix " + xmlFile.getAbsolutePath(), e);
-    } catch (ParsingException e) {
-      log.error(e.getMessage(), e);
-      throw new CannotFixXMLException("Cannot fix " + xmlFile.getAbsolutePath(), e);
-    } catch (FileSystemException e) {
-      log.error(e.getMessage(), e);
-      throw new CannotFixXMLException("Cannot fix " + xmlFile.getAbsolutePath(), e);
+    } catch (IOException | ParsingException | FileSystemException e) {
+      log.error("Cannot fix xml", e);
+      throw new CannotFixXMLException("Cannot fix xml", e);
     }
   }
 

--- a/src/org/opendatakit/briefcase/util/FileSystemUtils.java
+++ b/src/org/opendatakit/briefcase/util/FileSystemUtils.java
@@ -388,7 +388,7 @@ public class FileSystemUtils {
       long lLength = file.length();
 
       if (lLength > Integer.MAX_VALUE) {
-        log.error("File " + file.getName() + "is too large");
+        log.error("File is too large");
         return null;
       }
 
@@ -418,14 +418,14 @@ public class FileSystemUtils {
       return md5;
 
     } catch (NoSuchAlgorithmException e) {
-      log.error("MD5 calculation failed: " + e.getMessage());
+      log.error("MD5 calculation failed", e);
       return null;
 
     } catch (FileNotFoundException e) {
-      log.error("No File: " + e.getMessage());
+      log.error("No File", e);
       return null;
     } catch (IOException e) {
-      log.error("Problem reading from file: " + e.getMessage());
+      log.error("Problem reading from file", e);
       return null;
     }
 
@@ -568,13 +568,11 @@ public class FileSystemUtils {
       decryptFile(ei, f, unencryptedDir);
     } catch (InvalidKeyException | NoSuchPaddingException | InvalidAlgorithmParameterException
         | NoSuchAlgorithmException e) {
-      String msg = "Error decrypting:" + f.getName();
-      log.error(msg, e);
-      throw new CryptoException(msg + " Cause: " + e.toString());
+      log.error("Error decrypting file", e);
+      throw new CryptoException("Error decrypting:" + f.getName() + " Cause: " + e.toString());
     } catch (IOException e) {
-      String msg = "Error decrypting:" + f.getName();
-      log.error(msg, e);
-      throw new FileSystemException(msg + " Cause: " + e.toString());
+      log.error("Error decrypting file", e);
+      throw new FileSystemException("Error decrypting:" + f.getName() + " Cause: " + e.toString());
     }
 
     // get the FIM for the decrypted submission file
@@ -586,9 +584,8 @@ public class FileSystemUtils {
       Document subDoc = XmlManipulationUtils.parseXml(submissionFile);
       submissionFim = XmlManipulationUtils.getFormInstanceMetadata(subDoc.getRootElement());
     } catch (ParsingException | FileSystemException e) {
-      String msg = "Error decrypting: " + submissionFile.getName();
-      log.error(msg, e);
-      throw new FileSystemException(msg + " Cause: " + e);
+      log.error("Error decrypting submission", e);
+      throw new FileSystemException("Error decrypting: " + submissionFile.getName() + " Cause: " + e);
     }
 
     boolean same = submissionFim.xparam.formId.equals(fim.xparam.formId);

--- a/src/org/opendatakit/briefcase/util/FileSystemUtils.java
+++ b/src/org/opendatakit/briefcase/util/FileSystemUtils.java
@@ -198,9 +198,11 @@ public class FileSystemUtils {
     File dbDir = new File(formDirectory, HSQLDB_DIR);
     File dbFile = new File(dbDir, HSQLDB_DB);
 
+
     if (!dbDir.exists()) {
+      log.info("Creating database directory {}", dbDir);
       if (!dbDir.mkdirs()) {
-        log.warn("failed to create database directory: " + dbDir);
+        log.warn("failed to create database directory");
       } else if (oldDbFile.exists()) {
         migrateDatabase(oldDbFile, dbFile);
       }

--- a/src/org/opendatakit/briefcase/util/ServerFetcher.java
+++ b/src/org/opendatakit/briefcase/util/ServerFetcher.java
@@ -229,21 +229,21 @@ public class ServerFetcher {
 
       } catch (SocketTimeoutException se) {
         allSuccessful = false;
-        log.error("error accessing " + fd.getDownloadUrl(), se);
+        log.error("error accessing URL", se);
         fs.setStatusString("Communications to the server timed out. Detailed message: "
             + se.getLocalizedMessage() + " while accessing: " + fd.getDownloadUrl()
             + " A network login screen may be interfering with the transmission to the server.", false);
         EventBus.publish(new FormStatusEvent(fs));
       } catch (IOException e) {
         allSuccessful = false;
-        log.error("error accessing " + fd.getDownloadUrl(), e);
+        log.error("error accessing form download URL", e);
         fs.setStatusString("Unexpected error: " + e.getLocalizedMessage() + " while accessing: "
             + fd.getDownloadUrl()
             + " A network login screen may be interfering with the transmission to the server.", false);
         EventBus.publish(new FormStatusEvent(fs));
       } catch (FileSystemException | TransmissionException | URISyntaxException e) {
         allSuccessful = false;
-        log.error("error accessing " + fd.getDownloadUrl(), e);
+        log.error("error accessing form download URL", e);
         fs.setStatusString("Unexpected error: " + e.getLocalizedMessage() + " while accessing: "
             + fd.getDownloadUrl(), false);
         EventBus.publish(new FormStatusEvent(fs));

--- a/src/org/opendatakit/briefcase/util/ServerUploader.java
+++ b/src/org/opendatakit/briefcase/util/ServerUploader.java
@@ -87,6 +87,7 @@ public class ServerUploader {
       File newInstanceDir = FileSystemUtils.getFormSubmissionDirectory(instancesParentDir, instanceID);
       if (!newInstanceDir.equals(instanceDir)) {
         try {
+          log.info("Moving {} to {}", instanceDir, newInstanceDir);
           FileUtils.moveDirectory(instanceDir, newInstanceDir);
           /*
            * We might be tempted to do:
@@ -102,7 +103,7 @@ public class ServerUploader {
           formToTransfer.setStatusString(msg, true);
           EventBus.publish(new FormStatusEvent(formToTransfer));
         } catch (IOException e) {
-          String msg = "Submission directory could not be renamed: " + instanceDir.getName();
+          String msg = "Submission directory could not be renamed";
           log.warn(msg, e);
           formToTransfer.setStatusString("WARNING: " + msg, true);
           EventBus.publish(new FormStatusEvent(formToTransfer));

--- a/src/org/opendatakit/briefcase/util/XmlManipulationUtils.java
+++ b/src/org/opendatakit/briefcase/util/XmlManipulationUtils.java
@@ -750,13 +750,11 @@ public class XmlManipulationUtils {
       fr.close();
       fs.close();
     } catch (IOException e) {
-      String msg = "Original submission file could not be opened "
-          + submissionFile.getAbsolutePath();
+      String msg = "Original submission file could not be opened";
       log.error(msg, e);
       throw new MetadataUpdateException(msg);
     } catch (XmlPullParserException e) {
-      String msg = "Original submission file could not be parsed as XML file "
-          + submissionFile.getAbsolutePath();
+      String msg = "Original submission file could not be parsed as XML file";
       log.error(msg, e);
       throw new MetadataUpdateException(msg);
     }
@@ -771,8 +769,7 @@ public class XmlManipulationUtils {
       String name = root.getAttributeName(i);
       if (name.equals(INSTANCE_ID_ATTRIBUTE_NAME)) {
         if (!root.getAttributeValue(i).equals(instanceID)) {
-          String msg = "Original submission file's instanceID does not match that on server! "
-              + submissionFile.getAbsolutePath();
+          String msg = "Original submission file's instanceID does not match that on server!";
           log.error(msg);
           throw new MetadataUpdateException(msg);
         } else {
@@ -786,8 +783,7 @@ public class XmlManipulationUtils {
         Date newDate = WebUtils.parseDate(returnDate);
         // cross-platform datetime resolution is 1 second.
         if (Math.abs(newDate.getTime() - oldDate.getTime()) > 1000L) {
-          String msg = "Original submission file's submissionDate does not match that on server! "
-              + submissionFile.getAbsolutePath();
+          String msg = "Original submission file's submissionDate does not match that on server!";
           log.error(msg);
           throw new MetadataUpdateException(msg);
         } else {
@@ -829,15 +825,13 @@ public class XmlManipulationUtils {
       try {
         if (temp.exists()) {
           if (!temp.delete()) {
-            String msg = "Unable to remove temporary submission backup file "
-                + temp.getAbsolutePath();
+            String msg = "Unable to remove temporary submission backup file";
             log.error(msg);
             throw new MetadataUpdateException(msg);
           }
         }
         if (!submissionFile.renameTo(temp)) {
-          String msg = "Unable to rename submission to temporary submission backup file "
-              + temp.getAbsolutePath();
+          String msg = "Unable to rename submission to temporary submission backup file";
           log.error(msg);
           throw new MetadataUpdateException(msg);
         }
@@ -846,8 +840,7 @@ public class XmlManipulationUtils {
         restoreTemp = true;
 
         if (!revisedFile.renameTo(submissionFile)) {
-          String msg = "Original submission file could not be updated "
-              + submissionFile.getAbsolutePath();
+          String msg = "Original submission file could not be updated";
           log.error(msg);
           throw new MetadataUpdateException(msg);
         }
@@ -857,19 +850,18 @@ public class XmlManipulationUtils {
       } finally {
         if (restoreTemp) {
           if (!temp.renameTo(submissionFile)) {
-            String msg = "Unable to restore submission from temporary submission backup file "
-                + temp.getAbsolutePath();
+            String msg = "Unable to restore submission from temporary submission backup file";
             log.error(msg);
             throw new MetadataUpdateException(msg);
           }
         }
       }
     } catch (FileNotFoundException e) {
-      String msg = "Temporary submission file could not be opened " + revisedFile.getAbsolutePath();
+      String msg = "Temporary submission file could not be opened";
       log.error(msg, e);
       throw new MetadataUpdateException(msg);
     } catch (IOException e) {
-      String msg = "Temporary submission file could not be written " + revisedFile.getAbsolutePath();
+      String msg = "Temporary submission file could not be written";
       log.error(msg, e);
       throw new MetadataUpdateException(msg);
     }


### PR DESCRIPTION
Closes #401

#### What has been done to verify that this works as intended?
The project compiles and launches GUI.
Run all tests

#### Why is this the best possible solution? Were any other approaches considered?
This is the smallest change that solves this problem towards the next release.

The best possible solution would be to explicitly express our intent of sending error reports to Sentry. We need that to send to Sentry only actionable errors, avoiding to send errors related to the user's environment or issues with specific forms and submission files.
 
#### Are there any risks to merging this code? If so, what are they?
In the process of removing sensitive info from the errors, we have lost information that _maybe_ is valuable while debugging. I think this is a risk we can assume while we do a revision or work on a way to separate the errors that should go to Sentry from other errors.