### PR TITLE
Issue 580 fix export custom conf export media

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/work
     docker:
-      - image: circleci/openjdk:latest
+      - image: circleci/openjdk:8u171-jdk
     environment:
       - DISPLAY: :99.0
     steps:

--- a/src/org/opendatakit/briefcase/export/CsvSubmissionMappers.java
+++ b/src/org/opendatakit/briefcase/export/CsvSubmissionMappers.java
@@ -59,7 +59,7 @@ final class CsvSubmissionMappers {
           field,
           submission.findElement(field.getName()),
           configuration.getExportMediaPath(),
-          configuration.getExportMedia().orElse(true)
+          configuration.resolveExportMedia()
       ).map(value -> encodeMainValue(field, value))).collect(Collectors.toList()));
       cols.add(submission.getInstanceId());
       if (formDefinition.isFileEncryptedForm())
@@ -88,7 +88,7 @@ final class CsvSubmissionMappers {
               field,
               element.findElement(field.getName()),
               configuration.getExportMediaPath(),
-              configuration.getExportMedia().orElse(true)
+              configuration.resolveExportMedia()
           ).map(CsvSubmissionMappers::encodeRepeatValue)).collect(toList()));
           cols.add(encode(element.getParentLocalId(submission.getInstanceId()), false));
           cols.add(encode(element.getCurrentLocalId(submission.getInstanceId()), false));

--- a/src/org/opendatakit/briefcase/export/ExportConfiguration.java
+++ b/src/org/opendatakit/briefcase/export/ExportConfiguration.java
@@ -247,10 +247,6 @@ public class ExportConfiguration {
     return this;
   }
 
