### PR TITLE
Fix behavior of reload forms button

### DIFF
--- a/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.java
@@ -81,6 +81,8 @@ public class SettingsPanelForm {
 
     httpProxyPortField.addChangeListener(__ -> processHttpProxyFields());
 
+    reloadCacheButton.setEnabled(false);
+    
     updateProxyFields(useHttpProxyField.isSelected());
   }
 
@@ -114,6 +116,7 @@ public class SettingsPanelForm {
     storageLocationChooseButton.setVisible(false);
     storageLocationClearButton.setVisible(true);
     onStorageLocationCallbacks.forEach(consumer -> consumer.accept(path));
+    reloadCacheButton.setEnabled(true);
   }
 
   private void clearStorageLocation() {
@@ -121,6 +124,7 @@ public class SettingsPanelForm {
     storageLocationChooseButton.setVisible(true);
     storageLocationClearButton.setVisible(false);
     onClearStorageLocationCallbacks.forEach(Runnable::run);
+    reloadCacheButton.setEnabled(false);
   }
 
   void onStorageLocation(Consumer<Path> onSet, Runnable onClear) {


### PR DESCRIPTION
This PR changes the locking behavior of the reload forms button, which stayed enabled all the time, even when there was no storage dir set.

The new behavior is:
- Disable it by default
- Enable it when the storage directory is set
- Disable it again when the storage directory gets cleared

#### What has been done to verify that this works as intended?
- Verify it is disabled on first launch after clearing prefs.
- Verify it is enabled after setting the storage dir
- Verify it gets disabled when clearing the storage dir

#### Why is this the best possible solution? Were any other approaches considered?
It's the most straighforward change I could come up with to support the behavior we want.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.