### PR TITLE
Fix the default value of the overwrite files conf param

### DIFF
--- a/src/org/opendatakit/briefcase/export/ExportToCsv.java
+++ b/src/org/opendatakit/briefcase/export/ExportToCsv.java
@@ -98,7 +98,7 @@ public class ExportToCsv {
         .orElse(stripIllegalChars(formDef.getFormName()) + ".csv");
     OutputStreamWriter mainFile = getOutputStreamWriter(
         exportDir.resolve(mainFileName),
-        configuration.getOverwriteExistingFiles().orElse(true),
+        configuration.getOverwriteExistingFiles().orElse(false),
         getMainHeader(formDef.getModel(), formDef.isFileEncryptedForm())
     );
     files.put(formDef.getModel(), mainFile);


### PR DESCRIPTION
Closes #511 

#### What has been done to verify that this works as intended?
Clear preferences and launch Briefcase
Export twice the same form, verify there are double lines in the output file.

#### Why is this the best possible solution? Were any other approaches considered?
This PR just fixes the default value for that param.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.