### PR TITLE
Issue 424 improve spacing on cli

### DIFF
--- a/src/org/opendatakit/briefcase/Launcher.java
+++ b/src/org/opendatakit/briefcase/Launcher.java
@@ -26,11 +26,12 @@ import static org.opendatakit.briefcase.operations.ImportFromODK.IMPORT_FROM_ODK
 import static org.opendatakit.briefcase.operations.PullFormFromAggregate.DEPRECATED_PULL_AGGREGATE;
 import static org.opendatakit.briefcase.operations.PullFormFromAggregate.PULL_FORM_FROM_AGGREGATE;
 import static org.opendatakit.briefcase.operations.PushFormToAggregate.PUSH_FORM_TO_AGGREGATE;
+import static org.opendatakit.briefcase.ui.MainBriefcaseWindow.launchGUI;
+import static org.opendatakit.briefcase.ui.MainBriefcaseWindow.runLegacyCli;
 import static org.opendatakit.briefcase.util.FindDirectoryStructure.getOsName;
 
 import io.sentry.Sentry;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
-import org.opendatakit.briefcase.ui.MainBriefcaseWindow;
 import org.opendatakit.common.cli.Cli;
 
 /**
@@ -61,7 +62,12 @@ public class Launcher {
         .register(IMPORT_FROM_ODK)
         .register(EXPORT_FORM)
         .register(CLEAR_PREFS)
-        .otherwise(() -> MainBriefcaseWindow.main(args))
+        .otherwise((cli, commandLine) -> {
+          if (args.length == 0)
+            launchGUI();
+          else
+            runLegacyCli(commandLine, cli::printHelp);
+        })
         .run(args);
   }
 }

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 
 public class PullFormFromAggregate {
   private static final Logger log = LoggerFactory.getLogger(PullFormFromAggregate.class);
-  public static final Param<Void> DEPRECATED_PULL_AGGREGATE = Param.flag("pa", "pull_aggregate", "Pull form from an Aggregate instance");
+  public static final Param<Void> DEPRECATED_PULL_AGGREGATE = Param.flag("pa", "Pull form from an Aggregate instance");
   private static final Param<Void> PULL_AGGREGATE = Param.flag("plla", "pull_aggregate", "Pull form from an Aggregate instance");
 
   public static Operation PULL_FORM_FROM_AGGREGATE = Operation.of(

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -129,6 +129,14 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
   }
 
   public static void runLegacyCli(CommandLine cmd, Runnable helpShower) {
+    System.err.println("" +
+        "** WARNING **************************************************\n" +
+        "* You're running the legacy Briefcase launcher.             *\n" +
+        "*                                                           *\n" +
+        "* You can run Briefcase with -h to learn how to use the new *\n" +
+        "* launcher, which offers new operations and configuration   *\n" +
+        "* parameters                                                *\n" +
+        "*************************************************************\n");
     if (cmd.hasOption(HELP)) {
       helpShower.run();
       System.exit(1);

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -130,13 +130,10 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
 
   public static void runLegacyCli(CommandLine cmd, Runnable helpShower) {
     System.err.println("" +
-        "** WARNING **************************************************\n" +
-        "* You're running the legacy Briefcase launcher.             *\n" +
-        "*                                                           *\n" +
-        "* You can run Briefcase with -h to learn how to use the new *\n" +
-        "* launcher, which offers new operations and configuration   *\n" +
-        "* parameters                                                *\n" +
-        "*************************************************************\n");
+        "** WARNING ************************************************************\n" +
+        "* You are using old commands which will soon be removed from the CLI. *\n" +
+        "* Please run Briefcase with --help to learn about the new commands.   *\n" +
+        "***********************************************************************\n");
     if (cmd.hasOption(HELP)) {
       helpShower.run();
       System.exit(1);

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -124,63 +124,67 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
         System.exit(1);
       }
 
-      if (cmd.hasOption(HELP)) {
-        showHelp(options);
-        System.exit(1);
-      }
-
-      if (cmd.hasOption(VERSION)) {
-        showVersion();
-        System.exit(1);
-      }
-
-      // required for all operations
-      if (!cmd.hasOption(FORM_ID) || !cmd.hasOption(STORAGE_DIRECTORY)) {
-        System.err.println(FORM_ID + " and " + STORAGE_DIRECTORY + " are required");
-        showHelp(options);
-        System.exit(1);
-      }
-
-      // pull from collect or aggregate, not both
-      if (cmd.hasOption(ODK_DIR) && cmd.hasOption(AGGREGATE_URL)) {
-        System.err.println("Can only have one of " + ODK_DIR + " or " + AGGREGATE_URL);
-        showHelp(options);
-        System.exit(1);
-      }
-
-      // pull from aggregate
-      if (cmd.hasOption(AGGREGATE_URL) && (!(cmd.hasOption(ODK_USERNAME) && cmd.hasOption(ODK_PASSWORD)))) {
-        System.err.println(ODK_USERNAME + " and " + ODK_PASSWORD + " required when " + AGGREGATE_URL + " is specified");
-        showHelp(options);
-        System.exit(1);
-      }
-
-      // export files
-      if (cmd.hasOption(EXPORT_DIRECTORY) && !cmd.hasOption(EXPORT_FILENAME) || !cmd.hasOption(EXPORT_DIRECTORY) && cmd.hasOption(EXPORT_FILENAME)) {
-        System.err.println(EXPORT_DIRECTORY + " and " + EXPORT_FILENAME + " are both required to export");
-        showHelp(options);
-        System.exit(1);
-      }
-
-      if (cmd.hasOption(EXPORT_END_DATE)) {
-        if (!testDateFormat(cmd.getOptionValue(EXPORT_END_DATE))) {
-          System.err.println("Invalid date format in " + EXPORT_END_DATE);
-          showHelp(options);
-          System.exit(1);
-        }
-      }
-      if (cmd.hasOption(EXPORT_START_DATE)) {
-        if (!testDateFormat(cmd.getOptionValue(EXPORT_START_DATE))) {
-          System.err.println("Invalid date format in " + EXPORT_START_DATE);
-          showHelp(options);
-          System.exit(1);
-        }
-      }
-
-
-      BriefcaseCLI bcli = new BriefcaseCLI(cmd);
-      bcli.run();
+      runLegacyCli(cmd, () -> MainBriefcaseWindow.showHelp(options));
     }
+  }
+
+  public static void runLegacyCli(CommandLine cmd, Runnable helpShower) {
+    if (cmd.hasOption(HELP)) {
+      helpShower.run();
+      System.exit(1);
+    }
+
+    if (cmd.hasOption(VERSION)) {
+      helpShower.run();
+      System.exit(1);
+    }
+
+    // required for all operations
+    if (!cmd.hasOption(FORM_ID) || !cmd.hasOption(STORAGE_DIRECTORY)) {
+      System.err.println(FORM_ID + " and " + STORAGE_DIRECTORY + " are required");
+      helpShower.run();
+      System.exit(1);
+    }
+
+    // pull from collect or aggregate, not both
+    if (cmd.hasOption(ODK_DIR) && cmd.hasOption(AGGREGATE_URL)) {
+      System.err.println("Can only have one of " + ODK_DIR + " or " + AGGREGATE_URL);
+      helpShower.run();
+      System.exit(1);
+    }
+
+    // pull from aggregate
+    if (cmd.hasOption(AGGREGATE_URL) && (!(cmd.hasOption(ODK_USERNAME) && cmd.hasOption(ODK_PASSWORD)))) {
+      System.err.println(ODK_USERNAME + " and " + ODK_PASSWORD + " required when " + AGGREGATE_URL + " is specified");
+      helpShower.run();
+      System.exit(1);
+    }
+
+    // export files
+    if (cmd.hasOption(EXPORT_DIRECTORY) && !cmd.hasOption(EXPORT_FILENAME) || !cmd.hasOption(EXPORT_DIRECTORY) && cmd.hasOption(EXPORT_FILENAME)) {
+      System.err.println(EXPORT_DIRECTORY + " and " + EXPORT_FILENAME + " are both required to export");
+      helpShower.run();
+      System.exit(1);
+    }
+
+    if (cmd.hasOption(EXPORT_END_DATE)) {
+      if (!testDateFormat(cmd.getOptionValue(EXPORT_END_DATE))) {
+        System.err.println("Invalid date format in " + EXPORT_END_DATE);
+        helpShower.run();
+        System.exit(1);
+      }
+    }
+    if (cmd.hasOption(EXPORT_START_DATE)) {
+      if (!testDateFormat(cmd.getOptionValue(EXPORT_START_DATE))) {
+        System.err.println("Invalid date format in " + EXPORT_START_DATE);
+        helpShower.run();
+        System.exit(1);
+      }
+    }
+
+
+    BriefcaseCLI bcli = new BriefcaseCLI(cmd);
+    bcli.run();
   }
 
   public static void launchGUI() {

--- a/src/org/opendatakit/common/cli/Cli.java
+++ b/src/org/opendatakit/common/cli/Cli.java
@@ -73,7 +73,7 @@ public class Cli {
    * @return self {@link Cli} instance to chain more method calls
    */
   public Cli deprecate(Param<?> oldParam, Operation alternative) {
-    operations.add(Operation.of(oldParam, __ -> {
+    operations.add(Operation.deprecated(oldParam, __ -> {
       log.warn("Trying to run deprecated param -{}", oldParam.shortCode);
       System.out.println("The param -" + oldParam.shortCode + " has been deprecated. Run Briefcase again with -" + alternative.param.shortCode + " instead");
       printHelp();

--- a/src/org/opendatakit/common/cli/Cli.java
+++ b/src/org/opendatakit/common/cli/Cli.java
@@ -161,7 +161,7 @@ public class Cli {
     try {
       return new DefaultParser().parse(mapToOptions(params), args, false);
     } catch (UnrecognizedOptionException | MissingArgumentException e) {
-      System.err.println(e.getMessage());
+      System.err.println("Error: " + e.getMessage());
       log.error("Error", e);
       printHelp();
       System.exit(1);

--- a/src/org/opendatakit/common/cli/Cli.java
+++ b/src/org/opendatakit/common/cli/Cli.java
@@ -17,7 +17,6 @@ package org.opendatakit.common.cli;
 
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toSet;
-import static org.opendatakit.common.cli.CustomHelpFormatter.printHelp;
 
 import java.util.HashSet;
 import java.util.Objects;
@@ -50,8 +49,15 @@ public class Cli {
   private final Set<Operation> executedOperations = new HashSet<>();
 
   public Cli() {
-    register(Operation.of(SHOW_HELP, args -> printHelp(requiredOperations, operations)));
+    register(Operation.of(SHOW_HELP, args -> printHelp()));
     register(Operation.of(SHOW_VERSION, args -> printVersion()));
+  }
+
+  /**
+   * Prints the help message with all the registered operations and their paramsº
+   */
+  public void printHelp() {
+    CustomHelpFormatter.printHelp(requiredOperations, operations);
   }
 
   /**
@@ -69,7 +75,7 @@ public class Cli {
     operations.add(Operation.of(oldParam, __ -> {
       log.warn("Trying to run deprecated param -{}", oldParam.shortCode);
       System.out.println("The param -" + oldParam.shortCode + " has been deprecated. Run Briefcase again with -" + alternative.param.shortCode + " instead");
-      printHelp(requiredOperations, operations);
+      printHelp();
       System.exit(1);
     }));
     return this;
@@ -156,7 +162,7 @@ public class Cli {
     } catch (UnrecognizedOptionException | MissingArgumentException e) {
       System.err.println(e.getMessage());
       log.error("Error", e);
-      printHelp(requiredOperations, operations);
+      printHelp();
       System.exit(1);
       return null;
     } catch (Throwable t) {
@@ -172,7 +178,7 @@ public class Cli {
       System.out.print("Missing params: ");
       System.out.print(missingParams.stream().map(param -> "-" + param.shortCode).collect(joining(", ")));
       System.out.println("");
-      printHelp(requiredOperations, operations);
+      printHelp();
       System.exit(1);
     }
   }

--- a/src/org/opendatakit/common/cli/CustomHelpFormatter.java
+++ b/src/org/opendatakit/common/cli/CustomHelpFormatter.java
@@ -89,7 +89,7 @@ class CustomHelpFormatter {
     operations.stream()
         .filter(o -> !o.isDeprecated())
         .sorted(Comparator.comparing(operation -> operation.param.shortCode))
-        .forEach(operation -> System.out.println(helpLinesPerShortcode.get(operation.param.shortCode)));
+        .forEach(operation -> System.out.println("  " + helpLinesPerShortcode.get(operation.param.shortCode)));
     System.out.println("");
   }
 

--- a/src/org/opendatakit/common/cli/CustomHelpFormatter.java
+++ b/src/org/opendatakit/common/cli/CustomHelpFormatter.java
@@ -94,7 +94,8 @@ class CustomHelpFormatter {
 
   private static void printUsage() {
     System.out.println("");
-    System.out.println("Usage: java -jar " + jarFile + " <params>");
+    System.out.println("Launch the GUI with: java -jar " + jarFile);
+    System.out.println("Launch a CLI operation with: java -jar " + jarFile + " <operation> <params>");
     System.out.println("");
   }
 

--- a/src/org/opendatakit/common/cli/CustomHelpFormatter.java
+++ b/src/org/opendatakit/common/cli/CustomHelpFormatter.java
@@ -87,6 +87,7 @@ class CustomHelpFormatter {
   private static void printAvailableOperations(Map<String, String> helpLinesPerShortcode, Set<Operation> operations) {
     System.out.println("Available operations:");
     operations.stream()
+        .filter(o -> !o.isDeprecated())
         .sorted(Comparator.comparing(operation -> operation.param.shortCode))
         .forEach(operation -> System.out.println(helpLinesPerShortcode.get(operation.param.shortCode)));
     System.out.println("");
@@ -111,7 +112,7 @@ class CustomHelpFormatter {
     HelpFormatter helpFormatter = new HelpFormatter();
     helpFormatter.printHelp(pw, 999, "ignore", "ignore", options, 0, 4, "ignore");
     return Stream.of(out.toString().split("\n"))
-        .filter(line -> line.startsWith("-"))
+        .filter(line -> line.startsWith("-") && line.contains(","))
         .collect(toMap(
             (String line) -> line.substring(1, line.indexOf(",")),
             Function.identity()

--- a/src/org/opendatakit/common/cli/CustomHelpFormatter.java
+++ b/src/org/opendatakit/common/cli/CustomHelpFormatter.java
@@ -78,7 +78,7 @@ class CustomHelpFormatter {
   }
 
   private static void printOptionalParams(Map<String, String> helpLinesPerShortcode, Operation operation) {
-    System.out.println("  (optionally)");
+    System.out.println("Optional params for -" + operation.param.shortCode + " operation:");
     operation.optionalParams.stream()
         .sorted(Comparator.comparing(param -> param.shortCode))
         .forEach(param -> System.out.println("  " + helpLinesPerShortcode.get(param.shortCode)));

--- a/src/org/opendatakit/common/cli/Operation.java
+++ b/src/org/opendatakit/common/cli/Operation.java
@@ -18,12 +18,14 @@ public class Operation {
   final Consumer<Args> argsConsumer;
   final Set<Param> requiredParams;
   final Set<Param> optionalParams;
+  final boolean deprecated;
 
-  private Operation(Param param, Consumer<Args> argsConsumer, Set<Param> requiredParams, Set<Param> optionalParams) {
+  private Operation(Param param, Consumer<Args> argsConsumer, Set<Param> requiredParams, Set<Param> optionalParams, boolean deprecated) {
     this.param = param;
     this.argsConsumer = argsConsumer;
     this.requiredParams = requiredParams;
     this.optionalParams = optionalParams;
+    this.deprecated = deprecated;
   }
 
   /**
@@ -34,7 +36,7 @@ public class Operation {
    * @return a new {@link Operation} instance
    */
   public static Operation of(Param param, Consumer<Args> argsConsumer) {
-    return new Operation(param, argsConsumer, emptySet(), emptySet());
+    return new Operation(param, argsConsumer, emptySet(), emptySet(), false);
   }
 
   /**
@@ -46,7 +48,7 @@ public class Operation {
    * @return a new {@link Operation} instance
    */
   public static Operation of(Param param, Consumer<Args> argsConsumer, List<Param> requiredParams) {
-    return new Operation(param, argsConsumer, new HashSet<>(requiredParams), emptySet());
+    return new Operation(param, argsConsumer, new HashSet<>(requiredParams), emptySet(), false);
   }
 
   /**
@@ -59,7 +61,18 @@ public class Operation {
    * @return a new {@link Operation} instance
    */
   public static Operation of(Param param, Consumer<Args> argsConsumer, List<Param> requiredParams, List<Param> optionalParams) {
-    return new Operation(param, argsConsumer, new HashSet<>(requiredParams), new HashSet<>(optionalParams));
+    return new Operation(param, argsConsumer, new HashSet<>(requiredParams), new HashSet<>(optionalParams), false);
+  }
+
+  /**
+   * Creates a new deprecated {@link Operation} without params of any kind (required or optional)
+   *
+   * @param param        main {@link Param} that will trigger the execution of this {@link Operation}, normally a {@link Param#flag(String, String, String)}
+   * @param argsConsumer {@link Consumer}&lt;{@link Args}&gt; with the logic of this {@link Operation}
+   * @return a new {@link Operation} instance
+   */
+  public static Operation deprecated(Param param, Consumer<Args> argsConsumer) {
+    return new Operation(param, argsConsumer, emptySet(), emptySet(), true);
   }
 
   Set<Param> getAllParams() {
@@ -107,5 +120,9 @@ public class Operation {
         ", requiredParams=" + requiredParams +
         ", optionalParams=" + optionalParams +
         '}';
+  }
+
+  public boolean isDeprecated() {
+    return deprecated;
   }
 }

--- a/src/org/opendatakit/common/cli/Param.java
+++ b/src/org/opendatakit/common/cli/Param.java
@@ -101,6 +101,21 @@ public class Param<T> {
     );
   }
 
+  /**
+   * Creates a new {@link Param}&lt;{@link Void}&gt; instance for a command-line flag
+   *
+   * @param shortCode   the shortcode (usually one or two chars)
+   * @param description the description
+   * @return a new {@link Param}&lt;{@link Void}&gt; instance
+   */
+  public static Param<Void> flag(String shortCode, String description) {
+    return new Param<>(
+        shortCode,
+        new Option(shortCode, false, description),
+        Optional.empty()
+    );
+  }
+
   boolean isArg() {
     return this.option.hasArg();
   }


### PR DESCRIPTION
Closes #424, #451, #450, #452, and #453 

This PR introduces changes aimed to ensure we use the new CLI's features as much as possible when the fallback, legacy CLI launcher is run. This happens when the user doesn't add the new operation flags we use on the new Launcher. Specifically
- Ensure that we parse command line args once
- Ensure that the `MainBriefcaseWindow` will use the new CLI's `printHelp()` method

It's important that we use the new CLI's `printHelp()` method show because we want to help users running the legacy launcher to migrate their scripts to the new one.

Also, the new CLI's `printHelp()` method uses more relaxed settings that won't clutter text if the console is too narrow.

#### What has been done to verify that this works as intended?
Run Briefcase's command line operations (both new and legacy)

#### Why is this the best possible solution? Were any other approaches considered?
Setting wider console settings on the legacy CLI launcher would probably have been a simpler solution, but I consider that that wouldn't support our bet for a new launcher.

#### Are there any risks to merging this code? If so, what are they?
Nope