### PR TITLE
Issue 557 Use standard cookies spec

### DIFF
--- a/src/org/opendatakit/briefcase/reused/http/CommonsHttp.java
+++ b/src/org/opendatakit/briefcase/reused/http/CommonsHttp.java
@@ -16,6 +16,9 @@
 
 package org.opendatakit.briefcase.reused.http;
 
+import static org.apache.http.client.config.CookieSpecs.STANDARD;
+import static org.apache.http.client.config.RequestConfig.custom;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.SocketTimeoutException;
@@ -35,7 +38,10 @@ public class CommonsHttp implements Http {
   @Override
   public <T> Response<T> execute(Request<T> request) {
     // Always instantiate a new Executor to avoid side-effects between executions
-    Executor executor = Executor.newInstance(HttpClientBuilder.create().build());
+    Executor executor = Executor.newInstance(HttpClientBuilder
+        .create()
+        .setDefaultRequestConfig(custom().setCookieSpec(STANDARD).build())
+        .build());
     // Apply auth settings if credentials are received
     request.ifCredentials((URL url, Credentials credentials) -> executor.auth(
         HttpHost.create(url.getHost()),

--- a/src/org/opendatakit/briefcase/util/WebUtils.java
+++ b/src/org/opendatakit/briefcase/util/WebUtils.java
@@ -16,6 +16,8 @@
 
 package org.opendatakit.briefcase.util;
 
+import static org.apache.http.client.config.CookieSpecs.STANDARD;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLEncoder;
@@ -225,6 +227,7 @@ public final class WebUtils {
         .setMaxRedirects(1)
         .setCircularRedirectsAllowed(true)
         .setTargetPreferredAuthSchemes(targetPreferredAuthSchemes)
+        .setCookieSpec(STANDARD)
         .build();
 
     HttpClientBuilder clientBuilder = HttpClientBuilder.create()


### PR DESCRIPTION
Closes #557

This PR doesn't change behavior.

This PR introduces a technical change that will avoid warnings when dealing with Aggregate and compatible server that use latest RFC-compliant cookies.

#### What has been done to verify that this works as intended?
Since I haven't access to a server that uses such cookies, I have tried to pull from a standard Aggregate server and I've verified that it works as expected. No errors.

#### Why is this the best possible solution? Were any other approaches considered?
The changes have been made following instructions to solve this problem that are specific of the library we're using for HTTP interaction. It's a straightforward change.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.