### PR TITLE
Fix date range validation to allow start & date to be the same

### DIFF
--- a/src/org/opendatakit/briefcase/export/ExportConfiguration.java
+++ b/src/org/opendatakit/briefcase/export/ExportConfiguration.java
@@ -244,7 +244,7 @@ public class ExportConfiguration {
   }
 
   private boolean isDateRangeValid() {
-    return !startDate.isPresent() || !endDate.isPresent() || startDate.get().isBefore(endDate.get());
+    return !startDate.isPresent() || !endDate.isPresent() || !startDate.get().isAfter(endDate.get());
   }
 
   public void ifExportDirPresent(Consumer<Path> consumer) {


### PR DESCRIPTION
Closes #496

#### What has been done to verify that this works as intended?
Manually tested that the export button gets enabled when choosing the same date in the start and end filter fields.

#### Why is this the best possible solution? Were any other approaches considered?
This is a quite straightforward fix to ensure that the date ranges work the way we want.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.