### PR TITLE
Improve UX on start up dialogs

### DIFF
--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -17,7 +17,7 @@
 package org.opendatakit.briefcase.ui;
 
 import static java.lang.Boolean.TRUE;
-import static javax.swing.JOptionPane.INFORMATION_MESSAGE;
+import static javax.swing.JOptionPane.PLAIN_MESSAGE;
 import static javax.swing.JOptionPane.showMessageDialog;
 import static org.opendatakit.briefcase.model.BriefcasePreferences.BRIEFCASE_DIR_PROPERTY;
 import static org.opendatakit.briefcase.ui.MessageStrings.BRIEFCASE_WELCOME;
@@ -287,11 +287,11 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
   }
 
   private void showTrackingWarning() {
-    showMessageDialog(frame, TRACKING_WARNING, APP_NAME, INFORMATION_MESSAGE, imageIcon);
+    showMessageDialog(frame, TRACKING_WARNING, APP_NAME, PLAIN_MESSAGE);
   }
 
   private void showWelcomeMessage() {
-    showMessageDialog(frame, BRIEFCASE_WELCOME, APP_NAME, INFORMATION_MESSAGE, imageIcon);
+    showMessageDialog(frame, BRIEFCASE_WELCOME, APP_NAME, PLAIN_MESSAGE);
   }
 
   private boolean isFirstLaunchAfterTrackingUpgrade(BriefcasePreferences appPreferences) {

--- a/src/org/opendatakit/briefcase/ui/MessageStrings.java
+++ b/src/org/opendatakit/briefcase/ui/MessageStrings.java
@@ -56,14 +56,14 @@ public class MessageStrings {
           "    to operate. You will not be able to use Briefcase until you set this location.\n\n" +
           "2. We gather anonymous usage data (e.g., operating system, version number) to help\n" +
           "    our community prioritize fixes and features. If you do not want to contribute\n" +
-          "    your data, please uncheck that setting.\n\n" +
+          "    your usage data, please uncheck that setting.\n\n" +
           "3. ODK is a community-powered project and the community lives at\n" +
           "    https://forum.opendatakit.org. Stop by for a visit and introduce yourself!\n" +
           "\n";
   static final String TRACKING_WARNING = "" +
-      "We gather anonymous usage data (e.g., operating system, version number) to help\n" +
+      "We now gather anonymous usage data (e.g., operating system, version number) to help\n" +
       "our community prioritize fixes and features. If you do not want to contribute\n" +
-      "your data, please uncheck that setting.\n\n";
+      "your usage data, please uncheck that setting in the Settings tab.\n";
   public static final String README_CONTENTS =
       "This ODK Briefcase storage area retains\n" +
           "all the forms and submissions that have been\n" +


### PR DESCRIPTION
I clarified that the data that being collected is usage data because we don't want people to think we are collecting form data. This is the language that was used in the issue at #444.

I also added a `now` to the upgrade dialog to help explain why they are seeing the dialog.

I removed the icon because it's doesn't add much and because it is low resolution is, IMHO, distracting.