### PR TITLE
Issue 546 Avoid NPE on main window

### DIFF
--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -87,8 +87,6 @@ public class MainBriefcaseWindow extends WindowAdapter {
   }
 
   private MainBriefcaseWindow() {
-    AnnotationProcessor.process(this);
-
     BriefcasePreferences appPreferences = BriefcasePreferences.appScoped();
     Optional<Path> briefcaseDir = appPreferences.getBriefcaseDir().filter(Files::exists);
     if (!briefcaseDir.isPresent())
@@ -135,6 +133,9 @@ public class MainBriefcaseWindow extends WindowAdapter {
     frame.pack();
     frame.setLocationRelativeTo(null);
     frame.setVisible(true);
+
+    // Subscribe to events once the UI is ready to react (lock/unlock)
+    AnnotationProcessor.process(this);
 
     if (isFirstLaunch(appPreferences)) {
       lockUI();


### PR DESCRIPTION
Closes #546

This PR fixes the time of subscription to events
- We need to wait until the UI can react (lock/unlock).
- Otherwise, it could produce NPEs since not all members of the class have been created.

#### What has been done to verify that this works as intended?
This is a precaution to avoid possible NPEs. We have already received Sentry reports of this but it's quite difficult to reproduce in a controlled setup.

At least I've tried to trigger the same scenario that would produce a race between the `MainBriefcaseWindow` constructor and its event handlers to verify that no error is produced.

I've also run Briefcase and verified that the locking/unlocking system works by clearing the storage directory in the Settings tab.

#### Why is this the best possible solution? Were any other approaches considered?
This is a straightforward change.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.