### PR TITLE
Issue 442 improve cli push

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,8 @@ dependencies {
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
     }
     compile group: 'com.github.lgooddatepicker', name: 'LGoodDatePicker', version: '10.3.1'
+    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.5'
+    compile group: 'org.apache.httpcomponents', name: 'fluent-hc', version: '4.5.5'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile('junit:junit:4.12'){

--- a/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
@@ -49,13 +49,14 @@ public class PushFormToAggregate {
           args.get(FORM_ID),
           args.get(ODK_USERNAME),
           args.get(ODK_PASSWORD),
-          args.get(AGGREGATE_SERVER)
+          args.get(AGGREGATE_SERVER),
+          args.has(FORCE_SEND_BLANK)
       ),
       Arrays.asList(STORAGE_DIR, FORM_ID, ODK_USERNAME, ODK_PASSWORD, AGGREGATE_SERVER),
       Collections.singletonList(FORCE_SEND_BLANK)
   );
 
-  private static void pushFormToAggregate(String storageDir, String formid, String username, String password, String server) {
+  private static void pushFormToAggregate(String storageDir, String formid, String username, String password, String server, boolean forceSendBlank) {
     CliEventsCompanion.attach(log);
     bootCache(storageDir);
     Optional<FormStatus> maybeFormStatus = FileSystemUtils.getBriefcaseFormList().stream()
@@ -73,7 +74,7 @@ public class PushFormToAggregate {
 
     RemoteServer remoteServer = RemoteServer.authenticated(transferSettings.getUrl(), transferSettings.getUsername(), new String(transferSettings.getPassword()));
 
-    TransferToServer.push(transferSettings, http, remoteServer, form);
+    TransferToServer.push(transferSettings, http, remoteServer, forceSendBlank, form);
   }
 
 }

--- a/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
@@ -26,6 +26,8 @@ import java.util.Arrays;
 import java.util.Optional;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.ServerConnectionInfo;
+import org.opendatakit.briefcase.push.RemoteServer;
+import org.opendatakit.briefcase.reused.http.CommonsHttp;
 import org.opendatakit.briefcase.util.FileSystemUtils;
 import org.opendatakit.briefcase.util.ServerConnectionTest;
 import org.opendatakit.briefcase.util.TransferToServer;
@@ -64,7 +66,11 @@ public class PushFormToAggregate {
 
     ServerConnectionTest.testPush(transferSettings);
 
-    TransferToServer.push(transferSettings, form);
+    CommonsHttp http = new CommonsHttp();
+
+    RemoteServer remoteServer = RemoteServer.authenticated(transferSettings.getUrl(), transferSettings.getUsername(), new String(transferSettings.getPassword()));
+
+    TransferToServer.push(transferSettings, http, remoteServer, form);
   }
 
 }

