### PR TITLE
Issue 455 bug pulling from odk

### DIFF
--- a/src/org/opendatakit/briefcase/export/ExportForms.java
+++ b/src/org/opendatakit/briefcase/export/ExportForms.java
@@ -159,6 +159,10 @@ public class ExportForms {
     this.transferSettings.put(getFormId(form), transferSettings);
   }
 
+  public void removeTransferSettings(FormStatus form) {
+    transferSettings.remove(getFormId(form));
+  }
+
   public boolean allSelectedFormsHaveConfiguration() {
     return getSelectedForms().stream()
         .map(ExportForms::getFormId)

--- a/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
+++ b/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
@@ -145,6 +145,16 @@ public class BriefcasePreferences {
    *
    * @param keys keys whose mappings are to be removed from the preference node.
    */
+  public void removeAll(String... keys) {
+    removeAll(Arrays.asList(keys));
+  }
+
+  /**
+   * Removes all the values associated with the specified key list in this preference
+   * node, if any.
+   *
+   * @param keys keys whose mappings are to be removed from the preference node.
+   */
   public void removeAll(List<String> keys) {
     keys.forEach(this::remove);
   }

--- a/src/org/opendatakit/briefcase/model/TransferSucceededEvent.java
+++ b/src/org/opendatakit/briefcase/model/TransferSucceededEvent.java
@@ -17,17 +17,21 @@
 package org.opendatakit.briefcase.model;
 
 import java.util.List;
+import java.util.Optional;
 
 public class TransferSucceededEvent {
-
   @SuppressWarnings("unused")
   private final boolean isDeletableSource;
   public final List<FormStatus> formsToTransfer;
-  public final ServerConnectionInfo transferSettings;
+  public final Optional<ServerConnectionInfo> transferSettings;
 
-  public TransferSucceededEvent(boolean isDeletableSource, List<FormStatus> formsToTransfer, ServerConnectionInfo transferSettings) {
+  public TransferSucceededEvent(boolean isDeletableSource, List<FormStatus> formsToTransfer, Optional<ServerConnectionInfo> transferSettings) {
     this.isDeletableSource = isDeletableSource;
     this.formsToTransfer = formsToTransfer;
     this.transferSettings = transferSettings;
+  }
+
+  public static TransferSucceededEvent from(boolean isDeletableSource, List<FormStatus> formsToTransfer, ServerConnectionInfo transferSettings) {
+    return new TransferSucceededEvent(isDeletableSource, formsToTransfer, Optional.of(transferSettings));
   }
 }

--- a/src/org/opendatakit/briefcase/transfer/NewTransferAction.java
+++ b/src/org/opendatakit/briefcase/transfer/NewTransferAction.java
@@ -43,7 +43,7 @@ public class NewTransferAction {
         EventBus.publish(new TransferFailedEvent(false, formsToTransfer));
 
       if (allSuccessful)
-        EventBus.publish(new TransferSucceededEvent(false, formsToTransfer, transferSettings));
+        EventBus.publish(TransferSucceededEvent.from(false, formsToTransfer, transferSettings));
     } catch (Exception e) {
       log.error("transfer action failed", e);
       EventBus.publish(new TransferFailedEvent(false, formsToTransfer));

--- a/src/org/opendatakit/briefcase/ui/PullTransferPanel.java
+++ b/src/org/opendatakit/briefcase/ui/PullTransferPanel.java
@@ -27,6 +27,7 @@ import java.awt.event.FocusEvent;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import javax.swing.GroupLayout;
 import javax.swing.GroupLayout.Alignment;
@@ -473,12 +474,22 @@ public class PullTransferPanel extends JPanel {
   @EventSubscriber(eventClass = TransferSucceededEvent.class)
   public void onTransferSucceededEvent(TransferSucceededEvent event) {
     setActiveTransferState(false);
-    if (BriefcasePreferences.getStorePasswordsConsentProperty() && event.transferSettings.isPresent()) {
-      event.formsToTransfer.forEach(form -> {
-        appPreferences.put(String.format("%s_pull_settings_url", form.getFormDefinition().getFormId()), event.transferSettings.get().getUrl());
-        appPreferences.put(String.format("%s_pull_settings_username", form.getFormDefinition().getFormId()), event.transferSettings.get().getUsername());
-        appPreferences.put(String.format("%s_pull_settings_password", form.getFormDefinition().getFormId()), String.valueOf(event.transferSettings.get().getPassword()));
-      });
+    if (BriefcasePreferences.getStorePasswordsConsentProperty()) {
+      if (event.transferSettings.isPresent()) {
+        event.formsToTransfer.forEach(form -> {
+          appPreferences.put(String.format("%s_pull_settings_url", form.getFormDefinition().getFormId()), event.transferSettings.get().getUrl());
+          appPreferences.put(String.format("%s_pull_settings_username", form.getFormDefinition().getFormId()), event.transferSettings.get().getUsername());
+          appPreferences.put(String.format("%s_pull_settings_password", form.getFormDefinition().getFormId()), String.valueOf(event.transferSettings.get().getPassword()));
+        });
+      } else {
+        event.formsToTransfer.forEach(form -> {
+          appPreferences.removeAll(Arrays.asList(
+              String.format("%s_pull_settings_url", form.getFormDefinition().getFormId()),
+              String.format("%s_pull_settings_username", form.getFormDefinition().getFormId()),
+              String.format("%s_pull_settings_password", form.getFormDefinition().getFormId())
+          ));
+        });
+      }
     }
     analytics.event("Pull", "Transfer", "Success", null);
   }

--- a/src/org/opendatakit/briefcase/ui/PullTransferPanel.java
+++ b/src/org/opendatakit/briefcase/ui/PullTransferPanel.java
@@ -27,7 +27,6 @@ import java.awt.event.FocusEvent;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import javax.swing.GroupLayout;
 import javax.swing.GroupLayout.Alignment;
@@ -482,13 +481,11 @@ public class PullTransferPanel extends JPanel {
           appPreferences.put(String.format("%s_pull_settings_password", form.getFormDefinition().getFormId()), String.valueOf(event.transferSettings.get().getPassword()));
         });
       } else {
-        event.formsToTransfer.forEach(form -> {
-          appPreferences.removeAll(Arrays.asList(
-              String.format("%s_pull_settings_url", form.getFormDefinition().getFormId()),
-              String.format("%s_pull_settings_username", form.getFormDefinition().getFormId()),
-              String.format("%s_pull_settings_password", form.getFormDefinition().getFormId())
-          ));
-        });
+        event.formsToTransfer.forEach(form -> appPreferences.removeAll(
+            String.format("%s_pull_settings_url", form.getFormDefinition().getFormId()),
+            String.format("%s_pull_settings_username", form.getFormDefinition().getFormId()),
+            String.format("%s_pull_settings_password", form.getFormDefinition().getFormId())
+        ));
       }
     }
     analytics.event("Pull", "Transfer", "Success", null);

--- a/src/org/opendatakit/briefcase/ui/PullTransferPanel.java
+++ b/src/org/opendatakit/briefcase/ui/PullTransferPanel.java
@@ -473,11 +473,11 @@ public class PullTransferPanel extends JPanel {
   @EventSubscriber(eventClass = TransferSucceededEvent.class)
   public void onTransferSucceededEvent(TransferSucceededEvent event) {
     setActiveTransferState(false);
-    if (BriefcasePreferences.getStorePasswordsConsentProperty()) {
+    if (BriefcasePreferences.getStorePasswordsConsentProperty() && event.transferSettings.isPresent()) {
       event.formsToTransfer.forEach(form -> {
-        appPreferences.put(String.format("%s_pull_settings_url", form.getFormDefinition().getFormId()), event.transferSettings.getUrl());
-        appPreferences.put(String.format("%s_pull_settings_username", form.getFormDefinition().getFormId()), event.transferSettings.getUsername());
-        appPreferences.put(String.format("%s_pull_settings_password", form.getFormDefinition().getFormId()), String.valueOf(event.transferSettings.getPassword()));
+        appPreferences.put(String.format("%s_pull_settings_url", form.getFormDefinition().getFormId()), event.transferSettings.get().getUrl());
+        appPreferences.put(String.format("%s_pull_settings_username", form.getFormDefinition().getFormId()), event.transferSettings.get().getUsername());
+        appPreferences.put(String.format("%s_pull_settings_password", form.getFormDefinition().getFormId()), String.valueOf(event.transferSettings.get().getPassword()));
       });
     }
     analytics.event("Pull", "Transfer", "Success", null);

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -210,8 +210,11 @@ public class ExportPanel {
 
   @EventSubscriber(eventClass = TransferSucceededEvent.class)
   public void successfulCompletion(TransferSucceededEvent event) {
-    if (BriefcasePreferences.getStorePasswordsConsentProperty() && event.transferSettings.isPresent())
-      event.formsToTransfer.forEach(form -> forms.putTransferSettings(form, event.transferSettings.get()));
+    if (BriefcasePreferences.getStorePasswordsConsentProperty())
+      if (event.transferSettings.isPresent())
+        event.formsToTransfer.forEach(form -> forms.putTransferSettings(form, event.transferSettings.get()));
+      else
+        event.formsToTransfer.forEach(forms::removeTransferSettings);
   }
 
   @EventSubscriber(eventClass = SavePasswordsConsentGiven.class)

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -210,8 +210,8 @@ public class ExportPanel {
 
   @EventSubscriber(eventClass = TransferSucceededEvent.class)
   public void successfulCompletion(TransferSucceededEvent event) {
-    if (BriefcasePreferences.getStorePasswordsConsentProperty())
-      event.formsToTransfer.forEach(form -> forms.putTransferSettings(form, event.transferSettings));
+    if (BriefcasePreferences.getStorePasswordsConsentProperty() && event.transferSettings.isPresent())
+      event.formsToTransfer.forEach(form -> forms.putTransferSettings(form, event.transferSettings.get()));
   }
 
   @EventSubscriber(eventClass = SavePasswordsConsentGiven.class)

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelMode.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelMode.java
@@ -21,7 +21,7 @@ import javax.swing.JLabel;
 import javax.swing.JTextPane;
 
 class ConfigurationPanelMode {
-  static final String REQUIRE_PULL_TEXT = "Requires manually pulling the form once";
+  static final String REQUIRE_PULL_TEXT = "Requires manually pulling from Aggregate once";
   static final String REQUIRE_SAVE_PASSWORDS = "Requires Remember passwords in Settings";
   private final boolean isOverridePanel;
   private boolean savePasswordsConsent;

--- a/src/org/opendatakit/briefcase/util/ITransferFromSourceAction.java
+++ b/src/org/opendatakit/briefcase/util/ITransferFromSourceAction.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.briefcase.util;
 
+import java.util.Optional;
 import org.opendatakit.briefcase.model.ServerConnectionInfo;
 
 interface ITransferFromSourceAction {
@@ -30,5 +31,5 @@ interface ITransferFromSourceAction {
    */
   boolean isSourceDeletable();
 
-  ServerConnectionInfo getTransferSettings();
+  Optional<ServerConnectionInfo> getTransferSettings();
 }

--- a/src/org/opendatakit/briefcase/util/TransferAction.java
+++ b/src/org/opendatakit/briefcase/util/TransferAction.java
@@ -57,7 +57,7 @@ public class TransferAction {
         boolean allSuccessful = dest.doAction();
 
         if (allSuccessful) {
-          EventBus.publish(new TransferSucceededEvent(srcIsDeletable, formsToTransfer, dest.getTransferSettings()));
+          EventBus.publish(TransferSucceededEvent.from(srcIsDeletable, formsToTransfer, dest.getTransferSettings()));
         } else {
           EventBus.publish(new TransferFailedEvent(srcIsDeletable, formsToTransfer));
         }

--- a/src/org/opendatakit/briefcase/util/TransferFromODK.java
+++ b/src/org/opendatakit/briefcase/util/TransferFromODK.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Optional;
 import org.apache.commons.io.FileUtils;
 import org.bushe.swing.event.EventBus;
 import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
@@ -345,9 +346,8 @@ public class TransferFromODK implements ITransferFromSourceAction {
   }
 
   @Override
-  public ServerConnectionInfo getTransferSettings() {
-    // TODO Solve this violation of Liskov's principle
-    throw new RuntimeException("This class has no transfer settings");
+  public Optional<ServerConnectionInfo> getTransferSettings() {
+    return Optional.empty();
   }
 
   public static void pull(Path odk, List<FormStatus> forms) {

--- a/src/org/opendatakit/briefcase/util/TransferFromServer.java
+++ b/src/org/opendatakit/briefcase/util/TransferFromServer.java
@@ -18,6 +18,7 @@ package org.opendatakit.briefcase.util;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.bushe.swing.event.EventBus;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.ServerConnectionInfo;
@@ -58,7 +59,7 @@ public class TransferFromServer implements ITransferFromSourceAction {
     try {
       boolean allSuccessful = action.doAction();
       if (allSuccessful)
-        EventBus.publish(new TransferSucceededEvent(false, formList, transferSettings));
+        EventBus.publish(TransferSucceededEvent.from(false, formList, transferSettings));
 
       if (!allSuccessful)
         throw new PullFromServerException(formList);
@@ -69,7 +70,7 @@ public class TransferFromServer implements ITransferFromSourceAction {
   }
 
   @Override
-  public ServerConnectionInfo getTransferSettings() {
-    return originServerInfo;
+  public Optional<ServerConnectionInfo> getTransferSettings() {
+    return Optional.of(originServerInfo);
   }
 }

--- a/src/org/opendatakit/briefcase/util/TransferToServer.java
+++ b/src/org/opendatakit/briefcase/util/TransferToServer.java
@@ -52,7 +52,7 @@ public class TransferToServer implements ITransferToDestAction {
     try {
       boolean allSuccessful = action.doAction();
       if (allSuccessful)
-        EventBus.publish(new TransferSucceededEvent(false, formList, transferSettings));
+        EventBus.publish(TransferSucceededEvent.from(false, formList, transferSettings));
 
       if (!allSuccessful)
         throw new PushFromServerException(formList);


### PR DESCRIPTION
Addresses first part of #455

#### What has been done to verify that this works as intended?
Manually tested:
- Send a submission from Collect to Aggregate
- Pull it with Briefcase (with "remember passwords" enabled)
- Check that exporting the form with the "pull before export" enabled works as expected
- Pull the same form from a custom ODK dir
- Check that no errors are logged in the output or log files
- Check that now Briefcase asks to pull the form from Aggregate to be able to "pull before export"

#### Why is this the best possible solution? Were any other approaches considered?
This is the narrowest fix without changing the design I could come up with. A change of design would be recommended, as discussed in #455

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.