### PR TITLE
Issue 436 gather usage default on

### DIFF
--- a/src/org/opendatakit/briefcase/Launcher.java
+++ b/src/org/opendatakit/briefcase/Launcher.java
@@ -15,9 +15,11 @@
  */
 package org.opendatakit.briefcase;
 
+import static java.lang.Boolean.TRUE;
 import static org.opendatakit.briefcase.buildconfig.BuildConfig.SENTRY_DSN;
 import static org.opendatakit.briefcase.buildconfig.BuildConfig.SENTRY_ENABLED;
 import static org.opendatakit.briefcase.buildconfig.BuildConfig.VERSION;
+import static org.opendatakit.briefcase.model.BriefcasePreferences.BRIEFCASE_TRACKING_CONSENT_PROPERTY;
 import static org.opendatakit.briefcase.operations.ClearPreferences.CLEAR_PREFS;
 import static org.opendatakit.briefcase.operations.Export.EXPORT_FORM;
 import static org.opendatakit.briefcase.operations.ImportFromODK.IMPORT_FROM_ODK;
@@ -27,6 +29,7 @@ import static org.opendatakit.briefcase.operations.PushFormToAggregate.PUSH_FORM
 import static org.opendatakit.briefcase.util.FindDirectoryStructure.getOsName;
 
 import io.sentry.Sentry;
+import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.ui.MainBriefcaseWindow;
 import org.opendatakit.common.cli.Cli;
 
@@ -46,6 +49,10 @@ public class Launcher {
           getOsName(),
           System.getProperty("java.version")
       ));
+
+    BriefcasePreferences appPreferences = BriefcasePreferences.appScoped();
+    if (!appPreferences.hasKey(BRIEFCASE_TRACKING_CONSENT_PROPERTY))
+      appPreferences.put(BRIEFCASE_TRACKING_CONSENT_PROPERTY, TRUE.toString());
 
     new Cli()
         .deprecate(DEPRECATED_PULL_AGGREGATE, PULL_FORM_FROM_AGGREGATE)

--- a/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
+++ b/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
@@ -46,7 +46,7 @@ public class BriefcasePreferences {
   private static final String BRIEFCASE_PROXY_HOST_PROPERTY = "briefcaseProxyHost";
   private static final String BRIEFCASE_PROXY_PORT_PROPERTY = "briefcaseProxyPort";
   private static final String BRIEFCASE_PARALLEL_PULLS_PROPERTY = "briefcaseParallelPulls";
-  private static final String BRIEFCASE_TRACKING_CONSENT_PROPERTY = "briefcaseTrackingConsent";
+  public static final String BRIEFCASE_TRACKING_CONSENT_PROPERTY = "briefcaseTrackingConsent";
   private static final String BRIEFCASE_STORE_PASSWORDS_CONSENT_PROPERTY = "briefcaseStorePasswordsConsent";
   private static final String BRIEFCASE_UNIQUE_USER_ID_PROPERTY = "uniqueUserID";
 


### PR DESCRIPTION
Closes #436 

#### What has been done to verify that this works as intended?
Followed instructions on the issue to clear prefs and launch Briefcase to check that:
- On a first run, the setting is on
- On consecutive runs, user's preference is used

#### Why is this the best possible solution? Were any other approaches considered?
This is the smallest change I could think of

#### Are there any risks to merging this code? If so, what are they?
None.