### PR TITLE
Issue 558 Attach causing exception to domain exception

### DIFF
--- a/src/org/opendatakit/briefcase/util/PullFromServerException.java
+++ b/src/org/opendatakit/briefcase/util/PullFromServerException.java
@@ -22,6 +22,10 @@ import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.reused.BriefcaseException;
 
 public class PullFromServerException extends BriefcaseException {
+  public PullFromServerException(List<FormStatus> forms, Throwable cause) {
+    super("Failure pulling forms from server. FormIds: " + forms.stream().map(f -> f.getFormDefinition().getFormId()).collect(joining(", ")), cause);
+  }
+
   public PullFromServerException(List<FormStatus> forms) {
     super("Failure pulling forms from server. FormIds: " + forms.stream().map(f -> f.getFormDefinition().getFormId()).collect(joining(", ")));
   }

--- a/src/org/opendatakit/briefcase/util/PullFromServerException.java
+++ b/src/org/opendatakit/briefcase/util/PullFromServerException.java
@@ -23,10 +23,14 @@ import org.opendatakit.briefcase.reused.BriefcaseException;
 
 public class PullFromServerException extends BriefcaseException {
   public PullFromServerException(List<FormStatus> forms, Throwable cause) {
-    super("Failure pulling forms from server. FormIds: " + forms.stream().map(f -> f.getFormDefinition().getFormId()).collect(joining(", ")), cause);
+    super(buildMessage(forms), cause);
   }
 
   public PullFromServerException(List<FormStatus> forms) {
-    super("Failure pulling forms from server. FormIds: " + forms.stream().map(f -> f.getFormDefinition().getFormId()).collect(joining(", ")));
+    super(buildMessage(forms));
+  }
+
+  private static String buildMessage(List<FormStatus> forms) {
+    return "Failure pulling forms from server. FormIds: " + forms.stream().map(f -> f.getFormDefinition().getFormId()).collect(joining(", "));
   }
 }

--- a/src/org/opendatakit/briefcase/util/PullFromServerException.java
+++ b/src/org/opendatakit/briefcase/util/PullFromServerException.java
@@ -21,12 +21,12 @@ import java.util.List;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.reused.BriefcaseException;
 
-public class PullFromServerException extends BriefcaseException {
-  public PullFromServerException(List<FormStatus> forms, Throwable cause) {
+class PullFromServerException extends BriefcaseException {
+  PullFromServerException(List<FormStatus> forms, Throwable cause) {
     super(buildMessage(forms), cause);
   }
 
-  public PullFromServerException(List<FormStatus> forms) {
+  PullFromServerException(List<FormStatus> forms) {
     super(buildMessage(forms));
   }
 

--- a/src/org/opendatakit/briefcase/util/TransferFromServer.java
+++ b/src/org/opendatakit/briefcase/util/TransferFromServer.java
@@ -68,7 +68,7 @@ public class TransferFromServer implements ITransferFromSourceAction {
         throw new PullFromServerException(formList);
     } catch (Exception e) {
       EventBus.publish(new PullEvent.Failure());
-      throw new PullFromServerException(formList);
+      throw new PullFromServerException(formList, e);
     }
   }
 


### PR DESCRIPTION
Closes #558

This PR doesn't change behavior.

This PR introduces a technical change to add information to an error log in order to try to know if there's a bug behind it or not.

#### What has been done to verify that this works as intended?
It's not clear how to reproduce the error that would let us know if the change works, but it's a really straightforward change and it doesn't affect to any other part of Briefcase. It should be safe to merge. 

#### Why is this the best possible solution? Were any other approaches considered?
This PR follows the good practice to not losing the causing exception when wrapping it in a domain exception.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.