### PR TITLE
Fix success message to be the same as other pull sources

### DIFF
--- a/src/org/opendatakit/briefcase/ui/pull/FormInstaller.java
+++ b/src/org/opendatakit/briefcase/ui/pull/FormInstaller.java
@@ -84,10 +84,11 @@ public class FormInstaller {
           .forEach(sourcePath -> {
             copy(sourcePath, targetMediaDir.resolve(sourceMediaDir.relativize(sourcePath)));
             form.setStatusString("Installed " + sourcePath.getFileName() + " media file", true);
+            form.setStatusString("Installed " + sourcePath.getFileName() + " media file", true);
             EventBus.publish(new FormStatusEvent(form));
           });
 
-    form.setStatusString("Successfully installed", true);
+    form.setStatusString("Success", true);
     EventBus.publish(new FormStatusEvent(form));
   }
 


### PR DESCRIPTION
Closes #497 

#### What has been done to verify that this works as intended?
Manually pulled an individual form to verify that the message says "Success"

#### Why is this the best possible solution? Were any other approaches considered?
It's a straightforward text change. No behavior change.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.