### PR TITLE
Issue 401 Remove sentitive info from Sentry logs

### DIFF
--- a/src/org/opendatakit/briefcase/Launcher.java
+++ b/src/org/opendatakit/briefcase/Launcher.java
@@ -45,7 +45,7 @@ public class Launcher {
     if (!appPreferences.hasKey(BRIEFCASE_TRACKING_CONSENT_PROPERTY))
       appPreferences.put(BRIEFCASE_TRACKING_CONSENT_PROPERTY, TRUE.toString());
 
-    if (SENTRY_ENABLED)
+    if (SENTRY_ENABLED) {
       Sentry.init(String.format(
           "%s?release=%s&stacktrace.app.packages=org.opendatakit&tags=os:%s,jvm:%s",
           SENTRY_DSN,
@@ -54,6 +54,13 @@ public class Launcher {
           System.getProperty("java.version")
       ));
 
+      // Add a callback that will prevent sending crash reports to Sentry
+      // if the user disables tracking
+      Sentry.getStoredClient().addShouldSendEventCallback(event -> appPreferences
+          .nullSafeGet(BRIEFCASE_TRACKING_CONSENT_PROPERTY)
+          .map(Boolean::valueOf)
+          .orElse(true));
+    }
 
     new Cli()
         .deprecate(DEPRECATED_PULL_AGGREGATE, PULL_FORM_FROM_AGGREGATE)

--- a/src/org/opendatakit/briefcase/Launcher.java
+++ b/src/org/opendatakit/briefcase/Launcher.java
@@ -41,6 +41,10 @@ import org.opendatakit.common.cli.Cli;
  */
 public class Launcher {
   public static void main(String[] args) {
+    BriefcasePreferences appPreferences = BriefcasePreferences.appScoped();
+    if (!appPreferences.hasKey(BRIEFCASE_TRACKING_CONSENT_PROPERTY))
+      appPreferences.put(BRIEFCASE_TRACKING_CONSENT_PROPERTY, TRUE.toString());
+
     if (SENTRY_ENABLED)
       Sentry.init(String.format(
           "%s?release=%s&stacktrace.app.packages=org.opendatakit&tags=os:%s,jvm:%s",
@@ -50,9 +54,6 @@ public class Launcher {
           System.getProperty("java.version")
       ));
 
-    BriefcasePreferences appPreferences = BriefcasePreferences.appScoped();
-    if (!appPreferences.hasKey(BRIEFCASE_TRACKING_CONSENT_PROPERTY))
-      appPreferences.put(BRIEFCASE_TRACKING_CONSENT_PROPERTY, TRUE.toString());
 
     new Cli()
         .deprecate(DEPRECATED_PULL_AGGREGATE, PULL_FORM_FROM_AGGREGATE)

--- a/src/org/opendatakit/briefcase/util/AggregateUtils.java
+++ b/src/org/opendatakit/briefcase/util/AggregateUtils.java
@@ -39,6 +39,7 @@ import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.conn.ConnectTimeoutException;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.FileBody;
@@ -387,6 +388,12 @@ public class AggregateUtils {
     } catch (UnknownHostException e) {
       String msg = description.getFetchDocFailed() + "Unknown host";
       log.warn(msg, e);
+      throw new XmlDocumentFetchException(msg);
+    } catch (ConnectTimeoutException e) {
+      // We need to anonymize the host info that comes on the
+      // exception's message before logging the exception
+      String msg = description.getFetchDocFailed() + "Connection timeout";
+      log.warn(msg, e.getCause());
       throw new XmlDocumentFetchException(msg);
     } catch (IOException | MetadataUpdateException e) {
       String msg = description.getFetchDocFailed() + "Unexpected exception: " + e;


### PR DESCRIPTION
Continues work related to #401 and improves the Sentry appender to toggle it depending on the tracking consent.

#### What has been done to verify that this works as intended?
- Produced an export error by tampering a submission file
- Checked that disabling the tracking consent, the events don't reach Sentry
- Checked that re-enabling the tracking consent, the events reach Sentry

#### Why is this the best possible solution? Were any other approaches considered?

Regarding the anonymization of the `ConnectTimeoutException`:
Since we don't have control of this `ConnectTimeoutException`, we only can bypass the exception's message to avoid logging the host information that comes on it.

Regarding the tracking consent:
Sentry doesn't have a global toggle but it provides a callbacks system to inspect every Event and decide if it has to reach Sentry or not.

In this case, I'm taking advantage of this callback to check the tracking pref to prevent sending any Event if the users disables tracking.

#### Are there any risks to merging this code? If so, what are they?
None.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.