### PR TITLE
Improve data sent to analytics to track it more easily

### DIFF
--- a/src/org/opendatakit/briefcase/ui/reused/Analytics.java
+++ b/src/org/opendatakit/briefcase/ui/reused/Analytics.java
@@ -57,11 +57,21 @@ public class Analytics {
   }
 
   public void enter(String screenName) {
-    buildScreenViewHit().screenName(screenName).sessionControl("start").sendAsync();
+    buildScreenViewHit()
+        .documentTitle(screenName)
+        .documentPath(screenName.toLowerCase())
+        .screenName(screenName)
+        .sessionControl("start")
+        .sendAsync();
   }
 
   public void leave(String screenName) {
-    buildScreenViewHit().screenName(screenName).sessionControl("end").sendAsync();
+    buildScreenViewHit()
+        .documentTitle(screenName)
+        .documentPath(screenName.toLowerCase())
+        .screenName(screenName)
+        .sessionControl("end")
+        .sendAsync();
   }
 
   public void event(String category, String action, String label, Integer value) {


### PR DESCRIPTION
We were having trouble verifying that the usage information was being sent to GA, mainly because we weren't filling some fields that one would normally fill if the app was a website (following the recommendation on the GA manuals).

This PR sets the document path and title to the tab the user opens to trick GA into thinking that the app is a website. This improves a lot the information available on GA about Briefcase usage.

Previously we were even having trouble seen realtime usage information, which on this PR seems to work better.

#### What has been done to verify that this works as intended?
Manually launched Briefcase and verified on GA that we are sending data.

#### Why is this the best possible solution? Were any other approaches considered?
No other option for the moment.

#### Are there any risks to merging this code? If so, what are they?
Nope

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope