### PR TITLE
Issue 504 recover from moved storage dir failure

### DIFF
--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -27,6 +27,7 @@ import java.awt.Component;
 import java.awt.Toolkit;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import javax.swing.ImageIcon;
@@ -88,6 +89,7 @@ public class MainBriefcaseWindow extends WindowAdapter {
 
     BriefcasePreferences appPreferences = BriefcasePreferences.appScoped();
     FormCache formCache = appPreferences.getBriefcaseDir()
+        .filter(Files::exists)
         .map(FormCache::from)
         .orElse(FormCache.empty());
 

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -91,6 +91,8 @@ public class MainBriefcaseWindow extends WindowAdapter {
 
     BriefcasePreferences appPreferences = BriefcasePreferences.appScoped();
     Optional<Path> briefcaseDir = appPreferences.getBriefcaseDir().filter(Files::exists);
+    if (!briefcaseDir.isPresent())
+      appPreferences.unsetStorageDir();
     FormCache formCache = briefcaseDir
         .map(FormCache::from)
         .orElse(FormCache.empty());

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -28,8 +28,10 @@ import java.awt.Toolkit;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import javax.swing.ImageIcon;
 import javax.swing.JFrame;
 import javax.swing.JTabbedPane;
@@ -88,8 +90,8 @@ public class MainBriefcaseWindow extends WindowAdapter {
     AnnotationProcessor.process(this);
 
     BriefcasePreferences appPreferences = BriefcasePreferences.appScoped();
-    FormCache formCache = appPreferences.getBriefcaseDir()
-        .filter(Files::exists)
+    Optional<Path> briefcaseDir = appPreferences.getBriefcaseDir().filter(Files::exists);
+    FormCache formCache = briefcaseDir
         .map(FormCache::from)
         .orElse(FormCache.empty());
 


### PR DESCRIPTION
Closes #504

#### What has been done to verify that this works as intended?
Set the conditions that would produce an error by moving the already saved briefcase dir location to somewhere else and run Briefcase. Verified that I got the welcome message and no errors, as expected.

#### Why is this the best possible solution? Were any other approaches considered?
This is the narrowest fix to implement a solution discussed in #504 

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.