### PR TITLE
Issue 544 make submissions directory filter less restrictive

### DIFF
--- a/src/org/opendatakit/briefcase/export/Submission.java
+++ b/src/org/opendatakit/briefcase/export/Submission.java
@@ -66,7 +66,7 @@ class Submission {
     this.cipherFactory = cipherFactory;
     this.signature = signature;
     // Precalculate this for later use when sorting submissions
-    this.submissionDateEpoch = metaData.getSubmissionDate().orElse(OffsetDateTime.MIN).toInstant().toEpochMilli();
+    this.submissionDateEpoch = metaData.getSubmissionDate().orElse(OffsetDateTime.of(1970, 1, 1, 0, 0, 0, 0, OffsetDateTime.now().getOffset())).toInstant().toEpochMilli();
   }
 
   /**

--- a/src/org/opendatakit/briefcase/reused/UncheckedFiles.java
+++ b/src/org/opendatakit/briefcase/reused/UncheckedFiles.java
@@ -218,11 +218,9 @@ public class UncheckedFiles {
 
   public static boolean isInstanceDir(Path dir) {
     return Files.isDirectory(dir)
-        // Instance directories follow the pattern "uuid01234567-0123-0123-0123-012345678901"
-        // ("uuid" followed by a UUID string)
-        // This is decided when forms are pulled and written into the storage directory
-        // TODO Extract into an artifact, test, and use everywhere where this convention is used
-        && dir.getFileName().toString().matches("^uuid[\\w]{8}-[\\w]{4}-[\\w]{4}-[\\w]{4}-[\\w]{12}$")
+        // Ignore hidden mac/linux hidden folders
+        && !dir.getFileName().toString().startsWith(".")
+        // Check for presence of a submission.xml file inside
         && Files.exists(dir.resolve("submission.xml"));
   }
 

--- a/test/java/org/opendatakit/briefcase/reused/UncheckedFilesIsInstanceDirTest.java
+++ b/test/java/org/opendatakit/briefcase/reused/UncheckedFilesIsInstanceDirTest.java
@@ -70,7 +70,7 @@ public class UncheckedFilesIsInstanceDirTest {
   }
 
   @Test
-  public void a_linux_or_mac_hidden_directoryis_not_an_instance_directory_even_if_it_has_a_submission_dot_xml_file() {
+  public void a_linux_or_mac_hidden_directory_is_not_an_instance_directory_even_if_it_has_a_submission_dot_xml_file() {
     Path correctDir = createDirectories(tempDir.resolve(".DS_Store"));
     write(correctDir.resolve("submission.xml"), Stream.empty());
     assertThat(isInstanceDir(createDirectories(correctDir)), is(false));

--- a/test/java/org/opendatakit/briefcase/reused/UncheckedFilesIsInstanceDirTest.java
+++ b/test/java/org/opendatakit/briefcase/reused/UncheckedFilesIsInstanceDirTest.java
@@ -50,7 +50,7 @@ public class UncheckedFilesIsInstanceDirTest {
 
   @Test
   public void a_file_is_not_an_instance_directory() {
-    Path someFile = tempDir.resolve("cocotero.txt");
+    Path someFile = tempDir.resolve("some_file.txt");
     write(someFile, Stream.empty());
     assertThat(isInstanceDir(someFile), is(false));
   }
@@ -63,8 +63,15 @@ public class UncheckedFilesIsInstanceDirTest {
   }
 
   @Test
-  public void an_arbitrarily_named_directory_with_a_submission_dot_xml_file_is_not_an_instance_directory() {
-    Path correctDir = createDirectories(tempDir.resolve("cocotero"));
+  public void an_arbitrarily_named_directory_with_a_submission_dot_xml_file_is_also_an_instance_directory() {
+    Path correctDir = createDirectories(tempDir.resolve("some_directory"));
+    write(correctDir.resolve("submission.xml"), Stream.empty());
+    assertThat(isInstanceDir(createDirectories(correctDir)), is(true));
+  }
+
+  @Test
+  public void a_linux_or_mac_hidden_directoryis_not_an_instance_directory_even_if_it_has_a_submission_dot_xml_file() {
+    Path correctDir = createDirectories(tempDir.resolve(".DS_Store"));
     write(correctDir.resolve("submission.xml"), Stream.empty());
     assertThat(isInstanceDir(createDirectories(correctDir)), is(false));
   }

--- a/test/java/org/opendatakit/briefcase/reused/UncheckedFilesIsInstanceDirTest.java
+++ b/test/java/org/opendatakit/briefcase/reused/UncheckedFilesIsInstanceDirTest.java
@@ -56,13 +56,6 @@ public class UncheckedFilesIsInstanceDirTest {
   }
 
   @Test
-  public void an_arbitrary_named_directory_is_not_an_instance_directory() {
-    assertThat(isInstanceDir(createDirectories(tempDir.resolve("cocotero"))), is(false));
-    assertThat(isInstanceDir(createDirectories(tempDir.resolve("uuid1234"))), is(false));
-    assertThat(isInstanceDir(createDirectories(tempDir.resolve("12345678-1234-1234-1234-123456789012"))), is(false));
-  }
-
-  @Test
   public void an_instance_dir_must_match_a_certain_name_and_contain_a_submissions_dot_xml_file() {
     Path correctDir = createDirectories(tempDir.resolve("uuid12345678-1234-1234-1234-123456789012"));
     write(correctDir.resolve("submission.xml"), Stream.empty());


### PR DESCRIPTION
Closes #544

This PR changes the filter Briefcase uses when listing the contents of the instances folder of a form to retrieve the submissions to be exported. Before this change, we would expect a particular format that would leave out forms using arbitrary instanceIDs and forms pulled from ODK Collect directories.

Now, the filter will reject only non-directory entries and hidden directories (directories starting with a `.` character are hidden in mac and linux computers)

#### What has been done to verify that this works as intended?
- Pull a form with submissions from an ODK Collect directory and export it. 
- Artificially add a `.DS_Store` directory inside the instances folder of the pulled form and add an empty `submission.xml` file in it.
- Verify that all submissions are present and no errors are logged

I've also improved the unit test suite that covers the directory filter with new test cases for this.

#### Why is this the best possible solution? Were any other approaches considered?
This is the narrowest fix I could come with

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.