-  public Optional<ExportMediaOverrideOption> getExportMediaOverride() {
-    return exportMediaOverride;
-  }
-
   public ExportConfiguration setExportMediaOverride(ExportMediaOverrideOption exportMediaOverride) {
     this.exportMediaOverride = Optional.ofNullable(exportMediaOverride);
     return this;
@@ -328,10 +324,6 @@ public class ExportConfiguration {
 
   public void ifOverwriteExistingFilesPresent(Consumer<Boolean> consumer) {
     overwriteExistingFiles.ifPresent(consumer);
-  }
-
-  public void ifExportMediaPresent(Consumer<Boolean> consumer) {
-    exportMedia.ifPresent(consumer);
   }
 
   public void ifExportMediaOverridePresent(Consumer<ExportMediaOverrideOption> consumer) {

--- a/src/org/opendatakit/briefcase/export/ExportConfiguration.java
+++ b/src/org/opendatakit/briefcase/export/ExportConfiguration.java
@@ -15,7 +15,6 @@
  */
 package org.opendatakit.briefcase.export;
 
-import static org.opendatakit.briefcase.export.PullBeforeOverrideOption.INHERIT;
 import static org.opendatakit.briefcase.ui.MessageStrings.DIR_INSIDE_BRIEFCASE_STORAGE;
 import static org.opendatakit.briefcase.ui.MessageStrings.DIR_INSIDE_ODK_DEVICE_DIRECTORY;
 import static org.opendatakit.briefcase.ui.MessageStrings.DIR_NOT_DIRECTORY;
@@ -60,7 +59,7 @@ public class ExportConfiguration {
   private static final String OVERWRITE_EXISTING_FILES = "overwriteExistingFiles";
   private static final String EXPORT_MEDIA = "exportMedia";
   private static final String EXPORT_MEDIA_OVERRIDE = "exportMediaOverride";
-  private static final Predicate<PullBeforeOverrideOption> ALL_EXCEPT_INHERIT = value -> value != INHERIT;
+  private static final Predicate<PullBeforeOverrideOption> PULL_BEFORE_ALL_EXCEPT_INHERIT = value -> value != PullBeforeOverrideOption.INHERIT;
   private static final Predicate<ExportMediaOverrideOption> EXPORT_MEDIA_ALL_EXCEPT_INHERIT = value -> value != ExportMediaOverrideOption.INHERIT;
   private Optional<String> exportFileName;
   private Optional<Path> exportDir;
@@ -151,7 +150,7 @@ public class ExportConfiguration {
     startDate.ifPresent(value -> map.put(keyPrefix + START_DATE, value.format(DateTimeFormatter.ISO_DATE)));
     endDate.ifPresent(value -> map.put(keyPrefix + END_DATE, value.format(DateTimeFormatter.ISO_DATE)));
     pullBefore.ifPresent(value -> map.put(keyPrefix + PULL_BEFORE, value.toString()));
-    pullBeforeOverride.filter(ALL_EXCEPT_INHERIT).ifPresent(value -> map.put(keyPrefix + PULL_BEFORE_OVERRIDE, value.name()));
+    pullBeforeOverride.filter(PULL_BEFORE_ALL_EXCEPT_INHERIT).ifPresent(value -> map.put(keyPrefix + PULL_BEFORE_OVERRIDE, value.name()));
     overwriteExistingFiles.ifPresent(value -> map.put(keyPrefix + OVERWRITE_EXISTING_FILES, value.toString()));
     exportMedia.ifPresent(value -> map.put(keyPrefix + EXPORT_MEDIA, value.toString()));
     exportMediaOverride.filter(EXPORT_MEDIA_ALL_EXCEPT_INHERIT).ifPresent(value -> map.put(keyPrefix + EXPORT_MEDIA_OVERRIDE, value.name()));
@@ -273,7 +272,7 @@ public class ExportConfiguration {
    */
   public boolean resolvePullBefore() {
     return Stream.of(
-        pullBeforeOverride.filter(ALL_EXCEPT_INHERIT).flatMap(PullBeforeOverrideOption::asBoolean),
+        pullBeforeOverride.filter(PULL_BEFORE_ALL_EXCEPT_INHERIT).flatMap(PullBeforeOverrideOption::asBoolean),
         pullBefore
     ).filter(Optional::isPresent).map(Optional::get).findFirst().orElse(false);
   }
@@ -376,7 +375,7 @@ public class ExportConfiguration {
         && !startDate.isPresent()
         && !endDate.isPresent()
         && !pullBefore.isPresent()
-        && !pullBeforeOverride.filter(ALL_EXCEPT_INHERIT).isPresent()
+        && !pullBeforeOverride.filter(PULL_BEFORE_ALL_EXCEPT_INHERIT).isPresent()
         && !overwriteExistingFiles.isPresent()
         && !exportMedia.isPresent()
         && !exportMediaOverride.isPresent();

--- a/src/org/opendatakit/briefcase/export/ExportConfiguration.java
+++ b/src/org/opendatakit/briefcase/export/ExportConfiguration.java
@@ -277,6 +277,27 @@ public class ExportConfiguration {
     ).filter(Optional::isPresent).map(Optional::get).findFirst().orElse(false);
   }
 
+  /**
+   * Resolves if we need to export media files depending on the exportMedia and exportMediaOverride
+   * settings with the following algorithm:
+   * <ul>
+   * <li>if the exportMediaOverride Optional holds an {@link ExportMediaOverrideOption} value
+   * different than {@link ExportMediaOverrideOption#INHERIT}, then it returns its associated
+   * boolean value</li>
+   * <li>if the exportMedia Optional holds a Boolean value, then it returns it.</li>
+   * <li>otherwise, it returns false</li>
+   * </ul>
+   * See the tests on ExportConfigurationTests to see all the specific cases.
+   *
+   * @return false if the algorithm resolves that we don't need to export media files, true otherwise
+   */
+  public boolean resolveExportMedia() {
+    return Stream.of(
+        exportMediaOverride.filter(EXPORT_MEDIA_ALL_EXCEPT_INHERIT).flatMap(ExportMediaOverrideOption::asBoolean),
+        exportMedia
+    ).filter(Optional::isPresent).map(Optional::get).findFirst().orElse(true);
+  }
+
   private boolean isDateRangeValid() {
     return !startDate.isPresent() || !endDate.isPresent() || !startDate.get().isAfter(endDate.get());
   }

--- a/src/org/opendatakit/briefcase/export/ExportMediaOverrideOption.java
+++ b/src/org/opendatakit/briefcase/export/ExportMediaOverrideOption.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.opendatakit.briefcase.export;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public enum ExportMediaOverrideOption {
+  INHERIT("Use default", null), EXPORT_MEDIA("Export media", true), DONT_EXPORT_MEDIA("Do not export media", false);
+
+  private final String label;
+  private final Optional<Boolean> value;
+
+  ExportMediaOverrideOption(String label, Boolean value) {
+    this.label = label;
+    this.value = Optional.ofNullable(value);
+  }
+
+  public static ExportMediaOverrideOption from(String name) {
+    return Stream.of(values())
+        .filter(value -> value.name().equals(name))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("Unknown ExportMediaOverrideOption value " + name));
+  }
+
+  public static ExportMediaOverrideOption from(Optional<Boolean> maybeValue) {
+    return maybeValue.map(value -> value ? EXPORT_MEDIA : DONT_EXPORT_MEDIA).orElse(INHERIT);
+  }
+
+  public Optional<Boolean> asBoolean() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return label;
+  }
+}

--- a/src/org/opendatakit/briefcase/export/ExportMediaOverrideOption.java
+++ b/src/org/opendatakit/briefcase/export/ExportMediaOverrideOption.java
@@ -16,7 +16,6 @@
 package org.opendatakit.briefcase.export;
 
 import java.util.Optional;
-import java.util.stream.Stream;
 
 public enum ExportMediaOverrideOption {
   INHERIT("Use default", null), EXPORT_MEDIA("Export media", true), DONT_EXPORT_MEDIA("Do not export media", false);
@@ -27,17 +26,6 @@ public enum ExportMediaOverrideOption {
   ExportMediaOverrideOption(String label, Boolean value) {
     this.label = label;
     this.value = Optional.ofNullable(value);
-  }
-
-  public static ExportMediaOverrideOption from(String name) {
-    return Stream.of(values())
-        .filter(value -> value.name().equals(name))
-        .findFirst()
-        .orElseThrow(() -> new IllegalArgumentException("Unknown ExportMediaOverrideOption value " + name));
-  }
-
-  public static ExportMediaOverrideOption from(Optional<Boolean> maybeValue) {
-    return maybeValue.map(value -> value ? EXPORT_MEDIA : DONT_EXPORT_MEDIA).orElse(INHERIT);
   }
 
   public Optional<Boolean> asBoolean() {

--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -86,7 +86,8 @@ public class Export {
         Optional.empty(),
         Optional.empty(),
         Optional.of(overwriteFiles),
-        Optional.of(exportMedia)
+        Optional.of(exportMedia),
+        Optional.empty()
     );
     ExportToCsv.export(FormDefinition.from(formDefinition), configuration);
 

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanel.java
@@ -37,6 +37,7 @@ public class ConfigurationPanel {
     configuration.ifPullBeforeOverridePresent(form::setPullBeforeOverride);
     configuration.ifOverwriteExistingFilesPresent(form::setOverwriteExistingFiles);
     form.setExportMedia(configuration.getExportMedia().orElse(true));
+    configuration.ifExportMediaOverridePresent(form::setExportMediaOverride);
 
     form.onSelectExportDir(path -> {
       configuration.setExportDir(path);
@@ -68,6 +69,10 @@ public class ConfigurationPanel {
     });
     form.onChangeExportMedia(exportMedia ->  {
       configuration.setExportMedia(exportMedia);
+      triggerOnChange();
+    });
+    form.onChangeExportMediaOverride(exportMediaOverrideOption ->  {
+      configuration.setExportMediaOverride(exportMediaOverrideOption);
       triggerOnChange();
     });
   }

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.form
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.form
@@ -144,7 +144,7 @@
       </vspacer>
       <component id="443be" class="javax.swing.JLabel" binding="pullBeforeOverrideLabel">
         <constraints>
-          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties>

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.form
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.form
@@ -232,7 +232,7 @@
           <text value="Export media files"/>
         </properties>
       </component>
-      <component id="e1b24" class="javax.swing.JComboBox" binding="exportMediaOverrideField">
+      <component id="e1b24" class="javax.swing.JComboBox" binding="exportMediaOverrideField" custom-create="true">
         <constraints>
           <grid row="7" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.form
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.form
@@ -115,7 +115,7 @@
       </component>
       <component id="6925f" class="javax.swing.JTextPane" binding="pullBeforeHintPanel">
         <constraints>
-          <grid row="8" column="2" row-span="1" col-span="2" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+          <grid row="9" column="2" row-span="1" col-span="2" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="50"/>
           </grid>
           <gridbag weightx="0.0" weighty="0.0"/>
@@ -131,7 +131,7 @@
       </component>
       <component id="9a017" class="javax.swing.JComboBox" binding="pullBeforeOverrideField" custom-create="true">
         <constraints>
-          <grid row="7" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties/>
@@ -144,7 +144,7 @@
       </vspacer>
       <component id="443be" class="javax.swing.JLabel" binding="pullBeforeOverrideLabel">
         <constraints>
-          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties>
@@ -201,7 +201,7 @@
       </grid>
       <component id="bd9c9" class="javax.swing.JCheckBox" binding="overwriteFilesField">
         <constraints>
-          <grid row="10" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="11" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties>
@@ -210,7 +210,7 @@
       </component>
       <vspacer id="1c95d">
         <constraints>
-          <grid row="9" column="0" row-span="1" col-span="3" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="10" column="0" row-span="1" col-span="3" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
       </vspacer>
@@ -222,6 +222,22 @@
         <properties>
           <text value="Export media files"/>
         </properties>
+      </component>
+      <component id="4aac8" class="javax.swing.JLabel" binding="exportMediaOverrideLabel">
+        <constraints>
+          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+          <gridbag weightx="0.0" weighty="0.0"/>
+        </constraints>
+        <properties>
+          <text value="Export media files"/>
+        </properties>
+      </component>
+      <component id="e1b24" class="javax.swing.JComboBox" binding="exportMediaOverrideField">
+        <constraints>
+          <grid row="7" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+          <gridbag weightx="0.0" weighty="0.0"/>
+        </constraints>
+        <properties/>
       </component>
     </children>
   </grid>

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
@@ -76,6 +76,8 @@ public class ConfigurationPanelForm extends JComponent {
   JLabel pullBeforeOverrideLabel;
   private JCheckBox overwriteFilesField;
   private JCheckBox exportMediaField;
+  private JComboBox exportMediaOverrideField;
+  private JLabel exportMediaOverrideLabel;
   private final List<Consumer<Path>> onSelectExportDirCallbacks = new ArrayList<>();
   private final List<Consumer<Path>> onSelectPemFileCallbacks = new ArrayList<>();
   private final List<Consumer<LocalDate>> onSelectStartDateCallbacks = new ArrayList<>();
@@ -101,7 +103,7 @@ public class ConfigurationPanelForm extends JComponent {
     endDatePicker.getComponentDateTextField().setPreferredSize(exportDirField.getPreferredSize());
     endDatePicker.getComponentToggleCalendarButton().setPreferredSize(exportDirChooseButton.getPreferredSize());
     pullBeforeHintPanel.setBackground(new Color(255, 255, 255, 0));
-    mode.decorate(pullBeforeField, pullBeforeOverrideLabel, pullBeforeOverrideField, pullBeforeHintPanel, uiLocked);
+    mode.decorate(pullBeforeField, pullBeforeOverrideLabel, pullBeforeOverrideField, pullBeforeHintPanel, exportMediaField, exportMediaOverrideField, exportMediaOverrideLabel, uiLocked);
     GridBagLayout layout = (GridBagLayout) container.getLayout();
     GridBagConstraints constraints = layout.getConstraints(pullBeforeHintPanel);
     constraints.insets = new Insets(0, isMac() ? 6 : isWindows() ? 2 : 0, 0, 0);
@@ -259,7 +261,7 @@ public class ConfigurationPanelForm extends JComponent {
 
   void changeMode(boolean savePasswordsConsent) {
     mode.setSavePasswordsConsent(savePasswordsConsent);
-    mode.decorate(pullBeforeField, pullBeforeOverrideLabel, pullBeforeOverrideField, pullBeforeHintPanel, uiLocked);
+    mode.decorate(pullBeforeField, pullBeforeOverrideLabel, pullBeforeOverrideField, pullBeforeHintPanel, exportMediaField, exportMediaOverrideField, exportMediaOverrideLabel, uiLocked);
   }
 
   private void createUIComponents() {
@@ -440,13 +442,13 @@ public class ConfigurationPanelForm extends JComponent {
     pullBeforeHintPanel.setText("Some hint will be shown here");
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
-    gbc.gridy = 8;
+    gbc.gridy = 9;
     gbc.gridwidth = 2;
     gbc.fill = GridBagConstraints.BOTH;
     container.add(pullBeforeHintPanel, gbc);
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
-    gbc.gridy = 7;
+    gbc.gridy = 8;
     gbc.anchor = GridBagConstraints.WEST;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     container.add(pullBeforeOverrideField, gbc);
@@ -461,7 +463,7 @@ public class ConfigurationPanelForm extends JComponent {
     pullBeforeOverrideLabel.setText("Pull before export");
     gbc = new GridBagConstraints();
     gbc.gridx = 0;
-    gbc.gridy = 7;
+    gbc.gridy = 8;
     gbc.anchor = GridBagConstraints.WEST;
     container.add(pullBeforeOverrideLabel, gbc);
     exportDirButtons = new JPanel();
@@ -498,13 +500,13 @@ public class ConfigurationPanelForm extends JComponent {
     overwriteFilesField.setText("Overwrite existing files");
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
-    gbc.gridy = 10;
+    gbc.gridy = 11;
     gbc.anchor = GridBagConstraints.WEST;
     container.add(overwriteFilesField, gbc);
     final JPanel spacer6 = new JPanel();
     gbc = new GridBagConstraints();
     gbc.gridx = 0;
-    gbc.gridy = 9;
+    gbc.gridy = 10;
     gbc.gridwidth = 3;
     gbc.fill = GridBagConstraints.VERTICAL;
     container.add(spacer6, gbc);
@@ -515,6 +517,20 @@ public class ConfigurationPanelForm extends JComponent {
     gbc.gridy = 5;
     gbc.anchor = GridBagConstraints.WEST;
     container.add(exportMediaField, gbc);
+    exportMediaOverrideLabel = new JLabel();
+    exportMediaOverrideLabel.setText("Export media files");
+    gbc = new GridBagConstraints();
+    gbc.gridx = 0;
+    gbc.gridy = 7;
+    gbc.anchor = GridBagConstraints.EAST;
+    container.add(exportMediaOverrideLabel, gbc);
+    exportMediaOverrideField = new JComboBox();
+    gbc = new GridBagConstraints();
+    gbc.gridx = 2;
+    gbc.gridy = 7;
+    gbc.anchor = GridBagConstraints.WEST;
+    gbc.fill = GridBagConstraints.HORIZONTAL;
+    container.add(exportMediaOverrideField, gbc);
   }
 
   /**

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
@@ -86,6 +86,7 @@ public class ConfigurationPanelForm extends JComponent {
   private final List<Consumer<PullBeforeOverrideOption>> onChangePullBeforeOverrideCallbacks = new ArrayList<>();
   private final List<Consumer<Boolean>> onChangeOverwriteExistingFilesCallbacks = new ArrayList<>();
   private final List<Consumer<Boolean>> onChangeExportMediaCallbacks = new ArrayList<>();
+  private final List<Consumer<ExportMediaOverrideOption>> onChangeExportMediaOverrideCallbacks = new ArrayList<>();
   private final ConfigurationPanelMode mode;
   private boolean uiLocked = false;
 
@@ -136,6 +137,7 @@ public class ConfigurationPanelForm extends JComponent {
         triggerOverwriteExistingFiles();
     });
     exportMediaField.addActionListener(__ -> triggerChangeExportMedia());
+    exportMediaOverrideField.addActionListener(__ -> triggerChangeExportMediaOverride());
   }
 
   public static ConfigurationPanelForm overridePanel(boolean savePasswordsConsent, boolean hasTransferSettings) {
@@ -229,6 +231,10 @@ public class ConfigurationPanelForm extends JComponent {
     exportMediaField.setSelected(value);
   }
 
+  void setExportMediaOverride(ExportMediaOverrideOption value) {
+    exportMediaOverrideField.setSelectedItem(value);
+  }
+
   void onSelectExportDir(Consumer<Path> callback) {
     onSelectExportDirCallbacks.add(callback);
   }
@@ -259,6 +265,10 @@ public class ConfigurationPanelForm extends JComponent {
 
   void onChangeExportMedia(Consumer<Boolean> callback) {
     onChangeExportMediaCallbacks.add(callback);
+  }
+
+  void onChangeExportMediaOverride(Consumer<ExportMediaOverrideOption> callback) {
+    onChangeExportMediaOverrideCallbacks.add(callback);
   }
 
   void changeMode(boolean savePasswordsConsent) {
@@ -321,6 +331,10 @@ public class ConfigurationPanelForm extends JComponent {
 
   private void triggerChangeExportMedia() {
     onChangeExportMediaCallbacks.forEach(callback -> callback.accept(exportMediaField.isSelected()));
+  }
+
+  private void triggerChangeExportMediaOverride() {
+    onChangeExportMediaOverrideCallbacks.forEach(callback -> callback.accept((ExportMediaOverrideOption) exportMediaOverrideField.getSelectedItem()));
   }
 
   private boolean confirmOverwriteFiles() {

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
@@ -95,7 +95,7 @@ public class ConfigurationPanelForm extends JComponent {
     startDatePicker = createDatePicker();
     endDatePicker = createDatePicker();
     pullBeforeOverrideField = new JComboBox<>(PullBeforeOverrideOption.values());
-    pullBeforeOverrideField.setSelectedItem(INHERIT);
+    pullBeforeOverrideField.setSelectedItem(PullBeforeOverrideOption.INHERIT);
     exportMediaOverrideField = new JComboBox<>(ExportMediaOverrideOption.values());
     exportMediaOverrideField.setSelectedItem(ExportMediaOverrideOption.INHERIT);
     $$$setupUI$$$();
@@ -467,7 +467,7 @@ public class ConfigurationPanelForm extends JComponent {
     gbc = new GridBagConstraints();
     gbc.gridx = 0;
     gbc.gridy = 8;
-    gbc.anchor = GridBagConstraints.WEST;
+    gbc.anchor = GridBagConstraints.EAST;
     container.add(pullBeforeOverrideLabel, gbc);
     exportDirButtons = new JPanel();
     exportDirButtons.setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
@@ -19,7 +19,6 @@ import static javax.swing.JOptionPane.PLAIN_MESSAGE;
 import static javax.swing.JOptionPane.YES_NO_OPTION;
 import static javax.swing.JOptionPane.YES_OPTION;
 import static javax.swing.JOptionPane.showConfirmDialog;
-import static org.opendatakit.briefcase.export.PullBeforeOverrideOption.INHERIT;
 import static org.opendatakit.briefcase.ui.reused.FileChooser.directory;
 import static org.opendatakit.briefcase.ui.reused.FileChooser.file;
 import static org.opendatakit.briefcase.ui.reused.FileChooser.isUnderBriefcaseFolder;
@@ -76,9 +75,9 @@ public class ConfigurationPanelForm extends JComponent {
   JTextPane pullBeforeHintPanel;
   JLabel pullBeforeOverrideLabel;
   private JCheckBox overwriteFilesField;
-  private JCheckBox exportMediaField;
-  private JComboBox exportMediaOverrideField;
-  private JLabel exportMediaOverrideLabel;
+  JCheckBox exportMediaField;
+  JComboBox exportMediaOverrideField;
+  JLabel exportMediaOverrideLabel;
   private final List<Consumer<Path>> onSelectExportDirCallbacks = new ArrayList<>();
   private final List<Consumer<Path>> onSelectPemFileCallbacks = new ArrayList<>();
   private final List<Consumer<LocalDate>> onSelectStartDateCallbacks = new ArrayList<>();
@@ -106,7 +105,7 @@ public class ConfigurationPanelForm extends JComponent {
     endDatePicker.getComponentDateTextField().setPreferredSize(exportDirField.getPreferredSize());
     endDatePicker.getComponentToggleCalendarButton().setPreferredSize(exportDirChooseButton.getPreferredSize());
     pullBeforeHintPanel.setBackground(new Color(255, 255, 255, 0));
-    mode.decorate(pullBeforeField, pullBeforeOverrideLabel, pullBeforeOverrideField, pullBeforeHintPanel, exportMediaField, exportMediaOverrideField, exportMediaOverrideLabel, uiLocked);
+    mode.decorate(this, uiLocked);
     GridBagLayout layout = (GridBagLayout) container.getLayout();
     GridBagConstraints constraints = layout.getConstraints(pullBeforeHintPanel);
     constraints.insets = new Insets(0, isMac() ? 6 : isWindows() ? 2 : 0, 0, 0);
@@ -264,7 +263,7 @@ public class ConfigurationPanelForm extends JComponent {
 
   void changeMode(boolean savePasswordsConsent) {
     mode.setSavePasswordsConsent(savePasswordsConsent);
-    mode.decorate(pullBeforeField, pullBeforeOverrideLabel, pullBeforeOverrideField, pullBeforeHintPanel, exportMediaField, exportMediaOverrideField, exportMediaOverrideLabel, uiLocked);
+    mode.decorate(this, uiLocked);
   }
 
   private void createUIComponents() {

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
@@ -49,6 +49,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.JTextPane;
+import org.opendatakit.briefcase.export.ExportMediaOverrideOption;
 import org.opendatakit.briefcase.export.PullBeforeOverrideOption;
 import org.opendatakit.briefcase.ui.reused.FileChooser;
 import org.opendatakit.briefcase.util.StringUtils;
@@ -95,6 +96,8 @@ public class ConfigurationPanelForm extends JComponent {
     endDatePicker = createDatePicker();
     pullBeforeOverrideField = new JComboBox<>(PullBeforeOverrideOption.values());
     pullBeforeOverrideField.setSelectedItem(INHERIT);
+    exportMediaOverrideField = new JComboBox<>(ExportMediaOverrideOption.values());
+    exportMediaOverrideField.setSelectedItem(ExportMediaOverrideOption.INHERIT);
     $$$setupUI$$$();
     startDatePicker.getSettings().setGapBeforeButtonPixels(0);
     startDatePicker.getComponentDateTextField().setPreferredSize(exportDirField.getPreferredSize());
@@ -524,7 +527,6 @@ public class ConfigurationPanelForm extends JComponent {
     gbc.gridy = 7;
     gbc.anchor = GridBagConstraints.EAST;
     container.add(exportMediaOverrideLabel, gbc);
-    exportMediaOverrideField = new JComboBox();
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
     gbc.gridy = 7;

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelMode.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelMode.java
@@ -41,7 +41,7 @@ class ConfigurationPanelMode {
     return new ConfigurationPanelMode(false, savePasswordsConsent, hasTransferSettings);
   }
 
-  void decorate(JCheckBox pullBeforeField, JLabel pullBeforeOverrideLabel, JComboBox pullBeforeOverrideField, JTextPane textpanel, boolean uiLocked) {
+  void decorate(JCheckBox pullBeforeField, JLabel pullBeforeOverrideLabel, JComboBox pullBeforeOverrideField, JTextPane textpanel, JCheckBox exportMediaField, JComboBox exportMediaOverrideField, JLabel exportMediaOverrideLabel, boolean uiLocked) {
     pullBeforeField.setVisible(!isOverridePanel);
     pullBeforeField.setEnabled(!uiLocked && savePasswordsConsent && (!isOverridePanel || hasTransferSettings));
     pullBeforeOverrideLabel.setVisible(isOverridePanel);
@@ -54,7 +54,9 @@ class ConfigurationPanelMode {
         : REQUIRE_PULL_TEXT
         : REQUIRE_SAVE_PASSWORDS
     );
-
+    exportMediaField.setVisible(!isOverridePanel);
+    exportMediaOverrideField.setVisible(isOverridePanel);
+    exportMediaOverrideLabel.setVisible(isOverridePanel);
   }
 
   boolean isExportDirCleanable() {

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelMode.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelMode.java
@@ -15,11 +15,6 @@
  */
 package org.opendatakit.briefcase.ui.export.components;
 
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JTextPane;
-
 class ConfigurationPanelMode {
   static final String REQUIRE_PULL_TEXT = "Requires manually pulling from Aggregate once";
   static final String REQUIRE_SAVE_PASSWORDS = "Requires Remember passwords in Settings";
@@ -41,22 +36,22 @@ class ConfigurationPanelMode {
     return new ConfigurationPanelMode(false, savePasswordsConsent, hasTransferSettings);
   }
 
-  void decorate(JCheckBox pullBeforeField, JLabel pullBeforeOverrideLabel, JComboBox pullBeforeOverrideField, JTextPane pullBeforeHintPanel, JCheckBox exportMediaField, JComboBox exportMediaOverrideField, JLabel exportMediaOverrideLabel, boolean uiLocked) {
-    pullBeforeField.setVisible(!isOverridePanel);
-    pullBeforeField.setEnabled(!uiLocked && savePasswordsConsent && (!isOverridePanel || hasTransferSettings));
-    pullBeforeOverrideLabel.setVisible(isOverridePanel);
-    pullBeforeOverrideField.setVisible(isOverridePanel);
-    pullBeforeOverrideField.setEnabled(!uiLocked && savePasswordsConsent && hasTransferSettings);
-    pullBeforeHintPanel.setVisible(!savePasswordsConsent || !hasTransferSettings || !isOverridePanel);
-    pullBeforeHintPanel.setText(savePasswordsConsent
+  void decorate(ConfigurationPanelForm form, boolean uiLocked) {
+    form.pullBeforeField.setVisible(!isOverridePanel);
+    form.pullBeforeField.setEnabled(!uiLocked && savePasswordsConsent && (!isOverridePanel || hasTransferSettings));
+    form.pullBeforeOverrideLabel.setVisible(isOverridePanel);
+    form.pullBeforeOverrideField.setVisible(isOverridePanel);
+    form.pullBeforeOverrideField.setEnabled(!uiLocked && savePasswordsConsent && hasTransferSettings);
+    form.pullBeforeHintPanel.setVisible(!savePasswordsConsent || !hasTransferSettings || !isOverridePanel);
+    form.pullBeforeHintPanel.setText(savePasswordsConsent
         ? hasTransferSettings && isOverridePanel
         ? ""
         : REQUIRE_PULL_TEXT
         : REQUIRE_SAVE_PASSWORDS
     );
-    exportMediaField.setVisible(!isOverridePanel);
-    exportMediaOverrideField.setVisible(isOverridePanel);
-    exportMediaOverrideLabel.setVisible(isOverridePanel);
+    form.exportMediaField.setVisible(!isOverridePanel);
+    form.exportMediaOverrideField.setVisible(isOverridePanel);
+    form.exportMediaOverrideLabel.setVisible(isOverridePanel);
   }
 
   boolean isExportDirCleanable() {

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelMode.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelMode.java
@@ -41,14 +41,14 @@ class ConfigurationPanelMode {
     return new ConfigurationPanelMode(false, savePasswordsConsent, hasTransferSettings);
   }
 
-  void decorate(JCheckBox pullBeforeField, JLabel pullBeforeOverrideLabel, JComboBox pullBeforeOverrideField, JTextPane textpanel, JCheckBox exportMediaField, JComboBox exportMediaOverrideField, JLabel exportMediaOverrideLabel, boolean uiLocked) {
+  void decorate(JCheckBox pullBeforeField, JLabel pullBeforeOverrideLabel, JComboBox pullBeforeOverrideField, JTextPane pullBeforeHintPanel, JCheckBox exportMediaField, JComboBox exportMediaOverrideField, JLabel exportMediaOverrideLabel, boolean uiLocked) {
     pullBeforeField.setVisible(!isOverridePanel);
     pullBeforeField.setEnabled(!uiLocked && savePasswordsConsent && (!isOverridePanel || hasTransferSettings));
     pullBeforeOverrideLabel.setVisible(isOverridePanel);
     pullBeforeOverrideField.setVisible(isOverridePanel);
     pullBeforeOverrideField.setEnabled(!uiLocked && savePasswordsConsent && hasTransferSettings);
-    textpanel.setVisible(!savePasswordsConsent || !hasTransferSettings || !isOverridePanel);
-    textpanel.setText(savePasswordsConsent
+    pullBeforeHintPanel.setVisible(!savePasswordsConsent || !hasTransferSettings || !isOverridePanel);
+    pullBeforeHintPanel.setText(savePasswordsConsent
         ? hasTransferSettings && isOverridePanel
         ? ""
         : REQUIRE_PULL_TEXT

--- a/test/java/org/opendatakit/briefcase/export/ExportConfigurationTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportConfigurationTest.java
@@ -162,13 +162,15 @@ public class ExportConfigurationTest {
 
   @Test
   public void resolves_if_we_need_to_pull_depending_on_a_pair_or_fields() {
-    ExportConfiguration config = empty();
-    assertThat(config.setPullBefore(true).setPullBeforeOverride(INHERIT).resolvePullBefore(), is(true));
-    assertThat(config.setPullBefore(true).setPullBeforeOverride(PULL).resolvePullBefore(), is(true));
-    assertThat(config.setPullBefore(true).setPullBeforeOverride(DONT_PULL).resolvePullBefore(), is(false));
-    assertThat(config.setPullBefore(false).setPullBeforeOverride(INHERIT).resolvePullBefore(), is(false));
-    assertThat(config.setPullBefore(false).setPullBeforeOverride(PULL).resolvePullBefore(), is(true));
-    assertThat(config.setPullBefore(false).setPullBeforeOverride(DONT_PULL).resolvePullBefore(), is(false));
+    assertThat(empty().resolvePullBefore(), is(false));
+    assertThat(empty().setPullBefore(true).resolvePullBefore(), is(true));
+    assertThat(empty().setPullBefore(false).resolvePullBefore(), is(false));
+    assertThat(empty().setPullBefore(true).setPullBeforeOverride(PullBeforeOverrideOption.INHERIT).resolvePullBefore(), is(true));
+    assertThat(empty().setPullBefore(true).setPullBeforeOverride(PullBeforeOverrideOption.PULL).resolvePullBefore(), is(true));
+    assertThat(empty().setPullBefore(true).setPullBeforeOverride(PullBeforeOverrideOption.DONT_PULL).resolvePullBefore(), is(false));
+    assertThat(empty().setPullBefore(false).setPullBeforeOverride(PullBeforeOverrideOption.INHERIT).resolvePullBefore(), is(false));
+    assertThat(empty().setPullBefore(false).setPullBeforeOverride(PullBeforeOverrideOption.PULL).resolvePullBefore(), is(true));
+    assertThat(empty().setPullBefore(false).setPullBeforeOverride(PullBeforeOverrideOption.DONT_PULL).resolvePullBefore(), is(false));
   }
 
   @Test

--- a/test/java/org/opendatakit/briefcase/export/ExportConfigurationTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportConfigurationTest.java
@@ -172,6 +172,19 @@ public class ExportConfigurationTest {
   }
 
   @Test
+  public void resolves_if_we_need_to_export_media_files_depending_on_a_pair_or_fields() {
+    assertThat(empty().resolveExportMedia(), is(true));
+    assertThat(empty().setExportMedia(true).resolveExportMedia(), is(true));
+    assertThat(empty().setExportMedia(false).resolveExportMedia(), is(false));
+    assertThat(empty().setExportMedia(true).setExportMediaOverride(ExportMediaOverrideOption.INHERIT).resolveExportMedia(), is(true));
+    assertThat(empty().setExportMedia(true).setExportMediaOverride(ExportMediaOverrideOption.EXPORT_MEDIA).resolveExportMedia(), is(true));
+    assertThat(empty().setExportMedia(true).setExportMediaOverride(ExportMediaOverrideOption.DONT_EXPORT_MEDIA).resolveExportMedia(), is(false));
+    assertThat(empty().setExportMedia(false).setExportMediaOverride(ExportMediaOverrideOption.INHERIT).resolveExportMedia(), is(false));
+    assertThat(empty().setExportMedia(false).setExportMediaOverride(ExportMediaOverrideOption.EXPORT_MEDIA).resolveExportMedia(), is(true));
+    assertThat(empty().setExportMedia(false).setExportMediaOverride(ExportMediaOverrideOption.DONT_EXPORT_MEDIA).resolveExportMedia(), is(false));
+  }
+
+  @Test
   public void has_an_API_similar_to_Optional_for_some_of_its_members() {
     ExportConfiguration emptyConfig = empty();
     assertThat(emptyConfig.mapExportDir(Object::toString), OptionalMatchers.isEmpty());

--- a/test/java/org/opendatakit/briefcase/export/ExportToCsvScenario.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportToCsvScenario.java
@@ -140,7 +140,8 @@ class ExportToCsvScenario {
         Optional.of(false),
         Optional.empty(),
         Optional.of(overwrite),
-        Optional.of(exportMedia)
+        Optional.of(exportMedia),
+        Optional.empty()
     );
     ExportToCsv.export(formDef, configuration);
   }


### PR DESCRIPTION
Closes #580 

This PR changes the behavior of the custom conf dialogs. Now, the user can choose to inherit whichever setting for export media is set in the default configuration panel or override it to enable or disable it.

These changes imitate what we did to solve the same situation with the "pull before export" setting.

#### What has been done to verify that this works as intended?
- Wrote new tests for the resolution of effective export media conf param.
- Run cycles of setting some scenario, relaunching Briefcase and verifying that the scenario was correctly saved & restored:

  | Default | Custom | Resolved to |
  |---|---|---|
  |ON|INHERIT|ON|
  |ON|ON|ON|
  |ON|OFF|OFF|
  |OFF|INHERIT|OFF|
  |OFF|ON|ON|
  |OFF|OFF|OFF|

- Verified with the Birds form that media files where exported according to each scenario

#### Why is this the best possible solution? Were any other approaches considered?
This imitates previous solution to the same problem.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.