### PR TITLE
Issue 553 make cli less picky about storage dir

### DIFF
--- a/src/org/opendatakit/briefcase/operations/Common.java
+++ b/src/org/opendatakit/briefcase/operations/Common.java
@@ -15,6 +15,11 @@
  */
 package org.opendatakit.briefcase.operations;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.opendatakit.briefcase.model.BriefcasePreferences;
+import org.opendatakit.briefcase.reused.UncheckedFiles;
 import org.opendatakit.common.cli.Param;
 
 class Common {
@@ -23,4 +28,13 @@ class Common {
   static final Param<String> ODK_USERNAME = Param.arg("u", "odk_username", "ODK Username");
   static final Param<String> ODK_PASSWORD = Param.arg("p", "odk_password", "ODK Password");
   static final Param<String> AGGREGATE_SERVER = Param.arg("url", "aggregate_url", "Aggregate server URL");
+
+  static Path getOrCreateBriefcaseDir(String storageDir) {
+    Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
+    if (!Files.exists(briefcaseDir)) {
+      System.err.println("The directory " + briefcaseDir.toString() + " doesn't exist. Creating it");
+      UncheckedFiles.createBriefcaseDir(briefcaseDir);
+    }
+    return briefcaseDir;
+  }
 }

--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -20,7 +20,6 @@ import static org.opendatakit.briefcase.export.ExportForms.buildExportDateTimePr
 import static org.opendatakit.briefcase.operations.Common.FORM_ID;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDate;
@@ -32,7 +31,6 @@ import org.opendatakit.briefcase.export.ExportToCsv;
 import org.opendatakit.briefcase.export.FormDefinition;
 import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
-import org.opendatakit.briefcase.reused.UncheckedFiles;
 import org.opendatakit.briefcase.ui.export.ExportPanel;
 import org.opendatakit.briefcase.util.FormCache;
 import org.opendatakit.common.cli.Operation;
@@ -69,11 +67,7 @@ public class Export {
 
   public static void export(String storageDir, String formid, Path exportDir, String baseFilename, boolean exportMedia, boolean overwriteFiles, Optional<LocalDate> startDate, Optional<LocalDate> endDate, Optional<Path> maybePemFile) {
     CliEventsCompanion.attach(log);
-    Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
-    if (!Files.exists(briefcaseDir)) {
-      System.err.println("The directory " + briefcaseDir.toString() + " doesn't exist. Creating it");
-      UncheckedFiles.createBriefcaseDir(briefcaseDir);
-    }
+    Path briefcaseDir = Common.getOrCreateBriefcaseDir(storageDir);
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();
     Optional<BriefcaseFormDefinition> maybeFormDefinition = formCache.getForms().stream()

--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -19,7 +19,6 @@ import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 import static org.opendatakit.briefcase.export.ExportForms.buildExportDateTimePrefix;
 import static org.opendatakit.briefcase.operations.Common.FORM_ID;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
-import static org.opendatakit.briefcase.ui.settings.SettingsPanel.README_CONTENTS;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -73,9 +72,7 @@ public class Export {
     Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
     if (!Files.exists(briefcaseDir)) {
       System.err.println("The directory " + briefcaseDir.toString() + " doesn't exist. Creating it");
-      UncheckedFiles.createDirectories(briefcaseDir);
-      UncheckedFiles.createDirectories(briefcaseDir.resolve("forms"));
-      UncheckedFiles.write(briefcaseDir.resolve("readme.txt"), README_CONTENTS.getBytes());
+      UncheckedFiles.createBriefcaseDir(briefcaseDir);
     }
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();

--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -19,7 +19,9 @@ import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 import static org.opendatakit.briefcase.export.ExportForms.buildExportDateTimePrefix;
 import static org.opendatakit.briefcase.operations.Common.FORM_ID;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
+import static org.opendatakit.briefcase.ui.settings.SettingsPanel.README_CONTENTS;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDate;
@@ -31,6 +33,7 @@ import org.opendatakit.briefcase.export.ExportToCsv;
 import org.opendatakit.briefcase.export.FormDefinition;
 import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
+import org.opendatakit.briefcase.reused.UncheckedFiles;
 import org.opendatakit.briefcase.ui.export.ExportPanel;
 import org.opendatakit.briefcase.util.FormCache;
 import org.opendatakit.common.cli.Operation;
@@ -68,6 +71,12 @@ public class Export {
   public static void export(String storageDir, String formid, Path exportDir, String baseFilename, boolean exportMedia, boolean overwriteFiles, Optional<LocalDate> startDate, Optional<LocalDate> endDate, Optional<Path> maybePemFile) {
     CliEventsCompanion.attach(log);
     Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
+    if (!Files.exists(briefcaseDir)) {
+      System.err.println("The directory " + briefcaseDir.toString() + " doesn't exist. Creating it");
+      UncheckedFiles.createDirectories(briefcaseDir);
+      UncheckedFiles.createDirectories(briefcaseDir.resolve("forms"));
+      UncheckedFiles.write(briefcaseDir.resolve("readme.txt"), README_CONTENTS.getBytes());
+    }
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();
     Optional<BriefcaseFormDefinition> maybeFormDefinition = formCache.getForms().stream()

--- a/src/org/opendatakit/briefcase/operations/ImportFromODK.java
+++ b/src/org/opendatakit/briefcase/operations/ImportFromODK.java
@@ -17,13 +17,16 @@ package org.opendatakit.briefcase.operations;
 
 import static java.util.stream.Collectors.toList;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
+import static org.opendatakit.briefcase.ui.settings.SettingsPanel.README_CONTENTS;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
+import org.opendatakit.briefcase.reused.UncheckedFiles;
 import org.opendatakit.briefcase.util.FileSystemUtils;
 import org.opendatakit.briefcase.util.FormCache;
 import org.opendatakit.briefcase.util.TransferFromODK;
@@ -49,6 +52,12 @@ public class ImportFromODK {
   public static void importODK(String storageDir, Path odkDir) {
     CliEventsCompanion.attach(log);
     Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
+    if (!Files.exists(briefcaseDir)) {
+      System.err.println("The directory " + briefcaseDir.toString() + " doesn't exist. Creating it");
+      UncheckedFiles.createDirectories(briefcaseDir);
+      UncheckedFiles.createDirectories(briefcaseDir.resolve("forms"));
+      UncheckedFiles.write(briefcaseDir.resolve("readme.txt"), README_CONTENTS.getBytes());
+    }
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();
 

--- a/src/org/opendatakit/briefcase/operations/ImportFromODK.java
+++ b/src/org/opendatakit/briefcase/operations/ImportFromODK.java
@@ -17,7 +17,6 @@ package org.opendatakit.briefcase.operations;
 
 import static java.util.stream.Collectors.toList;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
-import static org.opendatakit.briefcase.ui.settings.SettingsPanel.README_CONTENTS;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -54,9 +53,7 @@ public class ImportFromODK {
     Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
     if (!Files.exists(briefcaseDir)) {
       System.err.println("The directory " + briefcaseDir.toString() + " doesn't exist. Creating it");
-      UncheckedFiles.createDirectories(briefcaseDir);
-      UncheckedFiles.createDirectories(briefcaseDir.resolve("forms"));
-      UncheckedFiles.write(briefcaseDir.resolve("readme.txt"), README_CONTENTS.getBytes());
+      UncheckedFiles.createBriefcaseDir(briefcaseDir);
     }
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();

--- a/src/org/opendatakit/briefcase/operations/ImportFromODK.java
+++ b/src/org/opendatakit/briefcase/operations/ImportFromODK.java
@@ -18,14 +18,11 @@ package org.opendatakit.briefcase.operations;
 import static java.util.stream.Collectors.toList;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
-import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
-import org.opendatakit.briefcase.reused.UncheckedFiles;
 import org.opendatakit.briefcase.util.FileSystemUtils;
 import org.opendatakit.briefcase.util.FormCache;
 import org.opendatakit.briefcase.util.TransferFromODK;
@@ -50,11 +47,7 @@ public class ImportFromODK {
 
   public static void importODK(String storageDir, Path odkDir) {
     CliEventsCompanion.attach(log);
-    Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
-    if (!Files.exists(briefcaseDir)) {
-      System.err.println("The directory " + briefcaseDir.toString() + " doesn't exist. Creating it");
-      UncheckedFiles.createBriefcaseDir(briefcaseDir);
-    }
+    Path briefcaseDir = Common.getOrCreateBriefcaseDir(storageDir);
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();
 

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -23,17 +23,13 @@ import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Optional;
 import org.bushe.swing.event.EventBus;
-import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.reused.RemoteServer;
-import org.opendatakit.briefcase.reused.UncheckedFiles;
 import org.opendatakit.briefcase.reused.http.CommonsHttp;
 import org.opendatakit.briefcase.reused.http.Credentials;
 import org.opendatakit.briefcase.reused.http.Response;
@@ -64,11 +60,7 @@ public class PullFormFromAggregate {
 
   public static void pullFormFromAggregate(String storageDir, String formid, String username, String password, String server) {
     CliEventsCompanion.attach(log);
-    Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
-    if (!Files.exists(briefcaseDir)) {
-      System.err.println("The directory " + briefcaseDir.toString() + " doesn't exist. Creating it");
-      UncheckedFiles.createBriefcaseDir(briefcaseDir);
-    }
+    Path briefcaseDir = Common.getOrCreateBriefcaseDir(storageDir);
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();
 

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -20,7 +20,6 @@ import static org.opendatakit.briefcase.operations.Common.FORM_ID;
 import static org.opendatakit.briefcase.operations.Common.ODK_PASSWORD;
 import static org.opendatakit.briefcase.operations.Common.ODK_USERNAME;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
-import static org.opendatakit.briefcase.ui.settings.SettingsPanel.README_CONTENTS;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -68,9 +67,7 @@ public class PullFormFromAggregate {
     Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
     if (!Files.exists(briefcaseDir)) {
       System.err.println("The directory " + briefcaseDir.toString() + " doesn't exist. Creating it");
-      UncheckedFiles.createDirectories(briefcaseDir);
-      UncheckedFiles.createDirectories(briefcaseDir.resolve("forms"));
-      UncheckedFiles.write(briefcaseDir.resolve("readme.txt"), README_CONTENTS.getBytes());
+      UncheckedFiles.createBriefcaseDir(briefcaseDir);
     }
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -20,9 +20,11 @@ import static org.opendatakit.briefcase.operations.Common.FORM_ID;
 import static org.opendatakit.briefcase.operations.Common.ODK_PASSWORD;
 import static org.opendatakit.briefcase.operations.Common.ODK_USERNAME;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
+import static org.opendatakit.briefcase.ui.settings.SettingsPanel.README_CONTENTS;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -32,6 +34,7 @@ import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.reused.RemoteServer;
+import org.opendatakit.briefcase.reused.UncheckedFiles;
 import org.opendatakit.briefcase.reused.http.CommonsHttp;
 import org.opendatakit.briefcase.reused.http.Credentials;
 import org.opendatakit.briefcase.reused.http.Response;
@@ -63,6 +66,12 @@ public class PullFormFromAggregate {
   public static void pullFormFromAggregate(String storageDir, String formid, String username, String password, String server) {
     CliEventsCompanion.attach(log);
     Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
+    if (!Files.exists(briefcaseDir)) {
+      System.err.println("The directory " + briefcaseDir.toString() + " doesn't exist. Creating it");
+      UncheckedFiles.createDirectories(briefcaseDir);
+      UncheckedFiles.createDirectories(briefcaseDir.resolve("forms"));
+      UncheckedFiles.write(briefcaseDir.resolve("readme.txt"), README_CONTENTS.getBytes());
+    }
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();
 

--- a/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
@@ -23,17 +23,13 @@ import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
-import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.reused.RemoteServer;
-import org.opendatakit.briefcase.reused.UncheckedFiles;
 import org.opendatakit.briefcase.reused.http.CommonsHttp;
 import org.opendatakit.briefcase.reused.http.Credentials;
 import org.opendatakit.briefcase.reused.http.Response;
@@ -65,11 +61,7 @@ public class PushFormToAggregate {
 
   private static void pushFormToAggregate(String storageDir, String formid, String username, String password, String server, boolean forceSendBlank) {
     CliEventsCompanion.attach(log);
-    Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
-    if (!Files.exists(briefcaseDir)) {
-      System.err.println("The directory " + briefcaseDir.toString() + " doesn't exist. Creating it");
-      UncheckedFiles.createBriefcaseDir(briefcaseDir);
-    }
+    Path briefcaseDir = Common.getOrCreateBriefcaseDir(storageDir);
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();
 

--- a/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
@@ -20,9 +20,11 @@ import static org.opendatakit.briefcase.operations.Common.FORM_ID;
 import static org.opendatakit.briefcase.operations.Common.ODK_PASSWORD;
 import static org.opendatakit.briefcase.operations.Common.ODK_USERNAME;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
+import static org.opendatakit.briefcase.ui.settings.SettingsPanel.README_CONTENTS;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -32,6 +34,7 @@ import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.reused.RemoteServer;
+import org.opendatakit.briefcase.reused.UncheckedFiles;
 import org.opendatakit.briefcase.reused.http.CommonsHttp;
 import org.opendatakit.briefcase.reused.http.Credentials;
 import org.opendatakit.briefcase.reused.http.Response;
@@ -64,6 +67,12 @@ public class PushFormToAggregate {
   private static void pushFormToAggregate(String storageDir, String formid, String username, String password, String server, boolean forceSendBlank) {
     CliEventsCompanion.attach(log);
     Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
+    if (!Files.exists(briefcaseDir)) {
+      System.err.println("The directory " + briefcaseDir.toString() + " doesn't exist. Creating it");
+      UncheckedFiles.createDirectories(briefcaseDir);
+      UncheckedFiles.createDirectories(briefcaseDir.resolve("forms"));
+      UncheckedFiles.write(briefcaseDir.resolve("readme.txt"), README_CONTENTS.getBytes());
+    }
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();
 

--- a/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
@@ -20,7 +20,6 @@ import static org.opendatakit.briefcase.operations.Common.FORM_ID;
 import static org.opendatakit.briefcase.operations.Common.ODK_PASSWORD;
 import static org.opendatakit.briefcase.operations.Common.ODK_USERNAME;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
-import static org.opendatakit.briefcase.ui.settings.SettingsPanel.README_CONTENTS;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -69,9 +68,7 @@ public class PushFormToAggregate {
     Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
     if (!Files.exists(briefcaseDir)) {
       System.err.println("The directory " + briefcaseDir.toString() + " doesn't exist. Creating it");
-      UncheckedFiles.createDirectories(briefcaseDir);
-      UncheckedFiles.createDirectories(briefcaseDir.resolve("forms"));
-      UncheckedFiles.write(briefcaseDir.resolve("readme.txt"), README_CONTENTS.getBytes());
+      UncheckedFiles.createBriefcaseDir(briefcaseDir);
     }
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();

--- a/src/org/opendatakit/briefcase/reused/UncheckedFiles.java
+++ b/src/org/opendatakit/briefcase/reused/UncheckedFiles.java
@@ -47,6 +47,13 @@ import org.slf4j.LoggerFactory;
  * This class holds unchecked versions of some methods in {@link Files}.
  */
 public class UncheckedFiles {
+  private static final String README_CONTENTS = "" +
+      "This ODK Briefcase storage area retains\n" +
+      "all the forms and submissions that have been\n" +
+      "gathered into it.\n" +
+      "\n" +
+      "Users should not navigate into or modify its\n" +
+      "contents unless explicitly directed to do so.\n";
   private static final Logger log = LoggerFactory.getLogger(UncheckedFiles.class);
 
   public static Path createTempFile(String prefix, String suffix, FileAttribute<?>... attrs) {
@@ -287,5 +294,11 @@ public class UncheckedFiles {
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
+  }
+
+  public static void createBriefcaseDir(Path briefcaseDir) {
+    createDirectories(briefcaseDir);
+    createDirectories(briefcaseDir.resolve("forms"));
+    write(briefcaseDir.resolve("readme.txt"), README_CONTENTS.getBytes());
   }
 }

--- a/src/org/opendatakit/briefcase/ui/settings/SettingsPanel.java
+++ b/src/org/opendatakit/briefcase/ui/settings/SettingsPanel.java
@@ -24,7 +24,7 @@ import org.opendatakit.briefcase.ui.reused.Analytics;
 import org.opendatakit.briefcase.util.FormCache;
 
 public class SettingsPanel {
-  private static final String README_CONTENTS = "" +
+  public static final String README_CONTENTS = "" +
       "This ODK Briefcase storage area retains\n" +
       "all the forms and submissions that have been\n" +
       "gathered into it.\n" +

--- a/src/org/opendatakit/briefcase/ui/settings/SettingsPanel.java
+++ b/src/org/opendatakit/briefcase/ui/settings/SettingsPanel.java
@@ -24,13 +24,6 @@ import org.opendatakit.briefcase.ui.reused.Analytics;
 import org.opendatakit.briefcase.util.FormCache;
 
 public class SettingsPanel {
-  public static final String README_CONTENTS = "" +
-      "This ODK Briefcase storage area retains\n" +
-      "all the forms and submissions that have been\n" +
-      "gathered into it.\n" +
-      "\n" +
-      "Users should not navigate into or modify its\n" +
-      "contents unless explicitly directed to do so.\n";
 
   public static final String TAB_NAME = "Settings";
   private final SettingsPanelForm form;
@@ -51,9 +44,7 @@ public class SettingsPanel {
 
     form.onStorageLocation(path -> {
       Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(path);
-      UncheckedFiles.createDirectories(briefcaseDir);
-      UncheckedFiles.createDirectories(briefcaseDir.resolve("forms"));
-      UncheckedFiles.write(briefcaseDir.resolve("readme.txt"), README_CONTENTS.getBytes());
+      UncheckedFiles.createBriefcaseDir(briefcaseDir);
       formCache.setLocation(briefcaseDir);
       formCache.update();
       appPreferences.setStorageDir(path);

--- a/src/org/opendatakit/briefcase/util/FormCache.java
+++ b/src/org/opendatakit/briefcase/util/FormCache.java
@@ -80,6 +80,7 @@ public class FormCache {
       createFile(cacheFilePath);
       hashByPath = new HashMap<>();
       formDefByPath = new HashMap<>();
+      update();
     }
   }
 


### PR DESCRIPTION
Closes #553, closes #547 

This PR should be considered as an alternative behavior to the one proposed in  #549

Thir PR will imitate the old Briefcase behavior that will create the storage dir if the user adds a `-sd` arg that will produce a briefcase dir that doesn't exist.

#### What has been done to verify that this works as intended?
Run all 4 CLI ops with an `-sd` arg that would produce a non-existent briefcase dir. Verify that user gets an error feedback message but the op completes. Verify that the briefcase dir exists afterward.

#### Why is this the best possible solution? Were any other approaches considered?
This is an alternative to failing, which is proposed in #549 
This also is what Briefcase actually did in <=1.9.0

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.