### PR TITLE
Issue 509 Fix the behavior of http proxy fields on settings tab

### DIFF
--- a/src/org/opendatakit/briefcase/ui/settings/SettingsPanel.java
+++ b/src/org/opendatakit/briefcase/ui/settings/SettingsPanel.java
@@ -43,7 +43,11 @@ public class SettingsPanel {
     appPreferences.getPullInParallel().ifPresent(form::setPullInParallel);
     appPreferences.getRememberPasswords().ifPresent(form::setRememberPasswords);
     appPreferences.getSendUsageData().ifPresent(form::setSendUsageData);
-    appPreferences.getHttpProxy().ifPresent(form::setHttpProxy);
+    appPreferences.getHttpProxy().ifPresent(httpProxy -> {
+      form.enableUseHttpProxy();
+      form.setHttpProxy(httpProxy);
+      form.updateHttpProxyFields();
+    });
 
     form.onStorageLocation(path -> {
       Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(path);


### PR DESCRIPTION
Closes #509

#### What has been done to verify that this works as intended?
Manually tested that the fields do what's expected.
Also verified that information is still saved between launches and the proxy fields are shown in the correct state,

#### Why is this the best possible solution? Were any other approaches considered?
Narrowest change

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.