### PR TITLE
Issue 556 name as form index key

### DIFF
--- a/src/org/opendatakit/briefcase/export/ExportEvent.java
+++ b/src/org/opendatakit/briefcase/export/ExportEvent.java
@@ -17,12 +17,12 @@
 package org.opendatakit.briefcase.export;
 
 public class ExportEvent {
-  private final String formId;
+  private final String formName;
   private final String statusLine;
   private final boolean success;
 
-  private ExportEvent(String formId, String statusLine, boolean success) {
-    this.formId = formId;
+  private ExportEvent(String formName, String statusLine, boolean success) {
+    this.formName = formName;
     this.statusLine = statusLine;
     this.success = success;
   }
@@ -30,39 +30,39 @@ public class ExportEvent {
   public static ExportEvent progress(FormDefinition form, double percentage) {
     int base100Percentage = new Double(percentage * 100).intValue();
     String statusLine = String.format("Exported %s%% of the submissions", base100Percentage);
-    return new ExportEvent(form.getFormId(), statusLine, false);
+    return new ExportEvent(form.getFormName(), statusLine, false);
   }
 
   public static ExportEvent start(FormDefinition form) {
-    return new ExportEvent(form.getFormId(), "Export has started", false);
+    return new ExportEvent(form.getFormName(), "Export has started", false);
   }
 
   public static ExportEvent end(FormDefinition form, long exported) {
-    return new ExportEvent(form.getFormId(), "Export has ended", false);
+    return new ExportEvent(form.getFormName(), "Export has ended", false);
   }
 
   public static ExportEvent failure(FormDefinition form, String cause) {
-    return new ExportEvent.Failure(form.getFormId(), String.format("Failure: %s", cause), false);
+    return new ExportEvent.Failure(form.getFormName(), String.format("Failure: %s", cause), false);
   }
 
   public static ExportEvent failureSubmission(FormDefinition form, String instanceId, Throwable cause) {
     return new ExportEvent(
-        form.getFormId(),
-        String.format("Can't export submission %s of form ID %s. Cause: %s", instanceId, form.getFormId(), cause.getMessage()),
+        form.getFormName(),
+        String.format("Can't export submission %s of form %s. Cause: %s", instanceId, form.getFormName(), cause.getMessage()),
         false
     );
   }
 
   public static ExportEvent successForm(FormDefinition formDef, int total) {
-    return new ExportEvent.Success(formDef.getFormId(), String.format("Exported %d submission%s", total, sUnlessOne(total)), true);
+    return new ExportEvent.Success(formDef.getFormName(), String.format("Exported %d submission%s", total, sUnlessOne(total)), true);
   }
 
   public static ExportEvent partialSuccessForm(FormDefinition formDef, int exported, int total) {
-    return new ExportEvent.Success(formDef.getFormId(), String.format("Exported %d from %d submission%s", exported, total, sUnlessOne(total)), true);
+    return new ExportEvent.Success(formDef.getFormName(), String.format("Exported %d from %d submission%s", exported, total, sUnlessOne(total)), true);
   }
 
-  public String getFormId() {
-    return formId;
+  public String getFormName() {
+    return formName;
   }
 
   public String getStatusLine() {
@@ -79,14 +79,14 @@ public class ExportEvent {
   }
 
   public static class Failure extends ExportEvent {
-    private Failure(String formId, String statusLine, boolean success) {
-      super(formId, statusLine, success);
+    private Failure(String formName, String statusLine, boolean success) {
+      super(formName, statusLine, success);
     }
   }
 
   public static class Success extends ExportEvent {
-    private Success(String formId, String statusLine, boolean success) {
-      super(formId, statusLine, success);
+    private Success(String formName, String statusLine, boolean success) {
+      super(formName, statusLine, success);
     }
   }
 }

--- a/src/org/opendatakit/briefcase/transfer/TransferForms.java
+++ b/src/org/opendatakit/briefcase/transfer/TransferForms.java
@@ -65,6 +65,7 @@ public class TransferForms {
    */
   public void load(List<FormStatus> forms) {
     this.forms = forms;
+    rebuildIndex();
     triggerOnChange();
   }
 

--- a/src/org/opendatakit/briefcase/transfer/TransferForms.java
+++ b/src/org/opendatakit/briefcase/transfer/TransferForms.java
@@ -55,10 +55,6 @@ public class TransferForms {
     return new TransferForms(forms);
   }
 
-  private static String getFormId(FormStatus form) {
-    return form.getFormDefinition().getFormId();
-  }
-
   /**
    * Replaces the current list of {@link FormStatus} instances with
    * the incoming list.
@@ -80,9 +76,9 @@ public class TransferForms {
    * instances isn't lost.
    */
   public void merge(List<FormStatus> incomingForms) {
-    List<String> incomingFormIds = incomingForms.stream().map(TransferForms::getFormId).collect(toList());
-    List<FormStatus> formsToAdd = incomingForms.stream().filter(form -> !formsIndex.containsKey(getFormId(form))).collect(toList());
-    List<FormStatus> formsToRemove = formsIndex.values().stream().filter(form -> !incomingFormIds.contains(getFormId(form))).collect(toList());
+    List<String> incomingFormNames = incomingForms.stream().map(FormStatus::getFormName).collect(toList());
+    List<FormStatus> formsToAdd = incomingForms.stream().filter(form -> !formsIndex.containsKey(form.getFormName())).collect(toList());
+    List<FormStatus> formsToRemove = formsIndex.values().stream().filter(form -> !incomingFormNames.contains(form.getFormName())).collect(toList());
     forms.addAll(formsToAdd);
     forms.removeAll(formsToRemove);
     rebuildIndex();
@@ -161,7 +157,7 @@ public class TransferForms {
   }
 
   private void rebuildIndex() {
-    formsIndex = forms.stream().collect(toMap(TransferForms::getFormId, form -> form));
+    formsIndex = forms.stream().collect(toMap(FormStatus::getFormName, form -> form));
   }
 
   /**

--- a/src/org/opendatakit/briefcase/ui/pull/FormInstaller.java
+++ b/src/org/opendatakit/briefcase/ui/pull/FormInstaller.java
@@ -31,6 +31,7 @@ import org.opendatakit.briefcase.model.FormStatusEvent;
 import org.opendatakit.briefcase.model.OdkCollectFormDefinition;
 import org.opendatakit.briefcase.pull.PullEvent;
 import org.opendatakit.briefcase.reused.BriefcaseException;
+import org.opendatakit.briefcase.reused.UncheckedFiles;
 
 /**
  * This class has UI/CLI independent methods to install forms into

--- a/src/org/opendatakit/briefcase/ui/pull/FormInstaller.java
+++ b/src/org/opendatakit/briefcase/ui/pull/FormInstaller.java
@@ -87,6 +87,9 @@ public class FormInstaller {
             EventBus.publish(new FormStatusEvent(form));
           });
 
+    // Create an empty instances directory
+    UncheckedFiles.createDirectories(targetFormDir.resolve("instances"));
+
     form.setStatusString("Success", true);
     EventBus.publish(new FormStatusEvent(form));
   }

--- a/test/java/org/opendatakit/briefcase/export/ExportFormsTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportFormsTest.java
@@ -19,7 +19,7 @@ import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresent;
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
 import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
-import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -80,12 +80,11 @@ public class ExportFormsTest {
     forms.putConfiguration(firstForm, VALID_CONFIGURATION);
 
     assertThat(forms.hasConfiguration(firstForm), is(true));
-    assertThat(forms.getConfiguration(firstForm.getFormDefinition().getFormId()), is(VALID_CONFIGURATION));
-    assertThat(forms.getConfiguration(firstForm.getFormDefinition().getFormId()), is(VALID_CONFIGURATION));
+    assertThat(forms.getConfiguration(firstForm.getFormName()), is(VALID_CONFIGURATION));
 
     forms.putConfiguration(secondForm, INVALID_CONFIGURATION);
-    assertThat(forms.getCustomConfigurations().values(), hasSize(2));
-    assertThat(forms.getCustomConfigurations().values(), contains(VALID_CONFIGURATION, INVALID_CONFIGURATION));
+    assertThat(forms.getCustomConfigurationsByFormName().values(), hasSize(2));
+    assertThat(forms.getCustomConfigurationsByFormName().values(), containsInAnyOrder(VALID_CONFIGURATION, INVALID_CONFIGURATION));
 
     forms.removeConfiguration(firstForm);
 
@@ -160,8 +159,8 @@ public class ExportFormsTest {
     AtomicInteger count = new AtomicInteger(0);
     ExportForms forms = new ExportForms(buildFormStatusList(10), ExportConfiguration.empty(), new HashMap<>(), new HashMap<>(), new HashMap<>());
     FormStatus form = forms.get(0);
-    forms.onSuccessfulExport((formId, exportDateTime) -> {
-      if (formId.equals(form.getFormDefinition().getFormId()))
+    forms.onSuccessfulExport((formName, exportDateTime) -> {
+      if (formName.equals(form.getFormName()))
         count.incrementAndGet();
     });
 
@@ -176,10 +175,10 @@ public class ExportFormsTest {
     LocalDateTime exportDateTime = LocalDateTime.now();
     List<FormStatus> formsList = buildFormStatusList(10);
     FormStatus form = formsList.get(0);
-    String formId = form.getFormDefinition().getFormId();
+    String formName = form.getFormName();
     BriefcasePreferences exportPreferences = new BriefcasePreferences(InMemoryPreferences.empty());
-    exportPreferences.putAll(VALID_CONFIGURATION.asMap(buildCustomConfPrefix(formId)));
-    exportPreferences.put(ExportForms.buildExportDateTimePrefix(formId), exportDateTime.format(ISO_DATE_TIME));
+    exportPreferences.putAll(VALID_CONFIGURATION.asMap(buildCustomConfPrefix(formName)));
+    exportPreferences.put(ExportForms.buildExportDateTimePrefix(formName), exportDateTime.format(ISO_DATE_TIME));
     BriefcasePreferences appPreferences = new BriefcasePreferences(InMemoryPreferences.empty());
 
     ExportForms forms = ExportForms.load(ExportConfiguration.empty(), formsList, exportPreferences, appPreferences);
@@ -201,13 +200,13 @@ public class ExportFormsTest {
     List<FormStatus> formsList = Arrays.asList(formWithTransferSettings, formWithoutTransferSettings);
     BriefcasePreferences exportPreferences = new BriefcasePreferences(InMemoryPreferences.empty());
     BriefcasePreferences appPreferences = new BriefcasePreferences(InMemoryPreferences.empty());
-    appPreferences.put(String.format("%s_pull_settings_url", formWithTransferSettings.getFormDefinition().getFormId()), expectedTransferSettings.getUrl());
-    appPreferences.put(String.format("%s_pull_settings_username", formWithTransferSettings.getFormDefinition().getFormId()), expectedTransferSettings.getUsername());
-    appPreferences.put(String.format("%s_pull_settings_password", formWithTransferSettings.getFormDefinition().getFormId()), String.valueOf(expectedTransferSettings.getPassword()));
+    appPreferences.put(String.format("%s_pull_settings_url", formWithTransferSettings.getFormName()), expectedTransferSettings.getUrl());
+    appPreferences.put(String.format("%s_pull_settings_username", formWithTransferSettings.getFormName()), expectedTransferSettings.getUsername());
+    appPreferences.put(String.format("%s_pull_settings_password", formWithTransferSettings.getFormName()), String.valueOf(expectedTransferSettings.getPassword()));
 
     ExportForms forms = ExportForms.load(ExportConfiguration.empty(), formsList, exportPreferences, appPreferences);
 
-    assertThat(forms.getTransferSettings(formWithoutTransferSettings.getFormDefinition().getFormId()), isEmpty());
-    assertThat(forms.getTransferSettings(formWithTransferSettings.getFormDefinition().getFormId()), isPresentAndIs(expectedTransferSettings));
+    assertThat(forms.getTransferSettings(formWithoutTransferSettings.getFormName()), isEmpty());
+    assertThat(forms.getTransferSettings(formWithTransferSettings.getFormName()), isPresentAndIs(expectedTransferSettings));
   }
 }

--- a/test/java/org/opendatakit/briefcase/ui/export/ExportPanelUnitTest.java
+++ b/test/java/org/opendatakit/briefcase/ui/export/ExportPanelUnitTest.java
@@ -86,17 +86,17 @@ public class ExportPanelUnitTest {
     );
 
     FormStatus form = formsList.get(0);
-    String formId = form.getFormDefinition().getFormId();
+    String formName = form.getFormDefinition().getFormName();
 
     ExportConfiguration conf = ExportConfiguration.empty();
     conf.setExportDir(Paths.get(Files.createTempDirectory("briefcase_test").toUri()));
 
-    assertThat(ExportConfiguration.load(exportPreferences, buildCustomConfPrefix(formId)).getExportDir(), isEmpty());
+    assertThat(ExportConfiguration.load(exportPreferences, buildCustomConfPrefix(formName)).getExportDir(), isEmpty());
 
     forms.putConfiguration(form, conf);
     exportPanelForm.getFormsTable().getViewModel().triggerChange();
 
-    assertThat(ExportConfiguration.load(exportPreferences, buildCustomConfPrefix(formId)).getExportDir(), isPresent());
+    assertThat(ExportConfiguration.load(exportPreferences, buildCustomConfPrefix(formName)).getExportDir(), isPresent());
   }
 
   @Test
@@ -117,14 +117,14 @@ public class ExportPanelUnitTest {
     );
 
     FormStatus form = formsList.get(0);
-    String formId = form.getFormDefinition().getFormId();
+    String formName = form.getFormName();
 
-    assertThat(exportPreferences.nullSafeGet(buildExportDateTimePrefix(formId)), isEmpty());
+    assertThat(exportPreferences.nullSafeGet(buildExportDateTimePrefix(formName)), isEmpty());
 
     FormDefinition formDef = FormDefinition.from((BriefcaseFormDefinition) form.getFormDefinition());
     ExportEvent event = ExportEvent.successForm(formDef, 10);
     forms.appendStatus(event);
 
-    assertThat(exportPreferences.nullSafeGet(buildExportDateTimePrefix(formId)), isPresent());
+    assertThat(exportPreferences.nullSafeGet(buildExportDateTimePrefix(formName)), isPresent());
   }
 }


### PR DESCRIPTION
Partially addresses #556

This PR doesn't change Briefcase's behavior.

This PR comes with some technical changes to avoid getting the duplicated keys error some users have been experiencing.

This PR also fixes two bugs:
- The pull form definition option wouldn't create an empty instances directory. This would produce an error when exporting a form pulled this way.
- The forms list for pull/push panels wouldn't rebuild indexes after loading a list of forms. This could produce inconsistencies between in memory and on screen data.

#### What has been done to verify that this works as intended?
- Pull the forms in this package [forms.zip](https://github.com/opendatakit/briefcase/files/2180240/forms.zip)
  (There are two forms with the same form ID but different titles)
- Verify that both forms are shown in the push and export tables (`Simple Form` and `Simple Form 2`)
- Close Briefcase
- Remove the `cache.ser` file
- Open Briefcase
- Verify that both forms are shown in the push and export tables
- Verify that no error is logged during the whole process.

#### Why is this the best possible solution? Were any other approaches considered?
This still allows errors when Briefcase finds two forms with the same ID and title in different storage dir folders, which could only be possible by direct manual manipulation by the user.

Replacing form IDs as keys to identify forms in the storage dir seems the best option we currently have, without making Briefcase much more complex by using composite keys.

#### Are there any risks to merging this code? If so, what are they?
Nope, but any custom export configuration will be lost, as the pref keys were build using the form ID, not the form name.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.