### PR TITLE
Issue 530 silence sentry logs

### DIFF
--- a/src/org/opendatakit/briefcase/Launcher.java
+++ b/src/org/opendatakit/briefcase/Launcher.java
@@ -51,22 +51,8 @@ public class Launcher {
     if (!appPreferences.hasKey(BRIEFCASE_TRACKING_CONSENT_PROPERTY))
       appPreferences.put(BRIEFCASE_TRACKING_CONSENT_PROPERTY, TRUE.toString());
 
-    if (SENTRY_ENABLED) {
-      Sentry.init(String.format(
-          "%s?release=%s&stacktrace.app.packages=org.opendatakit&tags=os:%s,jvm:%s",
-          SENTRY_DSN,
-          VERSION,
-          getOsName(),
-          System.getProperty("java.version")
-      ));
-
-      // Add a callback that will prevent sending crash reports to Sentry
-      // if the user disables tracking
-      Sentry.getStoredClient().addShouldSendEventCallback(event -> appPreferences
-          .nullSafeGet(BRIEFCASE_TRACKING_CONSENT_PROPERTY)
-          .map(Boolean::valueOf)
-          .orElse(true));
-    }
+    if (SENTRY_ENABLED)
+      initSentryClient(appPreferences);
 
     new Cli()
         .deprecate(DEPRECATED_PULL_AGGREGATE, PULL_FORM_FROM_AGGREGATE)
@@ -89,5 +75,22 @@ public class Launcher {
           System.exit(1);
         })
         .run(args);
+  }
+
+  private static void initSentryClient(BriefcasePreferences appPreferences) {
+    Sentry.init(String.format(
+        "%s?release=%s&stacktrace.app.packages=org.opendatakit&tags=os:%s,jvm:%s",
+        SENTRY_DSN,
+        VERSION,
+        getOsName(),
+        System.getProperty("java.version")
+    ));
+
+    // Add a callback that will prevent sending crash reports to Sentry
+    // if the user disables tracking
+    Sentry.getStoredClient().addShouldSendEventCallback(event -> appPreferences
+        .nullSafeGet(BRIEFCASE_TRACKING_CONSENT_PROPERTY)
+        .map(Boolean::valueOf)
+        .orElse(true));
   }
 }

--- a/src/org/opendatakit/briefcase/Launcher.java
+++ b/src/org/opendatakit/briefcase/Launcher.java
@@ -31,6 +31,7 @@ import static org.opendatakit.briefcase.ui.MainBriefcaseWindow.launchGUI;
 import static org.opendatakit.briefcase.util.FindDirectoryStructure.getOsName;
 
 import io.sentry.Sentry;
+import io.sentry.SentryClient;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.common.cli.Cli;
@@ -77,7 +78,7 @@ public class Launcher {
         .run(args);
   }
 
