### PR TITLE
Issue 512 Fix remember passwords checkbox behavior

### DIFF
--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -89,7 +89,7 @@ public class ExportPanel {
       } else {
         analytics.event("Export", "Export", "Configuration errors", null);
         showErrorDialog(getForm().getContainer(), errors.stream().collect(joining("\n")), "Export errors");
-        form.unsetExporting();
+        form.unsetExporting(appPreferences.getRememberPasswords().orElse(false));
       }
     });
 
@@ -199,7 +199,7 @@ public class ExportPanel {
       log.error("Error while exporting forms", t);
       showErrorDialog(getForm().getContainer(), "Unexpected error. See logs", "Export errors");
     } finally {
-      form.unsetExporting();
+      form.unsetExporting(appPreferences.getRememberPasswords().orElse(false));
     }
   }
 

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanelForm.java
@@ -104,16 +104,16 @@ public class ExportPanelForm {
 
   void setExporting() {
     exportProgressBar.setVisible(true);
-    confPanel.setEnabled(false);
+    confPanel.setEnabled(false, false);
     formsTable.setEnabled(false);
     selectAllButton.setEnabled(false);
     clearAllButton.setEnabled(false);
     exportButton.setEnabled(false);
   }
 
-  void unsetExporting() {
+  void unsetExporting(boolean savePasswordsConsent) {
     exportProgressBar.setVisible(false);
-    confPanel.setEnabled(true);
+    confPanel.setEnabled(true, savePasswordsConsent);
     formsTable.setEnabled(true);
     selectAllButton.setEnabled(true);
     clearAllButton.setEnabled(true);

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanel.java
@@ -18,6 +18,7 @@ package org.opendatakit.briefcase.ui.export.components;
 import java.util.ArrayList;
 import java.util.List;
 import org.opendatakit.briefcase.export.ExportConfiguration;
+import org.opendatakit.briefcase.export.PullBeforeOverrideOption;
 
 public class ConfigurationPanel {
   private final ExportConfiguration configuration;
@@ -96,7 +97,8 @@ public class ConfigurationPanel {
     onChangeCallbacks.forEach(Runnable::run);
   }
 
-  public void setEnabled(boolean enabled) {
+  public void setEnabled(boolean enabled, boolean savePasswordsConsent) {
+    form.changeMode(savePasswordsConsent);
     form.setEnabled(enabled);
   }
 
@@ -113,6 +115,8 @@ public class ConfigurationPanel {
   }
 
   public void savePasswordsConsentRevoked() {
+    form.setPullBefore(false);
+    form.setPullBeforeOverride(PullBeforeOverrideOption.INHERIT);
     form.changeMode(false);
   }
 }

--- a/test/java/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelPageObject.java
+++ b/test/java/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelPageObject.java
@@ -92,12 +92,12 @@ class ConfigurationPanelPageObject {
     fixture.show();
   }
 
-  void disable() {
-    GuiActionRunner.execute(() -> component.setEnabled(false));
+  void disable(boolean savePasswordsConsent) {
+    GuiActionRunner.execute(() -> component.setEnabled(false, savePasswordsConsent));
   }
 
-  void enable() {
-    GuiActionRunner.execute(() -> component.setEnabled(true));
+  void enable(boolean savePasswordsConsent) {
+    GuiActionRunner.execute(() -> component.setEnabled(true, savePasswordsConsent));
   }
 
   public JButton choosePemFileButton() {

--- a/test/java/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelTest.java
+++ b/test/java/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelTest.java
@@ -122,7 +122,7 @@ public class ConfigurationPanelTest extends AssertJSwingJUnitTestCase {
   public void default_panel_can_be_disabled() {
     component = ConfigurationPanelPageObject.setUpDefaultPanel(robot(), ExportConfiguration.empty(), true, true);
     component.show();
-    component.disable();
+    component.disable(true);
     assertThat(component.exportDirField(), is(not(enabled())));
     assertThat(component.pemFileField(), is(not(enabled())));
     assertThat(component.startDateField(), is(not(enabled())));
@@ -134,8 +134,8 @@ public class ConfigurationPanelTest extends AssertJSwingJUnitTestCase {
   public void default_panel_can_be_enabled() {
     component = ConfigurationPanelPageObject.setUpDefaultPanel(robot(), ExportConfiguration.empty(), true, true);
     component.show();
-    component.disable();
-    component.enable();
+    component.disable(true);
+    component.enable(true);
     assertThat(component.exportDirField(), is(enabled()));
     assertThat(component.pemFileField(), is(enabled()));
     assertThat(component.startDateField(), is(enabled()));
@@ -198,7 +198,7 @@ public class ConfigurationPanelTest extends AssertJSwingJUnitTestCase {
   public void override_panel_can_be_disabled() {
     component = ConfigurationPanelPageObject.setUpOverridePanel(robot(), ExportConfiguration.empty(), true, true);
     component.show();
-    component.disable();
+    component.disable(true);
     assertThat(component.exportDirField(), is(not(enabled())));
     assertThat(component.pemFileField(), is(not(enabled())));
     assertThat(component.startDateField(), is(not(enabled())));
@@ -212,8 +212,8 @@ public class ConfigurationPanelTest extends AssertJSwingJUnitTestCase {
   public void override_panel__can_be_enabled() {
     component = ConfigurationPanelPageObject.setUpOverridePanel(robot(), ExportConfiguration.empty(), true, true);
     component.show();
-    component.disable();
-    component.enable();
+    component.disable(true);
+    component.enable(true);
     assertThat(component.exportDirField(), is(enabled()));
     assertThat(component.pemFileField(), is(enabled()));
     assertThat(component.startDateField(), is(enabled()));


### PR DESCRIPTION
- Now it stays disabled after exporting if the remember passwords setting is not checked
- Now it is unchecked if the user revokes the consent to remember passwords to avoid seeing it checked and disabled

Closes #512

#### What has been done to verify that this works as intended?
Manually tested in the UI

#### Why is this the best possible solution? Were any other approaches considered?
Passing the preference downstream is the narrowest fix I can come up with.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.