### PR TITLE
Issue 547 feedback on cli ops about missing storage dir

### DIFF
--- a/src/org/opendatakit/briefcase/operations/Common.java
+++ b/src/org/opendatakit/briefcase/operations/Common.java
@@ -15,6 +15,11 @@
  */
 package org.opendatakit.briefcase.operations;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.opendatakit.briefcase.model.BriefcasePreferences;
+import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.common.cli.Param;
 
 class Common {
@@ -23,4 +28,11 @@ class Common {
   static final Param<String> ODK_USERNAME = Param.arg("u", "odk_username", "ODK Username");
   static final Param<String> ODK_PASSWORD = Param.arg("p", "odk_password", "ODK Password");
   static final Param<String> AGGREGATE_SERVER = Param.arg("url", "aggregate_url", "Aggregate server URL");
+
+  static Path getBriefcaseDir(String storageDirArgValue) {
+    Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDirArgValue));
+    if (!Files.exists(briefcaseDir))
+      throw new BriefcaseException("The storage directory doesn't exist");
+    return briefcaseDir;
+  }
 }

--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -20,7 +20,6 @@ import static org.opendatakit.briefcase.export.ExportForms.buildExportDateTimePr
 import static org.opendatakit.briefcase.operations.Common.FORM_ID;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDate;
@@ -32,7 +31,6 @@ import org.opendatakit.briefcase.export.ExportToCsv;
 import org.opendatakit.briefcase.export.FormDefinition;
 import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
-import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.ui.export.ExportPanel;
 import org.opendatakit.briefcase.util.FormCache;
 import org.opendatakit.common.cli.Operation;