-  private static void initSentryClient(BriefcasePreferences appPreferences) {
+  private static SentryClient initSentryClient(BriefcasePreferences appPreferences) {
     Sentry.init(String.format(
         "%s?release=%s&stacktrace.app.packages=org.opendatakit&tags=os:%s,jvm:%s",
         SENTRY_DSN,
@@ -86,11 +87,15 @@ public class Launcher {
         System.getProperty("java.version")
     ));
 
+    SentryClient sentry = Sentry.getStoredClient();
+
     // Add a callback that will prevent sending crash reports to Sentry
     // if the user disables tracking
-    Sentry.getStoredClient().addShouldSendEventCallback(event -> appPreferences
+    sentry.addShouldSendEventCallback(event -> appPreferences
         .nullSafeGet(BRIEFCASE_TRACKING_CONSENT_PROPERTY)
         .map(Boolean::valueOf)
         .orElse(true));
+
+    return sentry;
   }
 }

--- a/src/org/opendatakit/briefcase/Launcher.java
+++ b/src/org/opendatakit/briefcase/Launcher.java
@@ -32,7 +32,10 @@ import static org.opendatakit.briefcase.util.FindDirectoryStructure.getOsName;
 
 import io.sentry.Sentry;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
+import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.common.cli.Cli;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Main launcher for Briefcase
@@ -41,6 +44,8 @@ import org.opendatakit.common.cli.Cli;
  * Briefcase with some command-line args
  */
 public class Launcher {
+  private static final Logger log = LoggerFactory.getLogger(Launcher.class);
+
   public static void main(String[] args) {
     BriefcasePreferences appPreferences = BriefcasePreferences.appScoped();
     if (!appPreferences.hasKey(BRIEFCASE_TRACKING_CONSENT_PROPERTY))
@@ -75,6 +80,17 @@ public class Launcher {
             launchGUI();
           else
             runLegacyCli(commandLine, cli::printHelp);
+        })
+        .onError(throwable -> {
+          if (throwable instanceof BriefcaseException) {
+            System.err.println("Error: " + throwable.getMessage());
+            log.error("Error", throwable);
+            System.exit(1);
+          } else {
+            System.err.println("Unexpected error in Briefcase. Please review briefcase.log for more information. For help, post to https://forum.opendatakit.org/c/support");
+            log.error("Error", throwable);
+            System.exit(1);
+          }
         })
         .run(args);
   }

--- a/src/org/opendatakit/briefcase/Launcher.java
+++ b/src/org/opendatakit/briefcase/Launcher.java
@@ -32,6 +32,7 @@ import static org.opendatakit.briefcase.util.FindDirectoryStructure.getOsName;
 
 import io.sentry.Sentry;
 import io.sentry.SentryClient;
+import java.util.Optional;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.common.cli.Cli;
@@ -52,8 +53,7 @@ public class Launcher {
     if (!appPreferences.hasKey(BRIEFCASE_TRACKING_CONSENT_PROPERTY))
       appPreferences.put(BRIEFCASE_TRACKING_CONSENT_PROPERTY, TRUE.toString());
 
-    if (SENTRY_ENABLED)
-      initSentryClient(appPreferences);
+    Optional<SentryClient> sentry = SENTRY_ENABLED ? Optional.of(initSentryClient(appPreferences)) : Optional.empty();
 
     new Cli()
         .deprecate(DEPRECATED_PULL_AGGREGATE, PULL_FORM_FROM_AGGREGATE)

--- a/src/org/opendatakit/briefcase/Launcher.java
+++ b/src/org/opendatakit/briefcase/Launcher.java
@@ -82,15 +82,11 @@ public class Launcher {
             runLegacyCli(commandLine, cli::printHelp);
         })
         .onError(throwable -> {
-          if (throwable instanceof BriefcaseException) {
-            System.err.println("Error: " + throwable.getMessage());
-            log.error("Error", throwable);
-            System.exit(1);
-          } else {
-            System.err.println("Unexpected error in Briefcase. Please review briefcase.log for more information. For help, post to https://forum.opendatakit.org/c/support");
-            log.error("Error", throwable);
-            System.exit(1);
-          }
+          System.err.println(throwable instanceof BriefcaseException
+              ? "Error: " + throwable.getMessage()
+              : "Unexpected error in Briefcase. Please review briefcase.log for more information. For help, post to https://forum.opendatakit.org/c/support");
+          log.error("Error", throwable);
+          System.exit(1);
         })
         .run(args);
   }

--- a/src/org/opendatakit/briefcase/Launcher.java
+++ b/src/org/opendatakit/briefcase/Launcher.java
@@ -73,6 +73,7 @@ public class Launcher {
               ? "Error: " + throwable.getMessage()
               : "Unexpected error in Briefcase. Please review briefcase.log for more information. For help, post to https://forum.opendatakit.org/c/support");
           log.error("Error", throwable);
+          sentry.ifPresent(client -> client.sendException(throwable));
           System.exit(1);
         })
         .run(args);

--- a/src/org/opendatakit/common/cli/Cli.java
+++ b/src/org/opendatakit/common/cli/Cli.java
@@ -135,7 +135,14 @@ public class Cli {
       if (executedOperations.isEmpty())
         otherwiseCallbacks.forEach(callback -> callback.accept(this, cli));
     } catch (Throwable t) {
-      onErrorCallbacks.forEach(callback -> callback.accept(t));
+      if (!onErrorCallbacks.isEmpty())
+        onErrorCallbacks.forEach(callback -> callback.accept(t));
+      else {
+        System.err.println("Error: " + t.getMessage());
+        System.err.println("No error callbacks have been defined");
+        log.error("Error", t);
+        System.exit(1);
+      }
     }
   }
 

--- a/src/org/opendatakit/common/cli/Cli.java
+++ b/src/org/opendatakit/common/cli/Cli.java
@@ -33,7 +33,6 @@ import org.apache.commons.cli.MissingArgumentException;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.UnrecognizedOptionException;
 import org.opendatakit.briefcase.buildconfig.BuildConfig;
-import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -135,16 +134,8 @@ public class Cli {
 
       if (executedOperations.isEmpty())
         otherwiseCallbacks.forEach(callback -> callback.accept(this, cli));
-    } catch (BriefcaseException e) {
-      onErrorCallbacks.forEach(callback -> callback.accept(e));
-      System.err.println("Error: " + e.getMessage());
-      log.error("Error", e);
-      System.exit(1);
     } catch (Throwable t) {
       onErrorCallbacks.forEach(callback -> callback.accept(t));
-      System.err.println("Unexpected error in Briefcase. Please review briefcase.log for more information. For help, post to https://forum.opendatakit.org/c/support");
-      log.error("Error", t);
-      System.exit(1);
     }
   }
 


### PR DESCRIPTION
Closes #530

This PR doesn't change behavior

This PR makes some technical changes to silence some of the reports that get to Sentry. Now, only non-caught exceptions that reach the Launcher (topmost class) should be sent as an error report to Sentry.

#### What has been done to verify that this works as intended?
Verified that CLI ops and UI launch work as expected.
Introduced a syntactic error in a submission to produce an export error and verified that the error was logged but no error reports were sent to Sentry (it is caught and handled by the Export panel).
Forced a non-caught error by adding `throw new RuntimeException("cocotero")` to the last line on the `try` block of the `Cli.run()` method and verified that an error report was sent to Sentry (tracking consent must be checked in the Settings Tab).

#### Why is this the best possible solution? Were any other approaches considered?
This solution has been discussed in #530 as a good solution to reduce the number of Sentry reports we need to comb in search for bugs.

The implementation also improves the design by uncoupling the Cli from our domain's dependencies, as it should be.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.