### PR TITLE
Issue 490 Lock UI on first launch

### DIFF
--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -132,6 +132,7 @@ public class MainBriefcaseWindow extends WindowAdapter {
     frame.setVisible(true);
 
     if (isFirstLaunch(appPreferences)) {
+      lockUI();
       showWelcomeMessage();
       appPreferences.put(TRACKING_WARNING_SHOWED_PREF_KEY, TRUE.toString());
     }


### PR DESCRIPTION
Closes #490

#### What has been done to verify that this works as intended?
Clear prefs, remove storage dir and run Briefcase. Check that the welcome message is shown and all the tabs are locked except for the settings tab

#### Why is this the best possible solution? Were any other approaches considered?
Just lost the line in some merge

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.