### PR TITLE
Add a rolling file appender to a logback conf example

### DIFF
--- a/res/logback.xml.example-release
+++ b/res/logback.xml.example-release
@@ -1,18 +1,24 @@
 <configuration>
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
-    </encoder>
-  </appender>
-
-  <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+  <appender name="SENTRY" class="io.sentry.logback.SentryAppender">
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
       <level>WARN</level>
     </filter>
   </appender>
 
+  <appender name="ROLLINGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>briefcase.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>briefcase.%d{yyyy-MM-dd}.log</fileNamePattern>
+      <maxHistory>30</maxHistory>
+      <totalSizeCap>100MB</totalSizeCap>
+    </rollingPolicy>
+    <encoder>
+      <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
   <root level="info">
-    <appender-ref ref="STDOUT"/>
-    <appender-ref ref="Sentry" />
+    <appender-ref ref="SENTRY" />
+    <appender-ref ref="ROLLINGFILE" />
   </root>
 </configuration>


### PR DESCRIPTION
Partially addresses #522 

#### What has been done to verify that this works as intended?
Run Brierfcase activating the new appender and verified that the `briefcase.log` file was generated.
Changed date and verified that the file rolling policy worked as expected (generates one file per day).

#### Why is this the best possible solution? Were any other approaches considered?
This is the rolling file appender config explained in logback docs

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.