@@ -69,10 +67,7 @@ public class Export {
 
   public static void export(String storageDir, String formid, Path exportDir, String baseFilename, boolean exportMedia, boolean overwriteFiles, Optional<LocalDate> startDate, Optional<LocalDate> endDate, Optional<Path> maybePemFile) {
     CliEventsCompanion.attach(log);
-    Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
-
-    if (!Files.exists(briefcaseDir))
-      throw new BriefcaseException("The storage directory doesn't exist");
+    Path briefcaseDir = Common.getBriefcaseDir(storageDir);
 
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();

--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -20,6 +20,7 @@ import static org.opendatakit.briefcase.export.ExportForms.buildExportDateTimePr
 import static org.opendatakit.briefcase.operations.Common.FORM_ID;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDate;
@@ -31,6 +32,7 @@ import org.opendatakit.briefcase.export.ExportToCsv;
 import org.opendatakit.briefcase.export.FormDefinition;
 import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
+import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.ui.export.ExportPanel;
 import org.opendatakit.briefcase.util.FormCache;
 import org.opendatakit.common.cli.Operation;
@@ -68,6 +70,10 @@ public class Export {
   public static void export(String storageDir, String formid, Path exportDir, String baseFilename, boolean exportMedia, boolean overwriteFiles, Optional<LocalDate> startDate, Optional<LocalDate> endDate, Optional<Path> maybePemFile) {
     CliEventsCompanion.attach(log);
     Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
+
+    if (!Files.exists(briefcaseDir))
+      throw new BriefcaseException("The storage directory doesn't exist");
+
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();
     Optional<BriefcaseFormDefinition> maybeFormDefinition = formCache.getForms().stream()

--- a/src/org/opendatakit/briefcase/operations/ImportFromODK.java
+++ b/src/org/opendatakit/briefcase/operations/ImportFromODK.java
@@ -18,12 +18,14 @@ package org.opendatakit.briefcase.operations;
 import static java.util.stream.Collectors.toList;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
+import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.util.FileSystemUtils;
 import org.opendatakit.briefcase.util.FormCache;
 import org.opendatakit.briefcase.util.TransferFromODK;
@@ -49,6 +51,10 @@ public class ImportFromODK {
   public static void importODK(String storageDir, Path odkDir) {
     CliEventsCompanion.attach(log);
     Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
+
+    if (!Files.exists(briefcaseDir))
+      throw new BriefcaseException("The storage directory doesn't exist");
+
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();
 

--- a/src/org/opendatakit/briefcase/operations/ImportFromODK.java
+++ b/src/org/opendatakit/briefcase/operations/ImportFromODK.java
@@ -18,14 +18,11 @@ package org.opendatakit.briefcase.operations;
 import static java.util.stream.Collectors.toList;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
-import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
-import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.util.FileSystemUtils;
 import org.opendatakit.briefcase.util.FormCache;
 import org.opendatakit.briefcase.util.TransferFromODK;
@@ -50,10 +47,7 @@ public class ImportFromODK {
 
   public static void importODK(String storageDir, Path odkDir) {
     CliEventsCompanion.attach(log);
-    Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
-
-    if (!Files.exists(briefcaseDir))
-      throw new BriefcaseException("The storage directory doesn't exist");
+    Path briefcaseDir = Common.getBriefcaseDir(storageDir);
 
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -23,13 +23,10 @@ import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Optional;
 import org.bushe.swing.event.EventBus;
-import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.reused.RemoteServer;
@@ -63,10 +60,7 @@ public class PullFormFromAggregate {
 
   public static void pullFormFromAggregate(String storageDir, String formid, String username, String password, String server) {
     CliEventsCompanion.attach(log);
-    Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
-
-    if (!Files.exists(briefcaseDir))
-      throw new BriefcaseException("The storage directory doesn't exist");
+    Path briefcaseDir = Common.getBriefcaseDir(storageDir);
 
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -23,6 +23,7 @@ import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -63,6 +64,10 @@ public class PullFormFromAggregate {
   public static void pullFormFromAggregate(String storageDir, String formid, String username, String password, String server) {
     CliEventsCompanion.attach(log);
     Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
+
+    if (!Files.exists(briefcaseDir))
+      throw new BriefcaseException("The storage directory doesn't exist");
+
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();
 

--- a/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
@@ -23,6 +23,7 @@ import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -64,6 +65,10 @@ public class PushFormToAggregate {
   private static void pushFormToAggregate(String storageDir, String formid, String username, String password, String server, boolean forceSendBlank) {
     CliEventsCompanion.attach(log);
     Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
+
+    if (!Files.exists(briefcaseDir))
+      throw new BriefcaseException("The storage directory doesn't exist");
+
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();
 

--- a/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
@@ -23,13 +23,10 @@ import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
-import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.reused.RemoteServer;
@@ -64,10 +61,7 @@ public class PushFormToAggregate {
 
   private static void pushFormToAggregate(String storageDir, String formid, String username, String password, String server, boolean forceSendBlank) {
     CliEventsCompanion.attach(log);
-    Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
-
-    if (!Files.exists(briefcaseDir))
-      throw new BriefcaseException("The storage directory doesn't exist");
+    Path briefcaseDir = Common.getBriefcaseDir(storageDir);
 
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();

--- a/src/org/opendatakit/briefcase/util/FormCache.java
+++ b/src/org/opendatakit/briefcase/util/FormCache.java
@@ -5,6 +5,7 @@ import static org.opendatakit.briefcase.reused.UncheckedFiles.createFile;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.delete;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.list;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InvalidClassException;
@@ -65,6 +66,10 @@ public class FormCache {
            ObjectInputStream ois = new ObjectInputStream(in)) {
         hashByPath = (Map<String, String>) ois.readObject();
         formDefByPath = (Map<String, BriefcaseFormDefinition>) ois.readObject();
+      } catch (EOFException e) {
+        // The file was corrupt. Since we can't do much about it, ignore the stacktrace
+        log.warn("Can't read forms cache file: EOF");
+        delete(cacheFilePath);
       } catch (InvalidClassException e) {
         log.warn("The serialized forms cache is incompatible due to an update on Briefcase");
         delete(cacheFilePath);


### PR DESCRIPTION
Closes #547

This PR brings to the CLI the same filtering we introduced in #542 for the main UI window. The difference is that, while the UI recovers from a missing storage directory by resetting its saved location, the CLI now will exit on error status and give the user some feedback

This PR also reduces the log's verbosity by ignoring the stacktrace from an EOF error while reading the cache file, which we can't really do much about.

#### What has been done to verify that this works as intended?
Run the four CLI ops with a storage directory argument pointing to a non-existing path in my filesystem. Verified that the CLI op fails and gives the expected feedback.

To test the change on the logs, truncate the cache file with `truncate -s0 cache.ser` (mac/linux). Then run a CLI op and verify that the logs get just one line explaining that there has been an EOF.

#### Why is this the best possible solution? Were any other approaches considered?
This is a straightforward fix, similar to what we do in the UI.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.