### PR TITLE
Fix pattern to check if form exists on remote server

### DIFF
--- a/src/org/opendatakit/briefcase/reused/RemoteServer.java
+++ b/src/org/opendatakit/briefcase/reused/RemoteServer.java
@@ -133,7 +133,7 @@ public class RemoteServer {
   public boolean containsForm(Http http, String formId) {
     return http.execute(Request.get(baseUrl, credentials)
         .resolve("/formList")
-        .withMapper(body -> Stream.of(body.split("\n")).anyMatch(line -> line.contains("?formId=" + formId + "\""))))
+        .withMapper(body -> Stream.of(body.split("\n")).anyMatch(line -> line.contains("?formId=" + formId))))
         .orElse(false);
   }
 


### PR DESCRIPTION
Closes #492

#### What has been done to verify that this works as intended?
Manually tested UI and CLI push operations to verify that:
- The UI, it always pushes the blank form
- The CLI, it only pushes the blank form if the form doesn't exist or when `-fsb` is used

#### Why is this the best possible solution? Were any other approaches considered?
This is just a change to rescue the pattern fix, lost while merging branches. The previous pattern works when no JR headers are sent with the form list request.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.