### PR TITLE
Issue 532 improve http proxy form fields

### DIFF
--- a/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.java
@@ -76,12 +76,12 @@ public class SettingsPanelForm {
     useHttpProxyField.addActionListener(__ -> updateHttpProxyFields());
 
     httpProxyHostField.addFocusListener(onFocusLost(() -> OptionalProduct.all(
-        Optional.ofNullable(httpProxyHostField.getText()),
+        Optional.ofNullable(httpProxyHostField.getText()).map(String::trim).filter(s -> !s.isEmpty()),
         Optional.ofNullable(httpProxyPortField.getValue()).map(o -> (Integer) o)
     ).map(HttpHost::new).ifPresent(this::setHttpProxy)));
 
     httpProxyPortField.addChangeListener(__ -> OptionalProduct.all(
-        Optional.ofNullable(httpProxyHostField.getText()).filter(s -> !s.isEmpty()),
+        Optional.ofNullable(httpProxyHostField.getText()).map(String::trim).filter(s -> !s.isEmpty()),
         Optional.ofNullable(httpProxyPortField.getValue()).map(o -> (Integer) o)
     ).map(HttpHost::new).ifPresent(this::setHttpProxy));
 

--- a/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.java
@@ -75,15 +75,9 @@ public class SettingsPanelForm {
 
     useHttpProxyField.addActionListener(__ -> updateHttpProxyFields());
 
-    httpProxyHostField.addFocusListener(onFocusLost(() -> OptionalProduct.all(
-        Optional.ofNullable(httpProxyHostField.getText()).map(String::trim).filter(s -> !s.isEmpty()),
-        Optional.ofNullable(httpProxyPortField.getValue()).map(o -> (Integer) o)
-    ).map(HttpHost::new).ifPresent(this::setHttpProxy)));
+    httpProxyHostField.addFocusListener(onFocusLost(this::processHttpProxyFields));
 
-    httpProxyPortField.addChangeListener(__ -> OptionalProduct.all(
-        Optional.ofNullable(httpProxyHostField.getText()).map(String::trim).filter(s -> !s.isEmpty()),
-        Optional.ofNullable(httpProxyPortField.getValue()).map(o -> (Integer) o)
-    ).map(HttpHost::new).ifPresent(this::setHttpProxy));
+    httpProxyPortField.addChangeListener(__ -> processHttpProxyFields());
 
     updateProxyFields(useHttpProxyField.isSelected());
   }
@@ -99,6 +93,13 @@ public class SettingsPanelForm {
       httpProxyPortField.setValue(8080);
       onClearHttpProxyCallbacks.forEach(Runnable::run);
     }
+  }
+
+  private void processHttpProxyFields() {
+    OptionalProduct.all(
+        Optional.ofNullable(httpProxyHostField.getText()).map(String::trim).filter(s -> !s.isEmpty()),
+        Optional.ofNullable(httpProxyPortField.getValue()).map(o -> (Integer) o)
+    ).map(HttpHost::new).ifPresent(this::setHttpProxy);
   }
 
   private void updateProxyFields(boolean enabled) {


### PR DESCRIPTION
Closes #532

#### What has been done to verify that this works as intended?
Manually test the form's behavior by leaving the HTTP Proxy host field empty.
Verify that there are no errors logged.
Verify that after closing and reopening Briefcase, the HTTP Proxy has not been saved

#### Why is this the best possible solution? Were any other approaches considered?
This is the smallest solution to the issue.

I opted not to give feedback by popping an error dialog because Briefcase wasn't saving anything anyway and it felt too intrusive.

#### Are there any risks to merging this code? If so, what are they?
Nope

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope