### PR TITLE
Improve error handling of the export process

### DIFF
--- a/src/org/opendatakit/briefcase/export/ExportEvent.java
+++ b/src/org/opendatakit/briefcase/export/ExportEvent.java
@@ -45,6 +45,14 @@ public final class ExportEvent {
     return new ExportEvent(form.getFormId(), String.format("Failure: %s", cause), false);
   }
 
+  public static ExportEvent failureSubmission(FormDefinition form, String instanceId, Throwable cause) {
+    return new ExportEvent(
+        form.getFormId(),
+        String.format("Can't export submission %s of form ID %s. Cause: %s", instanceId, form.getFormId(), cause.getMessage()),
+        false
+    );
+  }
+
   public static ExportEvent successForm(FormDefinition formDef, int total) {
     return new ExportEvent(formDef.getFormId(), String.format("Exported %d submission%s", total, sUnlessOne(total)), true);
   }

--- a/src/org/opendatakit/briefcase/ui/reused/source/SelectSourceForm.java
+++ b/src/org/opendatakit/briefcase/ui/reused/source/SelectSourceForm.java
@@ -73,7 +73,7 @@ public class SelectSourceForm extends JComponent {
     container = new JPanel();
     container.setLayout(new GridBagLayout());
     actionLabel = new JLabel();
-    actionLabel.setText("Pull Data From");
+    actionLabel.setText("Pull from");
     GridBagConstraints gbc;
     gbc = new GridBagConstraints();
     gbc.gridx = 0;


### PR DESCRIPTION
This PR improves error handling of the export process
- By separating the generation of CSV lines from the writing of those lines in files, we can control any parsing/mapping problem and react by gracefully ignoring the error and logging/sending feedback events
- Parsing errors can happen while trying to read submission dates. Those submissions must be skipped and reported as individual failures
- We should prevent the export process from failing due to errors while parsing/mapping individual submissions

Before this, any parsing error would stop the export and show a cryptic error dialog to the user.

#### What has been done to verify that this works as intended?
Tampered an individual submission to produce xml syntax errors and exported it.
Checked that:
- the tampered submission is not present in the output.
- other submissions are present in the ouptut
- the overall process finished and shows the number of exported submissions

#### Why is this the best possible solution? Were any other approaches considered?
It's the narrowest solution I could come up with

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope