### PR TITLE
Issue 444 tracking warning

### DIFF
--- a/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
+++ b/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
@@ -42,7 +42,7 @@ public class BriefcasePreferences {
   public static final String PASSWORD = "password";
   public static final String AGGREGATE_1_0_URL = "url_1_0";
 
-  private static final String BRIEFCASE_DIR_PROPERTY = "briefcaseDir";
+  public static final String BRIEFCASE_DIR_PROPERTY = "briefcaseDir";
   private static final String BRIEFCASE_PROXY_HOST_PROPERTY = "briefcaseProxyHost";
   private static final String BRIEFCASE_PROXY_PORT_PROPERTY = "briefcaseProxyPort";
   private static final String BRIEFCASE_PARALLEL_PULLS_PROPERTY = "briefcaseParallelPulls";

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -266,7 +266,7 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
 
     storageLocation.establishBriefcaseStorageLocation(frame, this);
 
-    showIntroDialogIfNeeded();
+    showIntroDialogIfNeeded(appPreferences);
   }
 
   private void createFormCache() {
@@ -275,15 +275,15 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
     }
   }
 
-  private void showIntroDialogIfNeeded() {
-    if (BriefcasePreferences.appScoped().getBriefcaseDirectoryOrNull() == null) {
+  private void showIntroDialogIfNeeded(BriefcasePreferences appPreferences) {
+    if (appPreferences.getBriefcaseDirectoryOrNull() == null) {
       showMessageDialog(frame, BRIEFCASE_WELCOME, APP_NAME, INFORMATION_MESSAGE, imageIcon);
-      BriefcasePreferences.appScoped().put(TRACKING_WARNING_SHOWED_PREF_KEY, TRUE.toString());
+      appPreferences.put(TRACKING_WARNING_SHOWED_PREF_KEY, TRUE.toString());
     }
 
-    if (!BriefcasePreferences.appScoped().hasKey(TRACKING_WARNING_SHOWED_PREF_KEY)) {
+    if (!appPreferences.hasKey(TRACKING_WARNING_SHOWED_PREF_KEY)) {
       showMessageDialog(frame, TRACKING_WARNING, APP_NAME, INFORMATION_MESSAGE, imageIcon);
-      BriefcasePreferences.appScoped().put(TRACKING_WARNING_SHOWED_PREF_KEY, TRUE.toString());
+      appPreferences.put(TRACKING_WARNING_SHOWED_PREF_KEY, TRUE.toString());
     }
   }
 

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -19,6 +19,7 @@ package org.opendatakit.briefcase.ui;
 import static java.lang.Boolean.TRUE;
 import static javax.swing.JOptionPane.INFORMATION_MESSAGE;
 import static javax.swing.JOptionPane.showMessageDialog;
+import static org.opendatakit.briefcase.model.BriefcasePreferences.BRIEFCASE_DIR_PROPERTY;
 import static org.opendatakit.briefcase.ui.MessageStrings.BRIEFCASE_WELCOME;
 import static org.opendatakit.briefcase.ui.MessageStrings.TRACKING_WARNING;
 
@@ -276,7 +277,7 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
   }
 
   private void showIntroDialogIfNeeded(BriefcasePreferences appPreferences) {
-    if (appPreferences.getBriefcaseDirectoryOrNull() == null) {
+    if (!appPreferences.hasKey(BRIEFCASE_DIR_PROPERTY)) {
       showMessageDialog(frame, BRIEFCASE_WELCOME, APP_NAME, INFORMATION_MESSAGE, imageIcon);
       appPreferences.put(TRACKING_WARNING_SHOWED_PREF_KEY, TRUE.toString());
     }

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -56,6 +56,7 @@ import org.slf4j.LoggerFactory;
 public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeListener {
   private static final String APP_NAME = "ODK Briefcase";
   private static final String BRIEFCASE_VERSION = APP_NAME + " - " + BriefcasePreferences.VERSION;
+  public static final String TRACKING_WARNING_SHOWED_PREF_KEY = "tracking warning showed";
   private final ImageIcon imageIcon = new ImageIcon(getClass().getClassLoader().getResource("odk_logo.png"));
 
   JFrame frame;
@@ -273,13 +274,13 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
     if (BriefcasePreferences.appScoped().getBriefcaseDirectoryOrNull() == null) {
       JOptionPane.showMessageDialog(frame, MessageStrings.BRIEFCASE_WELCOME, APP_NAME,
           JOptionPane.INFORMATION_MESSAGE, imageIcon);
-      BriefcasePreferences.appScoped().put("tracking warning showed", Boolean.TRUE.toString());
+      BriefcasePreferences.appScoped().put(TRACKING_WARNING_SHOWED_PREF_KEY, Boolean.TRUE.toString());
     }
 
-    if (!BriefcasePreferences.appScoped().hasKey("tracking warning showed")) {
+    if (!BriefcasePreferences.appScoped().hasKey(TRACKING_WARNING_SHOWED_PREF_KEY)) {
       JOptionPane.showMessageDialog(frame, MessageStrings.TRACKING_WARNING, APP_NAME,
           JOptionPane.INFORMATION_MESSAGE, imageIcon);
-      BriefcasePreferences.appScoped().put("tracking warning showed", Boolean.TRUE.toString());
+      BriefcasePreferences.appScoped().put(TRACKING_WARNING_SHOWED_PREF_KEY, Boolean.TRUE.toString());
     }
   }
 

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -16,6 +16,12 @@
 
 package org.opendatakit.briefcase.ui;
 
+import static java.lang.Boolean.TRUE;
+import static javax.swing.JOptionPane.INFORMATION_MESSAGE;
+import static javax.swing.JOptionPane.showMessageDialog;
+import static org.opendatakit.briefcase.ui.MessageStrings.BRIEFCASE_WELCOME;
+import static org.opendatakit.briefcase.ui.MessageStrings.TRACKING_WARNING;
+
 import java.awt.Component;
 import java.awt.EventQueue;
 import java.awt.Toolkit;
@@ -30,7 +36,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import javax.swing.ImageIcon;
 import javax.swing.JFrame;
-import javax.swing.JOptionPane;
 import javax.swing.JTabbedPane;
 import javax.swing.UIManager;
 import javax.swing.WindowConstants;
@@ -272,15 +277,13 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
 
   private void showIntroDialogIfNeeded() {
     if (BriefcasePreferences.appScoped().getBriefcaseDirectoryOrNull() == null) {
-      JOptionPane.showMessageDialog(frame, MessageStrings.BRIEFCASE_WELCOME, APP_NAME,
-          JOptionPane.INFORMATION_MESSAGE, imageIcon);
-      BriefcasePreferences.appScoped().put(TRACKING_WARNING_SHOWED_PREF_KEY, Boolean.TRUE.toString());
+      showMessageDialog(frame, BRIEFCASE_WELCOME, APP_NAME, INFORMATION_MESSAGE, imageIcon);
+      BriefcasePreferences.appScoped().put(TRACKING_WARNING_SHOWED_PREF_KEY, TRUE.toString());
     }
 
     if (!BriefcasePreferences.appScoped().hasKey(TRACKING_WARNING_SHOWED_PREF_KEY)) {
-      JOptionPane.showMessageDialog(frame, MessageStrings.TRACKING_WARNING, APP_NAME,
-          JOptionPane.INFORMATION_MESSAGE, imageIcon);
-      BriefcasePreferences.appScoped().put(TRACKING_WARNING_SHOWED_PREF_KEY, Boolean.TRUE.toString());
+      showMessageDialog(frame, TRACKING_WARNING, APP_NAME, INFORMATION_MESSAGE, imageIcon);
+      BriefcasePreferences.appScoped().put(TRACKING_WARNING_SHOWED_PREF_KEY, TRUE.toString());
     }
   }
 

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -273,6 +273,13 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
     if (BriefcasePreferences.appScoped().getBriefcaseDirectoryOrNull() == null) {
       JOptionPane.showMessageDialog(frame, MessageStrings.BRIEFCASE_WELCOME, APP_NAME,
           JOptionPane.INFORMATION_MESSAGE, imageIcon);
+      BriefcasePreferences.appScoped().put("tracking warning showed", Boolean.TRUE.toString());
+    }
+
+    if (!BriefcasePreferences.appScoped().hasKey("tracking warning showed")) {
+      JOptionPane.showMessageDialog(frame, MessageStrings.TRACKING_WARNING, APP_NAME,
+          JOptionPane.INFORMATION_MESSAGE, imageIcon);
+      BriefcasePreferences.appScoped().put("tracking warning showed", Boolean.TRUE.toString());
     }
   }
 

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -277,15 +277,33 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
   }
 
   private void showIntroDialogIfNeeded(BriefcasePreferences appPreferences) {
-    if (!appPreferences.hasKey(BRIEFCASE_DIR_PROPERTY)) {
-      showMessageDialog(frame, BRIEFCASE_WELCOME, APP_NAME, INFORMATION_MESSAGE, imageIcon);
+    if (isFirstLaunch(appPreferences)) {
+      showWelcomeMessage();
       appPreferences.put(TRACKING_WARNING_SHOWED_PREF_KEY, TRUE.toString());
     }
 
-    if (!appPreferences.hasKey(TRACKING_WARNING_SHOWED_PREF_KEY)) {
-      showMessageDialog(frame, TRACKING_WARNING, APP_NAME, INFORMATION_MESSAGE, imageIcon);
+    // Starting with Briefcase version 1.10.0, tracking is enabled by default.
+    // Users upgrading from previous versions must be warned about this.
+    if (isFirstLaunchAfterTrackingUpgrade(appPreferences)) {
+      showTrackingWarning();
       appPreferences.put(TRACKING_WARNING_SHOWED_PREF_KEY, TRUE.toString());
     }
+  }
+
+  private void showTrackingWarning() {
+    showMessageDialog(frame, TRACKING_WARNING, APP_NAME, INFORMATION_MESSAGE, imageIcon);
+  }
+
+  private void showWelcomeMessage() {
+    showMessageDialog(frame, BRIEFCASE_WELCOME, APP_NAME, INFORMATION_MESSAGE, imageIcon);
+  }
+
+  private boolean isFirstLaunchAfterTrackingUpgrade(BriefcasePreferences appPreferences) {
+    return !appPreferences.hasKey(TRACKING_WARNING_SHOWED_PREF_KEY);
+  }
+
+  private boolean isFirstLaunch(BriefcasePreferences appPreferences) {
+    return !appPreferences.hasKey(BRIEFCASE_DIR_PROPERTY);
   }
 
   /**

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -267,16 +267,6 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
 
     storageLocation.establishBriefcaseStorageLocation(frame, this);
 
-    showIntroDialogIfNeeded(appPreferences);
-  }
-
-  private void createFormCache() {
-    if (BriefcasePreferences.appScoped().getBriefcaseDirectoryOrNull() != null) {
-      FileSystemUtils.createFormCacheInBriefcaseFolder();
-    }
-  }
-
-  private void showIntroDialogIfNeeded(BriefcasePreferences appPreferences) {
     if (isFirstLaunch(appPreferences)) {
       showWelcomeMessage();
       appPreferences.put(TRACKING_WARNING_SHOWED_PREF_KEY, TRUE.toString());
@@ -287,6 +277,12 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
     if (isFirstLaunchAfterTrackingUpgrade(appPreferences)) {
       showTrackingWarning();
       appPreferences.put(TRACKING_WARNING_SHOWED_PREF_KEY, TRUE.toString());
+    }
+  }
+
+  private void createFormCache() {
+    if (BriefcasePreferences.appScoped().getBriefcaseDirectoryOrNull() != null) {
+      FileSystemUtils.createFormCacheInBriefcaseFolder();
     }
   }
 

--- a/src/org/opendatakit/briefcase/ui/MessageStrings.java
+++ b/src/org/opendatakit/briefcase/ui/MessageStrings.java
@@ -60,6 +60,10 @@ public class MessageStrings {
           "3. ODK is a community-powered project and the community lives at\n" +
           "    https://forum.opendatakit.org. Stop by for a visit and introduce yourself!\n" +
           "\n";
+  static final String TRACKING_WARNING = "" +
+      "We gather anonymous usage data (e.g., operating system, version number) to help\n" +
+      "our community prioritize fixes and features. If you do not want to contribute\n" +
+      "your data, please uncheck that setting.\n\n";
   public static final String README_CONTENTS =
       "This ODK Briefcase storage area retains\n" +
           "all the forms and submissions that have been\n" +


### PR DESCRIPTION
Closes #444

#### What has been done to verify that this works as intended?
Verification 1:
- Run the clear prefs CLI operation
- Launch Briefcase. The welcome message is shown. Accept and set a storage dir. No tracking warning is shown. Close Briefcase
- Launch Briefcase. No welcome message is shown. No tracking warning is shown.

Verification 2:
- Run the clear prefs CLI operation
- Launch the `master` version of Briefcase. The welcome message is shown. Accept and set a storage dir. Close Briefcase
- Launch Briefcase (this version). No welcome message is shown. The tracking warning is shown. Close Briefcase
- Launch Briefcase (this version). No welcome message is shown. No tracking warning is shown.

#### Why is this the best possible solution? Were any other approaches considered?
The basic solution is in https://github.com/opendatakit/briefcase/commit/ea548cca06d49f2610045498f3368e8732624855 
The rest of commits just improve design and code readability

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.