### PR TITLE
Issue 493 Restore lost analytics tracking of pull/push tabs

### DIFF
--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -111,9 +111,9 @@ public class MainBriefcaseWindow extends WindowAdapter {
     tabbedPane = new JTabbedPane(JTabbedPane.TOP);
     frame.setContentPane(tabbedPane);
 
-    addPane(PullPanel.TAB_NAME, PullPanel.from(http, appPreferences, transferTerminationFuture).getContainer());
+    addPane(PullPanel.TAB_NAME, PullPanel.from(http, appPreferences, transferTerminationFuture, analytics).getContainer());
 
-    PushPanel pushPanel = PushPanel.from(http, appPreferences, transferTerminationFuture, formCache);
+    PushPanel pushPanel = PushPanel.from(http, appPreferences, transferTerminationFuture, formCache, analytics);
     addPane(PushPanel.TAB_NAME, pushPanel.getContainer());
 
     ExportPanel exportPanel = ExportPanel.from(BriefcasePreferences.forClass(ExportPanel.class), appPreferences, analytics, formCache);

--- a/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
+++ b/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
@@ -40,6 +40,7 @@ import org.opendatakit.briefcase.ui.ODKOptionPane;
 import org.opendatakit.briefcase.ui.pull.components.PullFormsTable;
 import org.opendatakit.briefcase.ui.pull.components.PullFormsTableView;
 import org.opendatakit.briefcase.ui.pull.components.PullFormsTableViewModel;
+import org.opendatakit.briefcase.ui.reused.Analytics;
 import org.opendatakit.briefcase.ui.reused.source.Source;
 import org.opendatakit.briefcase.ui.reused.source.SourcePanel;
 
@@ -52,13 +53,14 @@ public class PullPanel {
   private TerminationFuture terminationFuture;
   private Optional<Source<?>> source = Optional.empty();
 
-  public PullPanel(PullPanelForm view, PullForms forms, BriefcasePreferences tabPreferences, BriefcasePreferences appPreferences, TerminationFuture terminationFuture) {
+  public PullPanel(PullPanelForm view, PullForms forms, BriefcasePreferences tabPreferences, BriefcasePreferences appPreferences, TerminationFuture terminationFuture, Analytics analytics) {
     AnnotationProcessor.process(this);
     this.view = view;
     this.forms = forms;
     this.tabPreferences = tabPreferences;
     this.appPreferences = appPreferences;
     this.terminationFuture = terminationFuture;
+    getContainer().addComponentListener(analytics.buildComponentListener("Pull"));
 
     // Register callbacks to view events
     view.onSource(source -> {
@@ -92,7 +94,7 @@ public class PullPanel {
     RemoteServer.readPreferences(tabPreferences).ifPresent(view::preloadSource);
   }
 
-  public static PullPanel from(Http http, BriefcasePreferences appPreferences, TerminationFuture terminationFuture) {
+  public static PullPanel from(Http http, BriefcasePreferences appPreferences, TerminationFuture terminationFuture, Analytics analytics) {
     PullForms pullForms = new PullForms(Collections.emptyList());
     PullFormsTableViewModel pullFormsTableViewModel = new PullFormsTableViewModel(pullForms);
     PullFormsTableView pullFormsTableView = new PullFormsTableView(pullFormsTableViewModel);
@@ -103,7 +105,8 @@ public class PullPanel {
         pullForms,
         BriefcasePreferences.forClass(PullPanel.class),
         appPreferences,
-        terminationFuture
+        terminationFuture,
+        analytics
     );
   }
 

--- a/src/org/opendatakit/briefcase/ui/push/PushPanel.java
+++ b/src/org/opendatakit/briefcase/ui/push/PushPanel.java
@@ -42,6 +42,7 @@ import org.opendatakit.briefcase.ui.ODKOptionPane;
 import org.opendatakit.briefcase.ui.push.components.PushFormsTable;
 import org.opendatakit.briefcase.ui.push.components.PushFormsTableView;
 import org.opendatakit.briefcase.ui.push.components.PushFormsTableViewModel;
+import org.opendatakit.briefcase.ui.reused.Analytics;
 import org.opendatakit.briefcase.ui.reused.source.Source;
 import org.opendatakit.briefcase.ui.reused.source.SourcePanel;
 import org.opendatakit.briefcase.util.FormCache;
@@ -56,7 +57,7 @@ public class PushPanel {
   private TerminationFuture terminationFuture;
   private Optional<Source> source = Optional.empty();
 
-  public PushPanel(PushPanelForm view, PushForms forms, BriefcasePreferences tabPreferences, BriefcasePreferences appPreferences, TerminationFuture terminationFuture, FormCache formCache) {
+  public PushPanel(PushPanelForm view, PushForms forms, BriefcasePreferences tabPreferences, BriefcasePreferences appPreferences, TerminationFuture terminationFuture, FormCache formCache, Analytics analytics) {
     AnnotationProcessor.process(this);
     this.view = view;
     this.forms = forms;
@@ -64,6 +65,7 @@ public class PushPanel {
     this.appPreferences = appPreferences;
     this.formCache = formCache;
     this.terminationFuture = terminationFuture;
+    getContainer().addComponentListener(analytics.buildComponentListener("Push"));
 
     // Register callbacks to view events
     view.onSource(source -> {
@@ -95,7 +97,7 @@ public class PushPanel {
     updateActionButtons();
   }
 
-  public static PushPanel from(Http http, BriefcasePreferences appPreferences, TerminationFuture terminationFuture, FormCache formCache) {
+  public static PushPanel from(Http http, BriefcasePreferences appPreferences, TerminationFuture terminationFuture, FormCache formCache, Analytics analytics) {
     PushForms pushForms = new PushForms(toFormStatuses(formCache.getForms()));
     PushFormsTableViewModel pushFormsTableViewModel = new PushFormsTableViewModel(pushForms);
     PushFormsTableView pushFormsTableView = new PushFormsTableView(pushFormsTableViewModel);
@@ -107,7 +109,8 @@ public class PushPanel {
         BriefcasePreferences.forClass(PushPanel.class),
         appPreferences,
         terminationFuture,
-        formCache
+        formCache,
+        analytics
     );
   }
 


### PR DESCRIPTION
Closes #493

#### What has been done to verify that this works as intended?
Compiled and run Briefcase.
Debugged to ensure analytics code was exercised when entering/leaving tabs

#### Why is this the best possible solution? Were any other approaches considered?
This is just code that was lost on some merge

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope