### PR TITLE
Issue 413 ui disable export media

### DIFF
--- a/src/org/opendatakit/briefcase/export/ExportConfiguration.java
+++ b/src/org/opendatakit/briefcase/export/ExportConfiguration.java
@@ -70,7 +70,7 @@ public class ExportConfiguration {
   private Optional<Boolean> overwriteExistingFiles;
   private Optional<Boolean> exportMedia;
 
-  public ExportConfiguration(Optional<String> exportFileName, Optional<Path> exportDir, Optional<Path> pemFile, Optional<LocalDate> startDate, Optional<LocalDate> endDate, Optional<Boolean> pullBefore, Optional<PullBeforeOverrideOption> pullBeforeOverride, Optional<Boolean> theOverwriteExistingFiles, Optional<Boolean> exportMedia) {
+  public ExportConfiguration(Optional<String> exportFileName, Optional<Path> exportDir, Optional<Path> pemFile, Optional<LocalDate> startDate, Optional<LocalDate> endDate, Optional<Boolean> pullBefore, Optional<PullBeforeOverrideOption> pullBeforeOverride, Optional<Boolean> overwriteExistingFiles, Optional<Boolean> exportMedia) {
     this.exportFileName = exportFileName;
     this.exportDir = exportDir;
     this.pemFile = pemFile;
@@ -78,7 +78,7 @@ public class ExportConfiguration {
     this.endDate = endDate;
     this.pullBefore = pullBefore;
     this.pullBeforeOverride = pullBeforeOverride;
-    this.overwriteExistingFiles = theOverwriteExistingFiles;
+    this.overwriteExistingFiles = overwriteExistingFiles;
     this.exportMedia = exportMedia;
   }
 

--- a/src/org/opendatakit/briefcase/export/ExportConfiguration.java
+++ b/src/org/opendatakit/briefcase/export/ExportConfiguration.java
@@ -58,6 +58,7 @@ public class ExportConfiguration {
   private static final String PULL_BEFORE = "pullBefore";
   private static final String PULL_BEFORE_OVERRIDE = "pullBeforeOverride";
   private static final String OVERWRITE_EXISTING_FILES = "overwriteExistingFiles";
+  private static final String EXPORT_MEDIA = "exportMedia";
   private static final Predicate<PullBeforeOverrideOption> ALL_EXCEPT_INHERIT = value -> value != INHERIT;
   private Optional<String> exportFileName;
   private Optional<Path> exportDir;
@@ -67,8 +68,9 @@ public class ExportConfiguration {
   private Optional<Boolean> pullBefore;
   private Optional<PullBeforeOverrideOption> pullBeforeOverride;
   private Optional<Boolean> overwriteExistingFiles;
+  private Optional<Boolean> exportMedia;
 
-  public ExportConfiguration(Optional<String> exportFileName, Optional<Path> exportDir, Optional<Path> pemFile, Optional<LocalDate> startDate, Optional<LocalDate> endDate, Optional<Boolean> pullBefore, Optional<PullBeforeOverrideOption> pullBeforeOverride, Optional<Boolean> theOverwriteExistingFiles) {
+  public ExportConfiguration(Optional<String> exportFileName, Optional<Path> exportDir, Optional<Path> pemFile, Optional<LocalDate> startDate, Optional<LocalDate> endDate, Optional<Boolean> pullBefore, Optional<PullBeforeOverrideOption> pullBeforeOverride, Optional<Boolean> theOverwriteExistingFiles, Optional<Boolean> exportMedia) {
     this.exportFileName = exportFileName;
     this.exportDir = exportDir;
     this.pemFile = pemFile;
@@ -77,10 +79,11 @@ public class ExportConfiguration {
     this.pullBefore = pullBefore;
     this.pullBeforeOverride = pullBeforeOverride;
     this.overwriteExistingFiles = theOverwriteExistingFiles;
+    this.exportMedia = exportMedia;
   }
 
   public static ExportConfiguration empty() {
-    return new ExportConfiguration(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+    return new ExportConfiguration(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
   }
 
   public static ExportConfiguration load(BriefcasePreferences prefs) {
@@ -92,7 +95,8 @@ public class ExportConfiguration {
         prefs.nullSafeGet(END_DATE).map(LocalDate::parse),
         prefs.nullSafeGet(PULL_BEFORE).map(Boolean::valueOf),
         prefs.nullSafeGet(PULL_BEFORE_OVERRIDE).map(PullBeforeOverrideOption::from),
-        prefs.nullSafeGet(OVERWRITE_EXISTING_FILES).map(Boolean::valueOf)
+        prefs.nullSafeGet(OVERWRITE_EXISTING_FILES).map(Boolean::valueOf),
+        prefs.nullSafeGet(EXPORT_MEDIA).map(Boolean::valueOf)
     );
   }
 
@@ -105,7 +109,8 @@ public class ExportConfiguration {
         prefs.nullSafeGet(keyPrefix + END_DATE).map(LocalDate::parse),
         prefs.nullSafeGet(keyPrefix + PULL_BEFORE).map(Boolean::valueOf),
         prefs.nullSafeGet(keyPrefix + PULL_BEFORE_OVERRIDE).map(PullBeforeOverrideOption::from),
-        prefs.nullSafeGet(keyPrefix + OVERWRITE_EXISTING_FILES).map(Boolean::valueOf)
+        prefs.nullSafeGet(keyPrefix + OVERWRITE_EXISTING_FILES).map(Boolean::valueOf),
+        prefs.nullSafeGet(keyPrefix + EXPORT_MEDIA).map(Boolean::valueOf)
     );
   }
 
@@ -121,7 +126,8 @@ public class ExportConfiguration {
         keyPrefix + END_DATE,
         keyPrefix + PULL_BEFORE,
         keyPrefix + PULL_BEFORE_OVERRIDE,
-        keyPrefix + OVERWRITE_EXISTING_FILES
+        keyPrefix + OVERWRITE_EXISTING_FILES,
+        keyPrefix + EXPORT_MEDIA
     );
   }
 
@@ -140,6 +146,7 @@ public class ExportConfiguration {
     pullBefore.ifPresent(value -> map.put(keyPrefix + PULL_BEFORE, value.toString()));
     pullBeforeOverride.filter(ALL_EXCEPT_INHERIT).ifPresent(value -> map.put(keyPrefix + PULL_BEFORE_OVERRIDE, value.name()));
     overwriteExistingFiles.ifPresent(value -> map.put(keyPrefix + OVERWRITE_EXISTING_FILES, value.toString()));
+    exportMedia.ifPresent(value -> map.put(keyPrefix + EXPORT_MEDIA, value.toString()));
     return map;
   }
 
@@ -151,7 +158,8 @@ public class ExportConfiguration {
         endDate,
         pullBefore,
         pullBeforeOverride,
-        overwriteExistingFiles
+        overwriteExistingFiles,
+        exportMedia
     );
   }
 
@@ -222,6 +230,15 @@ public class ExportConfiguration {
     return this;
   }
 
+  public Optional<Boolean> getExportMedia() {
+    return exportMedia;
+  }
+
+  public ExportConfiguration setExportMedia(boolean exportMedia) {
+    this.exportMedia = Optional.of(exportMedia);
+    return this;
+  }
+
   /**
    * Resolves if we need to pull forms depending on the pullBefore and pullBeforeOverride
    * settings with the following algorithm:
@@ -273,6 +290,10 @@ public class ExportConfiguration {
 
   public void ifOverwriteExistingFilesPresent(Consumer<Boolean> consumer) {
     overwriteExistingFiles.ifPresent(consumer);
+  }
+
+  public void ifExportMediaPresent(Consumer<Boolean> consumer) {
+    exportMedia.ifPresent(consumer);
   }
 
   private List<String> getErrors() {
@@ -334,7 +355,8 @@ public class ExportConfiguration {
         && !endDate.isPresent()
         && !pullBefore.isPresent()
         && !pullBeforeOverride.filter(ALL_EXCEPT_INHERIT).isPresent()
-        && !overwriteExistingFiles.isPresent();
+        && !overwriteExistingFiles.isPresent()
+        && !exportMedia.isPresent();
   }
 
   public boolean isValid() {
@@ -369,7 +391,8 @@ public class ExportConfiguration {
         endDate.isPresent() ? endDate : defaultConfiguration.endDate,
         pullBefore.isPresent() ? pullBefore : defaultConfiguration.pullBefore,
         pullBeforeOverride.isPresent() ? pullBeforeOverride : defaultConfiguration.pullBeforeOverride,
-        overwriteExistingFiles.isPresent() ? overwriteExistingFiles : defaultConfiguration.overwriteExistingFiles
+        overwriteExistingFiles.isPresent() ? overwriteExistingFiles : defaultConfiguration.overwriteExistingFiles,
+        exportMedia.isPresent() ? exportMedia : defaultConfiguration.exportMedia
     );
   }
 
@@ -383,6 +406,7 @@ public class ExportConfiguration {
         ", pullBefore=" + pullBefore +
         ", pullBeforeOverride=" + pullBeforeOverride +
         ", overwriteExistingFiles=" + overwriteExistingFiles +
+        ", exportMedia=" + exportMedia +
         '}';
   }
 
@@ -399,12 +423,13 @@ public class ExportConfiguration {
         Objects.equals(endDate, that.endDate) &&
         Objects.equals(pullBefore, that.pullBefore) &&
         Objects.equals(pullBeforeOverride, that.pullBeforeOverride) &&
-        Objects.equals(overwriteExistingFiles, that.overwriteExistingFiles);
+        Objects.equals(overwriteExistingFiles, that.overwriteExistingFiles) &&
+        Objects.equals(exportMedia, that.exportMedia);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(exportDir, pemFile, startDate, endDate, pullBefore, pullBeforeOverride, overwriteExistingFiles);
+    return Objects.hash(exportDir, pemFile, startDate, endDate, pullBefore, pullBeforeOverride, overwriteExistingFiles, exportMedia);
   }
 
   public static ErrorsOr<PrivateKey> readPemFile(Path pemFile) {

--- a/src/org/opendatakit/briefcase/export/ExportToCsv.java
+++ b/src/org/opendatakit/briefcase/export/ExportToCsv.java
@@ -60,11 +60,10 @@ public class ExportToCsv {
    *
    * @param formDef       the {@link BriefcaseFormDefinition} form definition of the form to be exported
    * @param configuration the {@link ExportConfiguration} export configuration
-   * @param exportMedia   a {@link Boolean} indicating if media files attached to each submission must be also exported
    * @return an {@link ExportOutcome} with the export operation's outcome
    * @see ExportConfiguration
    */
-  public static ExportOutcome export(FormDefinition formDef, ExportConfiguration configuration, boolean exportMedia) {
+  public static ExportOutcome export(FormDefinition formDef, ExportConfiguration configuration) {
     long start = System.nanoTime();
     // Create an export tracker object with the total number of submissions we have to export
     long submissionCount = walk(formDef.getFormDir().resolve("instances"))
@@ -120,13 +119,13 @@ public class ExportToCsv {
                 submission,
                 formDef.getModel(),
                 formDef.isFileEncryptedForm(),
-                exportMedia,
+                configuration.getExportMedia().orElse(true),
                 configuration.getExportMediaPath()
             );
             repeatLines = repeatGroups.stream().map(groupModel -> Pair.of(getRepeatCsvLine(
                 groupModel,
                 submission.getElements(groupModel.fqn()),
-                exportMedia,
+                configuration.getExportMedia().orElse(true),
                 configuration.getExportMediaPath(),
                 submission.getInstanceId(),
                 submission.getWorkingDir()

--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -85,7 +85,8 @@ public class Export {
         endDate,
         Optional.empty(),
         Optional.empty(),
-        Optional.of(overwriteFiles)
+        Optional.of(overwriteFiles),
+        Optional.of(exportMedia)
     );
     ExportToCsv.export(FormDefinition.from(formDefinition), configuration, exportMedia);
 

--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -88,7 +88,7 @@ public class Export {
         Optional.of(overwriteFiles),
         Optional.of(exportMedia)
     );
-    ExportToCsv.export(FormDefinition.from(formDefinition), configuration, exportMedia);
+    ExportToCsv.export(FormDefinition.from(formDefinition), configuration);
 
     BriefcasePreferences.forClass(ExportPanel.class).put(buildExportDateTimePrefix(formDefinition.getFormId()), LocalDateTime.now().format(ISO_DATE_TIME));
   }

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -197,7 +197,7 @@ public class ExportPanel {
                   appPreferences.getPullInParallel().orElse(false)
               ));
             BriefcaseFormDefinition formDefinition = (BriefcaseFormDefinition) form.getFormDefinition();
-            ExportToCsv.export(FormDefinition.from(formDefinition), configuration, true);
+            ExportToCsv.export(FormDefinition.from(formDefinition), configuration);
           });
     } catch (Throwable t) {
       log.error("Error while exporting forms", t);

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanel.java
@@ -36,6 +36,7 @@ public class ConfigurationPanel {
     configuration.ifPullBeforePresent(form::setPullBefore);
     configuration.ifPullBeforeOverridePresent(form::setPullBeforeOverride);
     configuration.ifOverwriteExistingFilesPresent(form::setOverwriteExistingFiles);
+    configuration.ifExportMediaPresent(form::setExportMedia);
 
     form.onSelectExportDir(path -> {
       configuration.setExportDir(path);
@@ -63,6 +64,10 @@ public class ConfigurationPanel {
     });
     form.onChangeOverwriteExistingFiles(overwriteExistingFiles -> {
       configuration.setOverwriteExistingFiles(overwriteExistingFiles);
+      triggerOnChange();
+    });
+    form.onChangeExportMedia(exportMedia ->  {
+      configuration.setExportMedia(exportMedia);
       triggerOnChange();
     });
   }

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanel.java
@@ -36,7 +36,7 @@ public class ConfigurationPanel {
     configuration.ifPullBeforePresent(form::setPullBefore);
     configuration.ifPullBeforeOverridePresent(form::setPullBeforeOverride);
     configuration.ifOverwriteExistingFilesPresent(form::setOverwriteExistingFiles);
-    configuration.ifExportMediaPresent(form::setExportMedia);
+    form.setExportMedia(configuration.getExportMedia().orElse(true));
 
     form.onSelectExportDir(path -> {
       configuration.setExportDir(path);

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.form
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.form
@@ -106,7 +106,7 @@
       </hspacer>
       <component id="4d9bd" class="javax.swing.JCheckBox" binding="pullBeforeField">
         <constraints>
-          <grid row="5" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties>
@@ -115,7 +115,7 @@
       </component>
       <component id="6925f" class="javax.swing.JTextPane" binding="pullBeforeHintPanel">
         <constraints>
-          <grid row="7" column="2" row-span="1" col-span="2" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+          <grid row="8" column="2" row-span="1" col-span="2" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="50"/>
           </grid>
           <gridbag weightx="0.0" weighty="0.0"/>
@@ -131,7 +131,7 @@
       </component>
       <component id="9a017" class="javax.swing.JComboBox" binding="pullBeforeOverrideField" custom-create="true">
         <constraints>
-          <grid row="6" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties/>
@@ -144,7 +144,7 @@
       </vspacer>
       <component id="443be" class="javax.swing.JLabel" binding="pullBeforeOverrideLabel">
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties>
@@ -201,7 +201,7 @@
       </grid>
       <component id="bd9c9" class="javax.swing.JCheckBox" binding="overwriteFilesField">
         <constraints>
-          <grid row="9" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="10" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties>
@@ -210,10 +210,19 @@
       </component>
       <vspacer id="1c95d">
         <constraints>
-          <grid row="8" column="0" row-span="1" col-span="3" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="9" column="0" row-span="1" col-span="3" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
       </vspacer>
+      <component id="b005d" class="javax.swing.JCheckBox" binding="exportMediaField">
+        <constraints>
+          <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <gridbag weightx="0.0" weighty="0.0"/>
+        </constraints>
+        <properties>
+          <text value="Export media files"/>
+        </properties>
+      </component>
     </children>
   </grid>
 </form>

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
@@ -85,6 +85,7 @@ public class ConfigurationPanelForm extends JComponent {
   private final List<Consumer<Boolean>> onChangePullBeforeCallbacks = new ArrayList<>();
   private final List<Consumer<PullBeforeOverrideOption>> onChangePullBeforeOverrideCallbacks = new ArrayList<>();
   private final List<Consumer<Boolean>> onChangeOverwriteExistingFilesCallbacks = new ArrayList<>();
+  private final List<Consumer<Boolean>> onChangeExportMediaCallbacks = new ArrayList<>();
   private final ConfigurationPanelMode mode;
   private boolean uiLocked = false;
 
@@ -132,6 +133,7 @@ public class ConfigurationPanelForm extends JComponent {
       if (!overwriteFilesField.isSelected() || confirmOverwriteFiles())
         triggerOverwriteExistingFiles();
     });
+    exportMediaField.addActionListener(__ -> triggerChangeExportMedia());
   }
 
   public static ConfigurationPanelForm overridePanel(boolean savePasswordsConsent, boolean hasTransferSettings) {
@@ -221,6 +223,10 @@ public class ConfigurationPanelForm extends JComponent {
     overwriteFilesField.setSelected(value);
   }
 
+  void setExportMedia(boolean value) {
+    exportMediaField.setSelected(value);
+  }
+
   void onSelectExportDir(Consumer<Path> callback) {
     onSelectExportDirCallbacks.add(callback);
   }
@@ -247,6 +253,10 @@ public class ConfigurationPanelForm extends JComponent {
 
   void onChangeOverwriteExistingFiles(Consumer<Boolean> callback) {
     onChangeOverwriteExistingFilesCallbacks.add(callback);
+  }
+
+  void onChangeExportMedia(Consumer<Boolean> callback) {
+    onChangeExportMediaCallbacks.add(callback);
   }
 
   void changeMode(boolean savePasswordsConsent) {
@@ -307,6 +317,9 @@ public class ConfigurationPanelForm extends JComponent {
     onChangeOverwriteExistingFilesCallbacks.forEach(callback -> callback.accept(overwriteFilesField.isSelected()));
   }
 
+  private void triggerChangeExportMedia() {
+    onChangeExportMediaCallbacks.forEach(callback -> callback.accept(exportMediaField.isSelected()));
+  }
 
   private boolean confirmOverwriteFiles() {
     if (showConfirmDialog(this, "Overwrite existing files?", "", YES_NO_OPTION, PLAIN_MESSAGE) == YES_OPTION)

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
@@ -77,6 +77,7 @@ public class ConfigurationPanelForm extends JComponent {
   JTextPane pullBeforeHintPanel;
   JLabel pullBeforeOverrideLabel;
   private JCheckBox overwriteFilesField;
+  private JCheckBox exportMediaField;
   private final List<Consumer<Path>> onSelectExportDirCallbacks = new ArrayList<>();
   private final List<Consumer<Path>> onSelectPemFileCallbacks = new ArrayList<>();
   private final List<Consumer<LocalDate>> onSelectStartDateCallbacks = new ArrayList<>();
@@ -415,7 +416,7 @@ public class ConfigurationPanelForm extends JComponent {
     pullBeforeField.setText("Pull before export");
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
-    gbc.gridy = 5;
+    gbc.gridy = 6;
     gbc.gridwidth = 2;
     gbc.anchor = GridBagConstraints.WEST;
     container.add(pullBeforeField, gbc);
@@ -428,13 +429,13 @@ public class ConfigurationPanelForm extends JComponent {
     pullBeforeHintPanel.setText("Some hint will be shown here");
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
-    gbc.gridy = 7;
+    gbc.gridy = 8;
     gbc.gridwidth = 2;
     gbc.fill = GridBagConstraints.BOTH;
     container.add(pullBeforeHintPanel, gbc);
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
-    gbc.gridy = 6;
+    gbc.gridy = 7;
     gbc.anchor = GridBagConstraints.WEST;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     container.add(pullBeforeOverrideField, gbc);
@@ -449,7 +450,7 @@ public class ConfigurationPanelForm extends JComponent {
     pullBeforeOverrideLabel.setText("Pull before export");
     gbc = new GridBagConstraints();
     gbc.gridx = 0;
-    gbc.gridy = 6;
+    gbc.gridy = 7;
     gbc.anchor = GridBagConstraints.WEST;
     container.add(pullBeforeOverrideLabel, gbc);
     exportDirButtons = new JPanel();
@@ -486,16 +487,23 @@ public class ConfigurationPanelForm extends JComponent {
     overwriteFilesField.setText("Overwrite existing files");
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
-    gbc.gridy = 9;
+    gbc.gridy = 10;
     gbc.anchor = GridBagConstraints.WEST;
     container.add(overwriteFilesField, gbc);
     final JPanel spacer6 = new JPanel();
     gbc = new GridBagConstraints();
     gbc.gridx = 0;
-    gbc.gridy = 8;
+    gbc.gridy = 9;
     gbc.gridwidth = 3;
     gbc.fill = GridBagConstraints.VERTICAL;
     container.add(spacer6, gbc);
+    exportMediaField = new JCheckBox();
+    exportMediaField.setText("Export media files");
+    gbc = new GridBagConstraints();
+    gbc.gridx = 2;
+    gbc.gridy = 5;
+    gbc.anchor = GridBagConstraints.WEST;
+    container.add(exportMediaField, gbc);
   }
 
   /**

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
@@ -28,7 +28,6 @@ import static org.opendatakit.briefcase.util.FindDirectoryStructure.isMac;
 import static org.opendatakit.briefcase.util.FindDirectoryStructure.isWindows;
 
 import com.github.lgooddatepicker.components.DatePicker;
-
 import java.awt.Color;
 import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
@@ -50,7 +49,6 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.JTextPane;
-
 import org.opendatakit.briefcase.export.PullBeforeOverrideOption;
 import org.opendatakit.briefcase.ui.reused.FileChooser;
 import org.opendatakit.briefcase.util.StringUtils;

--- a/test/java/org/opendatakit/briefcase/export/ExportToCsvScenario.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportToCsvScenario.java
@@ -142,7 +142,7 @@ class ExportToCsvScenario {
         Optional.of(overwrite),
         Optional.of(exportMedia)
     );
-    ExportToCsv.export(formDef, configuration, exportMedia);
+    ExportToCsv.export(formDef, configuration);
   }
 
   void assertSameContent() {

--- a/test/java/org/opendatakit/briefcase/export/ExportToCsvScenario.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportToCsvScenario.java
@@ -139,7 +139,8 @@ class ExportToCsvScenario {
         Optional.ofNullable(endDate),
         Optional.of(false),
         Optional.empty(),
-        Optional.of(overwrite)
+        Optional.of(overwrite),
+        Optional.of(exportMedia)
     );
     ExportToCsv.export(formDef, configuration, exportMedia);
   }


### PR DESCRIPTION
Closes #413 

#### What has been done to verify that this works as intended?
Tests passing.

Tested all combinations of the new setting with the UI, both as default and override confs. Verified that media files are exported only when the option is checked.

Verified that the export media checkbox is checked by default after cleaning prefs.

Verified that the export media checkbox state was saved after relaunching Briefcase (both default and override).

#### Why is this the best possible solution? Were any other approaches considered?
The changes on this PR imitate what's being done with other conf params.

We should refactor the export conf object and related UI components to use a more up-to-date approach like in the pull/push tabs that would dramatically reduce code duplication and complexity.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.