### PR TITLE
Issue 551 ignore hidden dirs updating cache

### DIFF
--- a/src/org/opendatakit/briefcase/reused/UncheckedFiles.java
+++ b/src/org/opendatakit/briefcase/reused/UncheckedFiles.java
@@ -216,6 +216,15 @@ public class UncheckedFiles {
     }
   }
 
+  public static boolean isFormDir(Path dir) {
+    String dirName = dir.getFileName().toString();
+    return Files.isDirectory(dir)
+        // Ignore hidden mac/linux hidden folders
+        && !dirName.startsWith(".")
+        // Check for presence of the blank form
+        && Files.exists(dir.resolve(dirName + ".xml"));
+  }
+
   public static boolean isInstanceDir(Path dir) {
     return Files.isDirectory(dir)
         // Ignore hidden mac/linux hidden folders

--- a/src/org/opendatakit/briefcase/util/FormCache.java
+++ b/src/org/opendatakit/briefcase/util/FormCache.java
@@ -81,6 +81,7 @@ public class FormCache {
       createFile(cacheFilePath);
       hashByPath = new HashMap<>();
       formDefByPath = new HashMap<>();
+      update();
     }
   }
 

--- a/src/org/opendatakit/briefcase/util/FormCache.java
+++ b/src/org/opendatakit/briefcase/util/FormCache.java
@@ -26,6 +26,7 @@ import org.bushe.swing.event.annotation.EventSubscriber;
 import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
 import org.opendatakit.briefcase.pull.PullEvent;
 import org.opendatakit.briefcase.reused.CacheUpdateEvent;
+import org.opendatakit.briefcase.reused.UncheckedFiles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,19 +110,21 @@ public class FormCache {
   public void update() {
     briefcaseDir.ifPresent(path -> {
       Set<String> scannedFiles = new HashSet<>();
-      list(path.resolve("forms")).forEach(formDir -> {
-        Path form = getFormFilePath(formDir);
-        scannedFiles.add(form.toString());
-        String hash = FileSystemUtils.getMd5Hash(form.toFile());
-        if (isFormNewOrChanged(form, hash)) {
-          try {
-            formDefByPath.put(form.toString(), new BriefcaseFormDefinition(form.getParent().toFile(), form.toFile()));
-            hashByPath.put(form.toString(), hash);
-          } catch (BadFormDefinition e) {
-            log.warn("Can't parse form file", e);
-          }
-        }
-      });
+      list(path.resolve("forms"))
+          .filter(UncheckedFiles::isFormDir)
+          .forEach(formDir -> {
+            Path form = getFormFilePath(formDir);
+            scannedFiles.add(form.toString());
+            String hash = FileSystemUtils.getMd5Hash(form.toFile());
+            if (isFormNewOrChanged(form, hash)) {
+              try {
+                formDefByPath.put(form.toString(), new BriefcaseFormDefinition(form.getParent().toFile(), form.toFile()));
+                hashByPath.put(form.toString(), hash);
+              } catch (BadFormDefinition e) {
+                log.warn("Can't parse form file", e);
+              }
+            }
+          });
       // Warning: Remove map entries by mutating the key set works because the key set is a view on the map
       hashByPath.keySet().removeIf(negate(scannedFiles::contains));
       formDefByPath.keySet().removeIf(negate(scannedFiles::contains));


### PR DESCRIPTION
Closes #551

It's not clear how to reproduce this issue. On Linux, creating a `.DS_Store` won't produce any error (maybe it's dependant on system and jvm version).

Nevertheless, before this PR, directories that weren't form dirs where implicitly being filtered out by the `foreach` block's code. Now an explicit filter is taking care of it, making the whole process more clear to new eyes.

This PR also forces an update of the cache after the cache file is created in the `FormCache` file. This will let Briefcase recover from situations where the cache file has been removed by the user or it has somehow become corrupt.

#### What has been done to verify that this works as intended?

Tested on Linux by creating a `.DS_Store` dir inside the `forms` dir and removing the cache file. Verified that no errors were present on the logs and that all forms in the storage dir where shown in the export tab.

Same results on mac.

#### Why is this the best possible solution? Were any other approaches considered?
This is a straightforward fix to bring the same filtering ideas we use in other places.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.