### PR TITLE
Making it a .DS_Store a directory could have unintended consequences

### DIFF
--- a/test/java/org/opendatakit/briefcase/reused/UncheckedFilesIsInstanceDirTest.java
+++ b/test/java/org/opendatakit/briefcase/reused/UncheckedFilesIsInstanceDirTest.java
@@ -71,7 +71,7 @@ public class UncheckedFilesIsInstanceDirTest {
 
   @Test
   public void a_linux_or_mac_hidden_directory_is_not_an_instance_directory_even_if_it_has_a_submission_dot_xml_file() {
-    Path correctDir = createDirectories(tempDir.resolve(".DS_Store"));
+    Path correctDir = createDirectories(tempDir.resolve(".some_hidden_directory"));
     write(correctDir.resolve("submission.xml"), Stream.empty());
     assertThat(isInstanceDir(createDirectories(correctDir)), is(false));
   }


### PR DESCRIPTION
Address #545

.DS_Store is a file on a Mac, not a directory. Calling the hidden directory .DS_Store seems like a bad idea.

#### What has been done to verify that this works as intended?
Ran ` ./gradlew test`

#### Why is this the best possible solution? Were any other approaches considered?
Very narrow fix.

#### Are there any risks to merging this code? If so, what are they?
If the test is meant to test how Briefcase works with .DS_Store **files**, then this test does not do that.
