### PR TITLE
Fix (recover) missing pull/push/export operation GA events

### DIFF
--- a/src/org/opendatakit/briefcase/export/ExportEvent.java
+++ b/src/org/opendatakit/briefcase/export/ExportEvent.java
@@ -16,7 +16,7 @@
 
 package org.opendatakit.briefcase.export;
 
-public final class ExportEvent {
+public class ExportEvent {
   private final String formId;
   private final String statusLine;
   private final boolean success;
@@ -42,7 +42,7 @@ public final class ExportEvent {
   }
 
   public static ExportEvent failure(FormDefinition form, String cause) {
-    return new ExportEvent(form.getFormId(), String.format("Failure: %s", cause), false);
+    return new ExportEvent.Failure(form.getFormId(), String.format("Failure: %s", cause), false);
   }
 
   public static ExportEvent failureSubmission(FormDefinition form, String instanceId, Throwable cause) {
@@ -54,11 +54,11 @@ public final class ExportEvent {
   }
 
   public static ExportEvent successForm(FormDefinition formDef, int total) {
-    return new ExportEvent(formDef.getFormId(), String.format("Exported %d submission%s", total, sUnlessOne(total)), true);
+    return new ExportEvent.Success(formDef.getFormId(), String.format("Exported %d submission%s", total, sUnlessOne(total)), true);
   }
 
   public static ExportEvent partialSuccessForm(FormDefinition formDef, int exported, int total) {
-    return new ExportEvent(formDef.getFormId(), String.format("Exported %d from %d submission%s", exported, total, sUnlessOne(total)), true);
+    return new ExportEvent.Success(formDef.getFormId(), String.format("Exported %d from %d submission%s", exported, total, sUnlessOne(total)), true);
   }
 
   public String getFormId() {
@@ -76,5 +76,17 @@ public final class ExportEvent {
   @SuppressWarnings("checkstyle:MethodName")
   private static String sUnlessOne(int num) {
     return num == 1 ? "" : "s";
+  }
+
+  public static class Failure extends ExportEvent {
+    private Failure(String formId, String statusLine, boolean success) {
+      super(formId, statusLine, success);
+    }
+  }
+
+  public static class Success extends ExportEvent {
+    private Success(String formId, String statusLine, boolean success) {
+      super(formId, statusLine, success);
+    }
   }
 }

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 import org.bushe.swing.event.annotation.AnnotationProcessor;
 import org.bushe.swing.event.annotation.EventSubscriber;
 import org.opendatakit.briefcase.export.ExportConfiguration;
+import org.opendatakit.briefcase.export.ExportEvent;
 import org.opendatakit.briefcase.export.ExportForms;
 import org.opendatakit.briefcase.export.ExportToCsv;
 import org.opendatakit.briefcase.export.FormDefinition;
@@ -56,6 +57,7 @@ public class ExportPanel {
   private final ExportPanelForm form;
   private final BriefcasePreferences appPreferences;
   private final BriefcasePreferences preferences;
+  private final Analytics analytics;
   private final FormCache formCache;
 
   ExportPanel(ExportForms forms, ExportPanelForm form, BriefcasePreferences appPreferences, BriefcasePreferences preferences, Analytics analytics, FormCache formCache) {
@@ -63,6 +65,7 @@ public class ExportPanel {
     this.form = form;
     this.appPreferences = appPreferences;
     this.preferences = preferences;
+    this.analytics = analytics;
     this.formCache = formCache;
     AnnotationProcessor.process(this);// if not using AOP
     analytics.register(form.getContainer());
@@ -227,5 +230,15 @@ public class ExportPanel {
   public void onSavePasswordsConsentRevoked(SavePasswordsConsentRevoked event) {
     forms.flushTransferSettings();
     form.getConfPanel().savePasswordsConsentRevoked();
+  }
+
+  @EventSubscriber(eventClass = ExportEvent.Success.class)
+  public void onExportSuccess(ExportEvent.Success event) {
+    analytics.event("Export", "Export", "Success", null);
+  }
+
+  @EventSubscriber(eventClass = ExportEvent.Failure.class)
+  public void onExportFailure(ExportEvent.Failure event) {
+    analytics.event("Export", "Export", "Failure", null);
   }
 }

--- a/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
+++ b/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
@@ -50,6 +50,7 @@ public class PullPanel {
   private final PullForms forms;
   private final BriefcasePreferences tabPreferences;
   private final BriefcasePreferences appPreferences;
+  private final Analytics analytics;
   private TerminationFuture terminationFuture;
   private Optional<Source<?>> source = Optional.empty();
 
@@ -60,6 +61,7 @@ public class PullPanel {
     this.tabPreferences = tabPreferences;
     this.appPreferences = appPreferences;
     this.terminationFuture = terminationFuture;
+    this.analytics = analytics;
     getContainer().addComponentListener(analytics.buildComponentListener("Pull"));
 
     // Register callbacks to view events
@@ -154,6 +156,7 @@ public class PullPanel {
     terminationFuture.reset();
     view.unsetPulling();
     updateActionButtons();
+    analytics.event("Pull", "Transfer", "Failure", null);
   }
 
   @EventSubscriber(eventClass = PullEvent.Success.class)
@@ -176,5 +179,6 @@ public class PullPanel {
         ));
       }
     }
+    analytics.event("Pull", "Transfer", "Success", null);
   }
 }

--- a/src/org/opendatakit/briefcase/ui/push/PushPanel.java
+++ b/src/org/opendatakit/briefcase/ui/push/PushPanel.java
@@ -54,6 +54,7 @@ public class PushPanel {
   private final BriefcasePreferences tabPreferences;
   private final BriefcasePreferences appPreferences;
   private final FormCache formCache;
+  private final Analytics analytics;
   private TerminationFuture terminationFuture;
   private Optional<Source> source = Optional.empty();
 
@@ -65,6 +66,7 @@ public class PushPanel {
     this.appPreferences = appPreferences;
     this.formCache = formCache;
     this.terminationFuture = terminationFuture;
+    this.analytics = analytics;
     getContainer().addComponentListener(analytics.buildComponentListener("Push"));
 
     // Register callbacks to view events
@@ -175,6 +177,7 @@ public class PushPanel {
     terminationFuture.reset();
     view.unsetPushing();
     updateActionButtons();
+    analytics.event("Push", "Transfer", "Failure", null);
   }
 
   @EventSubscriber(eventClass = PushEvent.Success.class)
@@ -190,6 +193,7 @@ public class PushPanel {
         appPreferences.put(String.format("%s_push_settings_password", form.getFormDefinition().getFormId()), String.valueOf(event.transferSettings.get().getPassword()));
       });
     }
+    analytics.event("Push", "Transfer", "Success", null);
   }
 
 


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
Manually pulled/pushed/exported forms to see event hits in the realtime report in GA

#### Why is this the best possible solution? Were any other approaches considered?
This is just some code that was missed during some merge conflict resolution

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.