### PR TITLE
Issue 398 cli pull in parallel

### DIFF
--- a/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
+++ b/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
@@ -16,8 +16,6 @@
 
 package org.opendatakit.briefcase.model;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.Security;
@@ -31,7 +29,6 @@ import java.util.prefs.Preferences;
 import org.apache.http.HttpHost;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bushe.swing.event.EventBus;
-import org.opendatakit.briefcase.buildconfig.BuildConfig;
 import org.opendatakit.briefcase.reused.OptionalProduct;
 import org.opendatakit.briefcase.reused.StorageLocationEvent;
 
@@ -41,12 +38,11 @@ import org.opendatakit.briefcase.reused.StorageLocationEvent;
  */
 public class BriefcasePreferences {
 
-  public static final String GOOGLE_TRACKING_ID = BuildConfig.GOOGLE_TRACKING_ID;
   public static final String USERNAME = "username";
   public static final String PASSWORD = "password";
   public static final String AGGREGATE_1_0_URL = "url_1_0";
 
-  public static final String BRIEFCASE_DIR_PROPERTY = "briefcaseDir";
+  private static final String BRIEFCASE_DIR_PROPERTY = "briefcaseDir";
   private static final String BRIEFCASE_PROXY_HOST_PROPERTY = "briefcaseProxyHost";
   private static final String BRIEFCASE_PROXY_PORT_PROPERTY = "briefcaseProxyPort";
   private static final String BRIEFCASE_PARALLEL_PULLS_PROPERTY = "briefcaseParallelPulls";
@@ -165,50 +161,6 @@ public class BriefcasePreferences {
     keys.forEach(this::remove);
   }
 
-  public static void setBriefcaseDirectoryProperty(String value) {
-    if (value == null) {
-      Preference.APPLICATION_SCOPED.remove(BRIEFCASE_DIR_PROPERTY);
-    } else {
-      Preference.APPLICATION_SCOPED.put(BRIEFCASE_DIR_PROPERTY, value);
-    }
-  }
-
-  public String getBriefcaseDirectoryOrNull() {
-    return get(BRIEFCASE_DIR_PROPERTY, null);
-  }
-
-  public String getBriefcaseDirectoryOrUserHome() {
-    try {
-      return get(BRIEFCASE_DIR_PROPERTY, Files.createTempDirectory("briefcase").toString());
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  public static void setBriefcaseProxyProperty(HttpHost value) {
-    if (value == null) {
-      Preference.APPLICATION_SCOPED.remove(BRIEFCASE_PROXY_HOST_PROPERTY);
-      Preference.APPLICATION_SCOPED.remove(BRIEFCASE_PROXY_PORT_PROPERTY);
-    } else {
-      Preference.APPLICATION_SCOPED.put(BRIEFCASE_PROXY_HOST_PROPERTY, value.getHostName());
-      Preference.APPLICATION_SCOPED.put(BRIEFCASE_PROXY_PORT_PROPERTY, Integer.toString(value.getPort()));
-    }
-  }
-
-  public static void setBriefcaseParallelPullsProperty(Boolean value) {
-    if (value == null) {
-      Preference.APPLICATION_SCOPED.remove(BRIEFCASE_PARALLEL_PULLS_PROPERTY);
-    } else {
-      Preference.APPLICATION_SCOPED.put(BRIEFCASE_PARALLEL_PULLS_PROPERTY, value.toString());
-    }
-  }
-
-  public static Boolean getBriefcaseParallelPullsProperty() {
-    return Boolean.valueOf(
-        Preference.APPLICATION_SCOPED.get(BRIEFCASE_PARALLEL_PULLS_PROPERTY, Boolean.FALSE.toString())
-    );
-  }
-
   public Optional<Path> getBriefcaseDir() {
     return nullSafeGet(BRIEFCASE_DIR_PROPERTY).map(Paths::get).map(BriefcasePreferences::buildBriefcaseDir);
   }
@@ -323,15 +275,6 @@ public class BriefcasePreferences {
   }
 
   /**
-   * Persist the user's decision to allow/disallow their behaviour being tracked.
-   *
-   * @param value (required) the boolean value representing the user's decision.
-   */
-  public static void setBriefcaseTrackingConsentProperty(boolean value) {
-    setBooleanProperty(BRIEFCASE_TRACKING_CONSENT_PROPERTY, value);
-  }
-
-  /**
    * Get the user's persisted decision regarding their consent to being tracked.
    *
    * @return the boolean representation of the user's consent to being tracked.
@@ -342,14 +285,6 @@ public class BriefcasePreferences {
 
   public static boolean getStorePasswordsConsentProperty() {
     return getBooleanProperty(BRIEFCASE_STORE_PASSWORDS_CONSENT_PROPERTY);
-  }
-
-  public static void setStorePasswordsConsentProperty(boolean value) {
-    setBooleanProperty(BRIEFCASE_STORE_PASSWORDS_CONSENT_PROPERTY, value);
-  }
-
-  private static void setBooleanProperty(String key, boolean value) {
-    Preference.APPLICATION_SCOPED.put(key, Boolean.valueOf(value).toString());
   }
 
   private static boolean getBooleanProperty(String key) {

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -95,7 +95,7 @@ public class PullFormFromAggregate {
 
       FormStatus form = maybeForm.get();
       EventBus.publish(new StartPullEvent(form));
-      TransferFromServer.pull(remoteServer.asServerConnectionInfo(), briefcaseDir, form);
+      TransferFromServer.pull(remoteServer.asServerConnectionInfo(), briefcaseDir, BriefcasePreferences.getBriefcaseParallelPullsProperty(), form);
     }
   }
 

--- a/src/org/opendatakit/briefcase/transfer/NewTransferAction.java
+++ b/src/org/opendatakit/briefcase/transfer/NewTransferAction.java
@@ -30,12 +30,13 @@ import org.slf4j.LoggerFactory;
 public class NewTransferAction {
   private static final Logger log = LoggerFactory.getLogger(NewTransferAction.class);
 
-  public static void transferServerToBriefcase(ServerConnectionInfo transferSettings, TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Path briefcaseDir) {
+  public static void transferServerToBriefcase(ServerConnectionInfo transferSettings, TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Path briefcaseDir, Boolean pullInParallel) {
     TransferFromServer action = new TransferFromServer(
         transferSettings,
         terminationFuture,
         formsToTransfer,
-        briefcaseDir
+        briefcaseDir,
+        pullInParallel
     );
     try {
       boolean allSuccessful = action.doAction();

--- a/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
+++ b/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
@@ -304,7 +304,7 @@ public class BriefcaseCLI {
         importODK(storageDir, Paths.get(odkDir));
 
       if (odkDir == null && server != null)
-        pullFormFromAggregate(storageDir, formid, username, password, server);
+        pullFormFromAggregate(storageDir, formid, username, password, server, false);
 
       if (exportPath != null)
         export(

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -16,7 +16,6 @@
 
 package org.opendatakit.briefcase.ui;
 
-import static java.lang.Boolean.TRUE;
 import static javax.swing.JOptionPane.PLAIN_MESSAGE;
 import static javax.swing.JOptionPane.showMessageDialog;
 import static org.opendatakit.briefcase.ui.BriefcaseCLI.launchLegacyCLI;
@@ -58,7 +57,6 @@ public class MainBriefcaseWindow extends WindowAdapter {
   private static final Logger log = LoggerFactory.getLogger(BaseFormParserForJavaRosa.class.getName());
   private static final String APP_NAME = "ODK Briefcase";
   private static final String BRIEFCASE_VERSION = APP_NAME + " - " + BuildConfig.VERSION;
-  private static final String TRACKING_WARNING_SHOWED_PREF_KEY = "tracking warning showed";
 
   private final JFrame frame;
   private final TerminationFuture transferTerminationFuture = new TerminationFuture();
@@ -133,14 +131,14 @@ public class MainBriefcaseWindow extends WindowAdapter {
     if (isFirstLaunch(appPreferences)) {
       lockUI();
       showWelcomeMessage();
-      appPreferences.put(TRACKING_WARNING_SHOWED_PREF_KEY, TRUE.toString());
+      appPreferences.setTrackingWarningShowed();
     }
 
     // Starting with Briefcase version 1.10.0, tracking is enabled by default.
     // Users upgrading from previous versions must be warned about this.
     if (isFirstLaunchAfterTrackingUpgrade(appPreferences)) {
       showTrackingWarning();
-      appPreferences.put(TRACKING_WARNING_SHOWED_PREF_KEY, TRUE.toString());
+      appPreferences.setTrackingWarningShowed();
     }
   }
 

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -193,7 +193,8 @@ public class ExportPanel {
                   sci,
                   new TerminationFuture(),
                   Collections.singletonList(form),
-                  appPreferences.getBriefcaseDir().orElseThrow(BriefcaseException::new)
+                  appPreferences.getBriefcaseDir().orElseThrow(BriefcaseException::new),
+                  BriefcasePreferences.getBriefcaseParallelPullsProperty()
               ));
             BriefcaseFormDefinition formDefinition = (BriefcaseFormDefinition) form.getFormDefinition();
             ExportToCsv.export(FormDefinition.from(formDefinition), configuration, true);

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -194,7 +194,7 @@ public class ExportPanel {
                   new TerminationFuture(),
                   Collections.singletonList(form),
                   appPreferences.getBriefcaseDir().orElseThrow(BriefcaseException::new),
-                  BriefcasePreferences.getBriefcaseParallelPullsProperty()
+                  appPreferences.getPullInParallel().orElse(false)
               ));
             BriefcaseFormDefinition formDefinition = (BriefcaseFormDefinition) form.getFormDefinition();
             ExportToCsv.export(FormDefinition.from(formDefinition), configuration, true);

--- a/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
+++ b/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
@@ -97,7 +97,7 @@ public class PullPanel {
     view.onPull(() -> {
       view.setPulling();
       forms.forEach(FormStatus::clearStatusHistory);
-      source.ifPresent(s -> s.pull(forms.getSelectedForms(), terminationFuture, appPreferences.getBriefcaseDir().orElseThrow(BriefcaseException::new), BriefcasePreferences.getBriefcaseParallelPullsProperty()));
+      source.ifPresent(s -> s.pull(forms.getSelectedForms(), terminationFuture, appPreferences.getBriefcaseDir().orElseThrow(BriefcaseException::new), appPreferences.getPullInParallel().orElse(false)));
     });
 
     view.onCancel(() -> terminationFuture.markAsCancelled(new PullEvent.Abort("Cancelled by the user")));

--- a/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
+++ b/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
@@ -97,7 +97,7 @@ public class PullPanel {
     view.onPull(() -> {
       view.setPulling();
       forms.forEach(FormStatus::clearStatusHistory);
-      source.ifPresent(s -> s.pull(forms.getSelectedForms(), terminationFuture, appPreferences.getBriefcaseDir().orElseThrow(BriefcaseException::new)));
+      source.ifPresent(s -> s.pull(forms.getSelectedForms(), terminationFuture, appPreferences.getBriefcaseDir().orElseThrow(BriefcaseException::new), BriefcasePreferences.getBriefcaseParallelPullsProperty()));
     });
 
     view.onCancel(() -> terminationFuture.markAsCancelled(new PullEvent.Abort("Cancelled by the user")));

--- a/src/org/opendatakit/briefcase/ui/reused/source/Source.java
+++ b/src/org/opendatakit/briefcase/ui/reused/source/Source.java
@@ -175,7 +175,7 @@ public interface Source<T> {
    * @param forms             {@link List} of forms to be pulled
    * @param terminationFuture object that to make the operation cancellable
    */
-  void pull(List<FormStatus> forms, TerminationFuture terminationFuture, Path briefcaseDir);
+  void pull(List<FormStatus> forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel);
 
   /**
    * Pushes forms to this configured {@link Source}.
@@ -239,8 +239,8 @@ public interface Source<T> {
     }
 
     @Override
-    public void pull(List<FormStatus> forms, TerminationFuture terminationFuture, Path briefcaseDir) {
-      TransferAction.transferServerToBriefcase(server.asServerConnectionInfo(), terminationFuture, forms, briefcaseDir);
+    public void pull(List<FormStatus> forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel) {
+      TransferAction.transferServerToBriefcase(server.asServerConnectionInfo(), terminationFuture, forms, briefcaseDir, pullInParallel);
     }
 
     @Override
@@ -318,7 +318,7 @@ public interface Source<T> {
     }
 
     @Override
-    public void pull(List<FormStatus> forms, TerminationFuture terminationFuture, Path briefcaseDir) {
+    public void pull(List<FormStatus> forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel) {
       TransferAction.transferODKToBriefcase(briefcaseDir, path.toFile(), terminationFuture, forms);
     }
 
@@ -394,7 +394,7 @@ public interface Source<T> {
     }
 
     @Override
-    public void pull(List<FormStatus> forms, TerminationFuture terminationFuture, Path briefcaseDir) {
+    public void pull(List<FormStatus> forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel) {
       SwingUtilities.invokeLater(() -> FormInstaller.install(briefcaseDir, form));
     }
 

--- a/src/org/opendatakit/briefcase/util/TransferAction.java
+++ b/src/org/opendatakit/briefcase/util/TransferAction.java
@@ -97,8 +97,8 @@ public class TransferAction {
     backgroundExecutorService.execute(new GatherTransferRunnable(src, formsToTransfer));
   }
 
-  public static void transferServerToBriefcase(ServerConnectionInfo originServerInfo, TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Path briefcaseDir) {
-    TransferFromServer source = new TransferFromServer(originServerInfo, terminationFuture, formsToTransfer, briefcaseDir);
+  public static void transferServerToBriefcase(ServerConnectionInfo originServerInfo, TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Path briefcaseDir, Boolean pullInParallel) {
+    TransferFromServer source = new TransferFromServer(originServerInfo, terminationFuture, formsToTransfer, briefcaseDir, pullInParallel);
     backgroundRun(source, formsToTransfer);
   }
 

--- a/src/org/opendatakit/briefcase/util/TransferFromServer.java
+++ b/src/org/opendatakit/briefcase/util/TransferFromServer.java
@@ -31,19 +31,21 @@ public class TransferFromServer implements ITransferFromSourceAction {
   final ServerConnectionInfo originServerInfo;
   final TerminationFuture terminationFuture;
   final List<FormStatus> formsToTransfer;
+  private final Boolean pullInParallel;
   private Path briefcaseDir;
 
-  public TransferFromServer(ServerConnectionInfo originServerInfo, TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Path briefcaseDir) {
+  public TransferFromServer(ServerConnectionInfo originServerInfo, TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Path briefcaseDir, Boolean pullInParallel) {
     this.originServerInfo = originServerInfo;
     this.terminationFuture = terminationFuture;
     this.formsToTransfer = formsToTransfer;
     this.briefcaseDir = briefcaseDir;
+    this.pullInParallel = pullInParallel;
   }
 
   @Override
   public boolean doAction() {
 
-    ServerFetcher fetcher = new ServerFetcher(originServerInfo, terminationFuture, briefcaseDir);
+    ServerFetcher fetcher = new ServerFetcher(originServerInfo, terminationFuture, briefcaseDir, pullInParallel);
 
     return fetcher.downloadFormAndSubmissionFiles(formsToTransfer);
   }
@@ -53,9 +55,9 @@ public class TransferFromServer implements ITransferFromSourceAction {
     return false;
   }
 
-  public static void pull(ServerConnectionInfo transferSettings, Path briefcaseDir, FormStatus... forms) {
+  public static void pull(ServerConnectionInfo transferSettings, Path briefcaseDir, Boolean pullInParallel, FormStatus... forms) {
     List<FormStatus> formList = Arrays.asList(forms);
-    TransferFromServer action = new TransferFromServer(transferSettings, new TerminationFuture(), formList, briefcaseDir);
+    TransferFromServer action = new TransferFromServer(transferSettings, new TerminationFuture(), formList, briefcaseDir, pullInParallel);
 
     try {
       boolean allSuccessful = action.doAction();


### PR DESCRIPTION
Closes #398

This PR adds a new CLI param `-pp` or `--parallel_pull` to enable pulling forms in parallel on the CLI. Before this, the CLI would use whatever saved preference the user would have set using the UI's Settings tab.

This PR also changes UI code to decouple it from global state - which was harmful in many ways - wherever we needed to know if the "pull in parallel" setting was set or not.

#### What has been done to verify that this works as intended?
Pulled a form with the UI with pull in parallel setting checked and unchecked. Verified on the logs that Briefcase would only use 1 thread if unchecked.
Pulled a form with the CLI adding and omitting the new `-pp` flag. Verified on the logs that Briefcase would only use 1 thread if the flag was omitted.

#### Why is this the best possible solution? Were any other approaches considered?
This a pretty straightforward change: break coupling to global state by replacing it with injected values. Then inject values from a new source.

Almost all the changes have been made using safe refactoring tools in IntelliJ.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.