--- a/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
@@ -23,6 +23,7 @@ import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 import static org.opendatakit.briefcase.operations.Common.bootCache;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.ServerConnectionInfo;
@@ -39,6 +40,7 @@ import org.slf4j.LoggerFactory;
 public class PushFormToAggregate {
   private static final Logger log = LoggerFactory.getLogger(PushFormToAggregate.class);
   private static final Param<Void> PUSH_AGGREGATE = Param.flag("psha", "push_aggregate", "Push form to an Aggregate instance");
+  private static final Param<Void> FORCE_SEND_BLANK = Param.flag("fsb", "force_send_blank", "Force sending the blank form to the Aggregate instance");
 
   public static Operation PUSH_FORM_TO_AGGREGATE = Operation.of(
       PUSH_AGGREGATE,
@@ -49,7 +51,8 @@ public class PushFormToAggregate {
           args.get(ODK_PASSWORD),
           args.get(AGGREGATE_SERVER)
       ),
-      Arrays.asList(STORAGE_DIR, FORM_ID, ODK_USERNAME, ODK_PASSWORD, AGGREGATE_SERVER)
+      Arrays.asList(STORAGE_DIR, FORM_ID, ODK_USERNAME, ODK_PASSWORD, AGGREGATE_SERVER),
+      Collections.singletonList(FORCE_SEND_BLANK)
   );
 
   private static void pushFormToAggregate(String storageDir, String formid, String username, String password, String server) {

--- a/src/org/opendatakit/briefcase/push/RemoteServer.java
+++ b/src/org/opendatakit/briefcase/push/RemoteServer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.push;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.opendatakit.briefcase.reused.http.Credentials;
+import org.opendatakit.briefcase.reused.http.Query;
+
+/**
+ * This class represents a remote Aggregate server and it has some methods
+ * to query its state.
+ */
+public class RemoteServer {
+  private final URI baseUri;
+  private final Optional<Credentials> credentials;
+
+  private RemoteServer(URI baseUri, Optional<Credentials> credentials) {
+    this.baseUri = baseUri;
+    this.credentials = credentials;
+  }
+
+  /**
+   * Factory that creates a new {@link RemoteServer} to be used when it requires
+   * authentication.
+   */
+  public static RemoteServer authenticated(String baseUri, String username, String password) {
+    return new RemoteServer(
+        URI.create(baseUri),
+        Optional.of(new Credentials(username, password))
+    );
+  }
+
+  /**
+   * Factory that creates a new {@link RemoteServer} to be used when it doesn't
+   * require authentication.
+   */
+  public static RemoteServer normal(String baseUri) {
+    return new RemoteServer(URI.create(baseUri), Optional.empty());
+  }
+
+  /**
+   * Returns a new {@link Query} to check if the given form ID is present in the
+   * remote server or not.
+   *
+   * @return true if the form is present on the remote server, false otherwise
+   */
+  public Query<Boolean> containsFormQuery(String formId) {
+    return buildBaseQuery()
+        .resolve("/formList")
+        .map((String body) -> Stream.of(body.split("\n"))
+            .anyMatch(s -> s.contains("<formID>" + formId + "</formID>")));
+  }
+
+  private Query<String> buildBaseQuery() {
+    return new Query<>(baseUri, credentials, Function.identity());
+  }
+}

--- a/src/org/opendatakit/briefcase/reused/http/CommonsHttp.java
+++ b/src/org/opendatakit/briefcase/reused/http/CommonsHttp.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.reused.http;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import org.apache.http.HttpHost;
+import org.apache.http.client.fluent.Executor;
+import org.apache.http.client.fluent.Request;
+
+public class CommonsHttp implements Http {
+  @Override
+  public <T> T execute(Query<T> query) {
+    // Always instantiate a new Executor to avoid side-effects between executions
+    Executor executor = Executor.newInstance();
+    // Apply auth settings if credentials are received
+    query.ifCredentials((URI uri, Credentials credentials) -> executor.auth(
+        HttpHost.create(uri.getHost()),
+        credentials.getUsername(),
+        credentials.getPassword()
+    ));
+    // get the response body and let the Query map it
+    return query.map(uncheckedExecute(query, executor));
+  }
+
+  private <T> String uncheckedExecute(Query<T> query, Executor executor) {
+    try {
+      Request request = Request.Get(query.getUri())
+          .addHeader("X-OpenRosa-Version", "1.0");
+      return executor.execute(request)
+          .returnContent()
+          .asString();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/src/org/opendatakit/briefcase/reused/http/Credentials.java
+++ b/src/org/opendatakit/briefcase/reused/http/Credentials.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.reused.http;
+
+import java.util.Objects;
+
+/**
+ * This Value Object class holds a username/password pair to be used as credentials.
+ */
+public class Credentials {
+  private final String username;
+  private final String password;
+
+  public Credentials(String username, String password) {
+    this.username = username;
+    this.password = password;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Credentials that = (Credentials) o;
+    return Objects.equals(username, that.username) &&
+        Objects.equals(password, that.password);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(username, password);
+  }
+
+  @Override
+  public String toString() {
+    return "Credentials(" + username + ", ***)";
+  }
+}

--- a/src/org/opendatakit/briefcase/reused/http/Http.java
+++ b/src/org/opendatakit/briefcase/reused/http/Http.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.reused.http;
+
+/**
+ * This interface has Briefcase's HTTP API to interact with external services
+ */
+public interface Http {
+  /**
+   * Runs a {@link Query} and returns some output value.
+   *
+   * @param query the {@link Query} to be executed
+   * @param <T>   type of the output value
+   * @return an output value of type T
+   */
+  <T> T execute(Query<T> query);
+}

--- a/src/org/opendatakit/briefcase/reused/http/Query.java
+++ b/src/org/opendatakit/briefcase/reused/http/Query.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.reused.http;
+
+import java.net.URI;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+/**
+ * This Value Object class represents a query to some {@link URI}, maybe using
+ * some {@link Credentials} for authentication.
+ * <p>
+ * It also gives type hints about the result calling sites would be able to expect
+ * when executed.
+ */
+public class Query<T> {
+  private final URI uri;
+  private final Optional<Credentials> credentials;
+  private final Function<String, T> bodyMapper;
+
+  /**
+   * Main constructor for {@link Query} instances.
+   *
+   * @param uri         the {@link URI} this query must be sent to
+   * @param credentials the authentication {@link Credentials}, wrapped inside
+   *                    an {@link Optional}, or an {@link Optional#empty()} if
+   *                    no credentials are required
+   * @param bodyMapper  a {@link Function} that takes the output body from the
+   *                    request and maps it to some other type
+   */
+  public Query(URI uri, Optional<Credentials> credentials, Function<String, T> bodyMapper) {
+    this.uri = uri;
+    this.credentials = credentials;
+    this.bodyMapper = bodyMapper;
+  }
+
+  /**
+   * Factory to create new {@link Query} instances for authenticated requests.
+   */
+  public static Query<String> authenticated(String uri, String username, String password) {
+    return new Query<>(
+        URI.create(uri),
+        Optional.of(new Credentials(username, password)),
+        Function.identity()
+    );
+  }
+
+  /**
+   * Factory to create new {@link Query} instances for non authenticated ("normal", lacking of
+   * a better name) requests.
+   */
+  public static Query<String> normal(String uri) {
+    return new Query<>(URI.create(uri), Optional.empty(), Function.identity());
+  }
+
+  /**
+   * Return a new {@link Query} pointing to other {@link URI} obtained by resolving
+   * the given path.
+   */
+  public Query<T> resolve(String path) {
+    return new Query<>(uri.resolve(path), credentials, bodyMapper);
+  }
+
+  /**
+   * Map a body {@link String} using the {@link Query#bodyMapper} and return the result.
+   */
+  public T map(String body) {
+    return bodyMapper.apply(body);
+  }
+
+  /**
+   * Return a new {@link Query} that will use the given {@link Function} as its {@link Query#bodyMapper}
+   *
+   * @see Query#map(String)
+   */
+  public <U> Query<U> map(Function<T, U> newBodyMapper) {
+    return new Query<>(uri, credentials, bodyMapper.andThen(newBodyMapper));
+  }
+
+  /**
+   * Run the given consumer if this {@link Query} has some credentials defined.
+   */
+  public void ifCredentials(BiConsumer<URI, Credentials> consumer) {
+    credentials.ifPresent(c -> consumer.accept(uri, c));
+  }
+
+  /**
+   * Return this {@link Query} instance's {@link URI} member
+   */
+  public URI getUri() {
+    return uri;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Query<?> query = (Query<?>) o;
+    return Objects.equals(uri, query.uri) &&
+        Objects.equals(credentials, query.credentials);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(uri, credentials);
+  }
+
+  @Override
+  public String toString() {
+    return "GET " + uri + " " + credentials.map(Credentials::toString).orElse("no credentials") + ")";
+  }
+}

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -53,6 +53,8 @@ import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.ExportAbortEvent;
 import org.opendatakit.briefcase.model.TerminationFuture;
 import org.opendatakit.briefcase.model.TransferAbortEvent;
+import org.opendatakit.briefcase.reused.http.CommonsHttp;
+import org.opendatakit.briefcase.reused.http.Http;
 import org.opendatakit.briefcase.ui.export.ExportPanel;
 import org.opendatakit.briefcase.ui.reused.Analytics;
 import org.opendatakit.briefcase.util.FileSystemUtils;
@@ -247,6 +249,8 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
     analytics.enter("Briefcase");
     Runtime.getRuntime().addShutdownHook(new Thread(() -> analytics.leave("Briefcase")));
 
+    Http http = new CommonsHttp();
+
     frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
 
     storageLocation = new StorageLocation();
@@ -258,7 +262,7 @@ public class MainBriefcaseWindow extends WindowAdapter implements UiStateChangeL
     PullTransferPanel gatherPanel = new PullTransferPanel(transferTerminationFuture, BriefcasePreferences.forClass(PullTransferPanel.class), appPreferences, analytics);
     addPane(PullTransferPanel.TAB_NAME, gatherPanel);
 
-    uploadPanel = new PushTransferPanel(transferTerminationFuture, BriefcasePreferences.forClass(PushTransferPanel.class), analytics);
+    uploadPanel = new PushTransferPanel(transferTerminationFuture, BriefcasePreferences.forClass(PushTransferPanel.class), analytics, http);
     addPane(PushTransferPanel.TAB_NAME, uploadPanel);
 
     exportPanel = ExportPanel.from(exportTerminationFuture, BriefcasePreferences.forClass(ExportPanel.class), appPreferences, BACKGROUND_EXECUTOR, analytics);

--- a/src/org/opendatakit/briefcase/util/ServerUploader.java
+++ b/src/org/opendatakit/briefcase/util/ServerUploader.java
@@ -211,7 +211,13 @@ public class ServerUploader {
 
       boolean outcome;
       boolean existsAlready = http.execute(server.containsFormQuery(formToTransfer.getFormDefinition().getFormId()));
-      outcome = existsAlready || uploadForm(formToTransfer, briefcaseFormDefFile, briefcaseFormMediaDir);
+      if (!existsAlready)
+        outcome = uploadForm(formToTransfer, briefcaseFormDefFile, briefcaseFormMediaDir);
+      else {
+        formToTransfer.setStatusString("Skipping form upload to remote server because it already exists", true);
+        EventBus.publish(new FormStatusEvent(formToTransfer));
+        outcome = true;
+      }
       thisFormSuccessful = thisFormSuccessful & outcome;
       allSuccessful = allSuccessful & outcome;
 

--- a/src/org/opendatakit/briefcase/util/ServerUploader.java
+++ b/src/org/opendatakit/briefcase/util/ServerUploader.java
@@ -39,6 +39,8 @@ import org.opendatakit.briefcase.model.ServerConnectionInfo;
 import org.opendatakit.briefcase.model.TerminationFuture;
 import org.opendatakit.briefcase.model.TransmissionException;
 import org.opendatakit.briefcase.model.XmlDocumentFetchException;
+import org.opendatakit.briefcase.push.RemoteServer;
+import org.opendatakit.briefcase.reused.http.Http;
 import org.opendatakit.briefcase.util.AggregateUtils.DocumentFetchResult;
 import org.opendatakit.briefcase.util.ServerFetcher.SubmissionChunk;
 import org.slf4j.Logger;
@@ -52,11 +54,15 @@ public class ServerUploader {
 
   private final ServerConnectionInfo serverInfo;
   private final TerminationFuture terminationFuture;
+  private final Http http;
+  private final RemoteServer server;
 
-  ServerUploader(ServerConnectionInfo serverInfo, TerminationFuture terminationFuture) {
+  ServerUploader(ServerConnectionInfo serverInfo, TerminationFuture terminationFuture, Http http, RemoteServer server) {
     AnnotationProcessor.process(this);// if not using AOP
     this.serverInfo = serverInfo;
     this.terminationFuture = terminationFuture;
+    this.server = server;
+    this.http = http;
   }
 
   public boolean isCancelled() {
@@ -204,7 +210,8 @@ public class ServerUploader {
       File briefcaseFormMediaDir = FileSystemUtils.getMediaDirectoryIfExists(briefcaseLfd.getFormDirectory());
 
       boolean outcome;
-      outcome = uploadForm(formToTransfer, briefcaseFormDefFile, briefcaseFormMediaDir);
+      boolean existsAlready = http.execute(server.containsFormQuery(formToTransfer.getFormDefinition().getFormId()));
+      outcome = existsAlready || uploadForm(formToTransfer, briefcaseFormDefFile, briefcaseFormMediaDir);
       thisFormSuccessful = thisFormSuccessful & outcome;
       allSuccessful = allSuccessful & outcome;
 

--- a/src/org/opendatakit/briefcase/util/TransferAction.java
+++ b/src/org/opendatakit/briefcase/util/TransferAction.java
@@ -178,8 +178,15 @@ public class TransferAction {
   public static void transferBriefcaseToServer(ServerConnectionInfo destinationServerInfo,
                                                TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Http http, RemoteServer server) throws IOException {
 
-    TransferToServer dest = new TransferToServer(destinationServerInfo, terminationFuture,
-        formsToTransfer, http, server);
+    TransferToServer dest = new TransferToServer(
+        destinationServerInfo,
+        terminationFuture,
+        formsToTransfer,
+        http,
+        server,
+        // Since this is only used by the GUI, always force sending the blank form
+        true
+    );
     backgroundRun(dest, formsToTransfer);
   }
 }

--- a/src/org/opendatakit/briefcase/util/TransferAction.java
+++ b/src/org/opendatakit/briefcase/util/TransferAction.java
@@ -31,6 +31,8 @@ import org.opendatakit.briefcase.model.ServerConnectionInfo;
 import org.opendatakit.briefcase.model.TerminationFuture;
 import org.opendatakit.briefcase.model.TransferFailedEvent;
 import org.opendatakit.briefcase.model.TransferSucceededEvent;
+import org.opendatakit.briefcase.push.RemoteServer;
+import org.opendatakit.briefcase.reused.http.Http;
 import org.opendatakit.briefcase.ui.TransferInProgressDialog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -174,10 +176,10 @@ public class TransferAction {
   }
 
   public static void transferBriefcaseToServer(ServerConnectionInfo destinationServerInfo,
-                                               TerminationFuture terminationFuture, List<FormStatus> formsToTransfer) throws IOException {
+                                               TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Http http, RemoteServer server) throws IOException {
 
     TransferToServer dest = new TransferToServer(destinationServerInfo, terminationFuture,
-        formsToTransfer);
+        formsToTransfer, http, server);
     backgroundRun(dest, formsToTransfer);
   }
 }

--- a/src/org/opendatakit/briefcase/util/TransferToServer.java
+++ b/src/org/opendatakit/briefcase/util/TransferToServer.java
@@ -26,34 +26,37 @@ import org.opendatakit.briefcase.model.TerminationFuture;
 import org.opendatakit.briefcase.model.TransferFailedEvent;
 import org.opendatakit.briefcase.model.TransferSucceededEvent;
 import org.opendatakit.briefcase.push.RemoteServer;
+import org.opendatakit.briefcase.reused.http.CommonsHttp;
 import org.opendatakit.briefcase.reused.http.Http;
 
 public class TransferToServer implements ITransferToDestAction {
   private final Http http;
   private final RemoteServer server;
+  private final boolean forceSendBlank;
   ServerConnectionInfo destServerInfo;
   TerminationFuture terminationFuture;
   List<FormStatus> formsToTransfer;
 
   public TransferToServer(ServerConnectionInfo destServerInfo,
-                          TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Http http, RemoteServer server) {
+                          TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Http http, RemoteServer server, boolean forceSendBlank) {
     this.destServerInfo = destServerInfo;
     this.terminationFuture = terminationFuture;
     this.formsToTransfer = formsToTransfer;
     this.http = http;
     this.server = server;
+    this.forceSendBlank = forceSendBlank;
   }
 
   @Override
   public boolean doAction() {
-    ServerUploader uploader = new ServerUploader(destServerInfo, terminationFuture, http, server);
+    ServerUploader uploader = new ServerUploader(destServerInfo, terminationFuture, http, server, forceSendBlank);
     
     return uploader.uploadFormAndSubmissionFiles( formsToTransfer);
   }
 
-  public static void push(ServerConnectionInfo transferSettings, Http http, RemoteServer server, FormStatus... forms) {
+  public static void push(ServerConnectionInfo transferSettings, CommonsHttp http, RemoteServer server, boolean forceSendBlank, FormStatus... forms) {
     List<FormStatus> formList = Arrays.asList(forms);
-    TransferToServer action = new TransferToServer(transferSettings, new TerminationFuture(), formList, http, server);
+    TransferToServer action = new TransferToServer(transferSettings, new TerminationFuture(), formList, http, server, forceSendBlank);
 
     try {
       boolean allSuccessful = action.doAction();

--- a/src/org/opendatakit/briefcase/util/TransferToServer.java
+++ b/src/org/opendatakit/briefcase/util/TransferToServer.java
@@ -25,29 +25,35 @@ import org.opendatakit.briefcase.model.ServerConnectionInfo;
 import org.opendatakit.briefcase.model.TerminationFuture;
 import org.opendatakit.briefcase.model.TransferFailedEvent;
 import org.opendatakit.briefcase.model.TransferSucceededEvent;
+import org.opendatakit.briefcase.push.RemoteServer;
+import org.opendatakit.briefcase.reused.http.Http;
 
 public class TransferToServer implements ITransferToDestAction {
+  private final Http http;
+  private final RemoteServer server;
   ServerConnectionInfo destServerInfo;
   TerminationFuture terminationFuture;
   List<FormStatus> formsToTransfer;
 
-  public TransferToServer(ServerConnectionInfo destServerInfo, 
-      TerminationFuture terminationFuture, List<FormStatus> formsToTransfer) {
+  public TransferToServer(ServerConnectionInfo destServerInfo,
+                          TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Http http, RemoteServer server) {
     this.destServerInfo = destServerInfo;
     this.terminationFuture = terminationFuture;
     this.formsToTransfer = formsToTransfer;
+    this.http = http;
+    this.server = server;
   }
 
   @Override
   public boolean doAction() {
-    ServerUploader uploader = new ServerUploader(destServerInfo, terminationFuture);
+    ServerUploader uploader = new ServerUploader(destServerInfo, terminationFuture, http, server);
     
     return uploader.uploadFormAndSubmissionFiles( formsToTransfer);
   }
 
-  public static void push(ServerConnectionInfo transferSettings, FormStatus... forms) {
+  public static void push(ServerConnectionInfo transferSettings, Http http, RemoteServer server, FormStatus... forms) {
     List<FormStatus> formList = Arrays.asList(forms);
-    TransferToServer action = new TransferToServer(transferSettings, new TerminationFuture(), formList);
+    TransferToServer action = new TransferToServer(transferSettings, new TerminationFuture(), formList, http, server);
 
     try {
       boolean allSuccessful = action.doAction();

--- a/src/org/opendatakit/briefcase/util/UploadToServer.java
+++ b/src/org/opendatakit/briefcase/util/UploadToServer.java
@@ -51,7 +51,7 @@ public class UploadToServer implements ITransferToDestAction {
   @Override
   public boolean doAction() {
 
-    ServerUploader uploader = new ServerUploader(destServerInfo, terminationFuture, new CommonsHttp(),RemoteServer.authenticated(destServerInfo.getUrl(), destServerInfo.getUsername(), new String(destServerInfo.getPassword())));
+    ServerUploader uploader = new ServerUploader(destServerInfo, terminationFuture, new CommonsHttp(),RemoteServer.authenticated(destServerInfo.getUrl(), destServerInfo.getUsername(), new String(destServerInfo.getPassword())), true);
 
     return uploader.uploadForm( status, formDef, formMediaDir);
   }

--- a/src/org/opendatakit/briefcase/util/UploadToServer.java
+++ b/src/org/opendatakit/briefcase/util/UploadToServer.java
@@ -21,6 +21,8 @@ import java.io.File;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.ServerConnectionInfo;
 import org.opendatakit.briefcase.model.TerminationFuture;
+import org.opendatakit.briefcase.push.RemoteServer;
+import org.opendatakit.briefcase.reused.http.CommonsHttp;
 
 public class UploadToServer implements ITransferToDestAction {
 
@@ -49,7 +51,7 @@ public class UploadToServer implements ITransferToDestAction {
   @Override
   public boolean doAction() {
 
-    ServerUploader uploader = new ServerUploader(destServerInfo, terminationFuture);
+    ServerUploader uploader = new ServerUploader(destServerInfo, terminationFuture, new CommonsHttp(),RemoteServer.authenticated(destServerInfo.getUrl(), destServerInfo.getUsername(), new String(destServerInfo.getPassword())));
 
     return uploader.uploadForm( status, formDef, formMediaDir);
   }

--- a/test/java/org/opendatakit/briefcase/push/RemoteServerTest.java
+++ b/test/java/org/opendatakit/briefcase/push/RemoteServerTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.push;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.opendatakit.briefcase.reused.http.FakeHttp;
+import org.opendatakit.briefcase.reused.http.Query;
+
+public class RemoteServerTest {
+  @Test
+  public void knows_if_a_form_is_present_or_not_in_an_authenticated_server() {
+    FakeHttp http = new FakeHttp();
+    http.stub(
+        Query.authenticated(
+            "https://some.server.com/formList",
+            "administrator",
+            "aggregate"
+        ),
+        "<xforms xmlns=\"http://openrosa.org/xforms/xformsList\">\n" +
+            "<xform><formID>some-form</formID>\n" +
+            "<name>Some Form</name>\n" +
+            "<majorMinorVersion>2012072302</majorMinorVersion>\n" +
+            "<version>2012072302</version>\n" +
+            "<hash>md5:29a492009d35c1515886ddd307521819</hash>\n" +
+            "<downloadUrl>https://some.server.com/formXml?formId=some-form</downloadUrl>\n" +
+            "</xform>\n" +
+            "</xforms>"
+    );
+    RemoteServer server = RemoteServer.authenticated("https://some.server.com", "administrator", "aggregate");
+    assertThat(http.execute(server.containsFormQuery("some-form")), is(true));
+    assertThat(http.execute(server.containsFormQuery("some-other-form")), is(false));
+  }
+
+  @Test
+  public void knows_if_a_form_is_present_or_not_in_a_non_authenticated_server() {
+    FakeHttp http = new FakeHttp();
+    http.stub(
+        Query.normal("https://some.server.com/formList"),
+        "<xforms xmlns=\"http://openrosa.org/xforms/xformsList\">\n" +
+            "<xform><formID>some-form</formID>\n" +
+            "<name>Some Form</name>\n" +
+            "<majorMinorVersion>2012072302</majorMinorVersion>\n" +
+            "<version>2012072302</version>\n" +
+            "<hash>md5:29a492009d35c1515886ddd307521819</hash>\n" +
+            "<downloadUrl>https://some.server.com/formXml?formId=some-form</downloadUrl>\n" +
+            "</xform>\n" +
+            "</xforms>"
+    );
+    RemoteServer server = RemoteServer.normal("https://some.server.com");
+    assertThat(http.execute(server.containsFormQuery("some-form")), is(true));
+    assertThat(http.execute(server.containsFormQuery("some-other-form")), is(false));
+  }
+
+}

--- a/test/java/org/opendatakit/briefcase/reused/http/CommonsHttpTest.java
+++ b/test/java/org/opendatakit/briefcase/reused/http/CommonsHttpTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.reused.http;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class CommonsHttpTest {
+  @Test
+  public void can_execute_a_query() {
+    Http http = new CommonsHttp();
+    String output = http.execute(Query.normal("https://github.com/opendatakit/briefcase"));
+    assertThat(output, containsString("ODK Briefcase is a Java application for fetching and pushing forms and their contents"));
+  }
+}

--- a/test/java/org/opendatakit/briefcase/reused/http/FakeHttp.java
+++ b/test/java/org/opendatakit/briefcase/reused/http/FakeHttp.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.reused.http;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class FakeHttp implements Http {
+  private final Map<Query<?>, String> stubs = new ConcurrentHashMap<>();
+
+  /**
+   * Stub a pre-defined output for a given {@link Query}.
+   */
+  public void stub(Query query, String stub) {
+    stubs.put(query, stub);
+  }
+
+  public <T> T execute(Query<T> query) {
+    return Optional.ofNullable(stubs.get(query))
+        .map(query::map)
+        .orElseThrow(RuntimeException::new);
+  }
+}


### PR DESCRIPTION
Addresses #442:
- Avoid sending the blank form if Briefcase detects that it's already present in the destination server
- Add a new CLI flag to let users decide if they want to force sending the form anyway

While we implement the rest of #442, which involves changes on the GUI, pushing from it always sends the blank forms.

#### What has been done to verify that this works as intended?
- Added tests (unit and integration) for the HTTP interaction parts
- Manually tested the CLI and GUI to verify the intended behavior:
  - CLI outputs some message telling if it's sending the blank form or skipping it. Just run the CLI op with and without the `-fsb` flag
  - GUI should add the same lines as the CLI to the push details when used in combination with `-fsb`

#### Why is this the best possible solution? Were any other approaches considered?
Most of the changes in this PR are quite straightforward but I had to choose between using the existing HTTP interaction code or implementing it new.

I've chosen to implement a new `Http` port to avoid some of the problems we have already detected on the current code:
- It has side-effects that can be unpredictable effects, especially when combined with authentication
- It has a low level of abstraction, which can be verbose, and hard to follow and change
- Whatever code based on it is inherently harder to test

#### Are there any risks to merging this code? If so, what are they?
None.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Yep: https://github.com/opendatakit/docs/issues/703