### PR TITLE
Add tests covering how values are encoded into CSV files

### DIFF
--- a/src/org/opendatakit/briefcase/export/CsvSubmissionMappers.java
+++ b/src/org/opendatakit/briefcase/export/CsvSubmissionMappers.java
@@ -131,7 +131,7 @@ final class CsvSubmissionMappers {
     return sb.toString().substring(1);
   }
 
-  private static String encode(String string, boolean allowNulls) {
+  static String encode(String string, boolean allowNulls) {
     if (string == null || string.isEmpty())
       return allowNulls ? "" : "\"\"";
     if (string.contains("\n") || string.contains("\"") || string.contains(","))
@@ -143,16 +143,17 @@ final class CsvSubmissionMappers {
     return getDateTimeInstance().format(new Date(offsetDateTime.toInstant().toEpochMilli()));
   }
 
-  private static String encodeMainValue(Model field, Pair<String, String> value) {
+  static String encodeMainValue(Model field, Pair<String, String> value) {
     return encode(
         value.getRight(),
         EMPTY_COL_WHEN_NULL_DATATYPES.contains(field.getDataType()) || value.getLeft().startsWith("meta")
     );
   }
 
-  private static String encodeRepeatValue(Pair<String, String> pair) {
+  static String encodeRepeatValue(Pair<String, String> pair) {
     return encode(
         pair.getRight(),
+        // It would be really surprising to have meta fields in a repeat. This is the original implementation, though.
         pair.getLeft().startsWith("meta") || pair.getLeft().startsWith("SET-OF")
     );
   }

--- a/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
@@ -72,17 +72,17 @@ public class CsvFieldMappersTest {
   }
 
   @Test
-  public void date_value() {
+  public void text_value() {
     scenario = nonGroup(DataType.TEXT);
 
-    List<Pair<String, String>> output = scenario.mapSimpleValue("some text");
+    List<Pair<String, String>> output = scenario.mapSimpleValue("some, text");
 
     assertThat(output, hasSize(1));
-    assertThat(output.get(0).getRight(), is("some text"));
+    assertThat(output.get(0).getRight(), is("some, text"));
   }
 
   @Test
-  public void text_value() {
+  public void date_value() {
     scenario = nonGroup(DataType.DATE);
 
     List<Pair<String, String>> output = scenario.mapSimpleValue("2018-01-01");
@@ -287,6 +287,11 @@ public class CsvFieldMappersTest {
     }
 
     static Scenario nonGroup(DataType dataType) {
+      Model fieldModel = createField(dataType);
+      return new Scenario("instance_" + instanceIdSeq++, "data", "field", fieldModel);
+    }
+
+    static Model createField(DataType dataType) {
       TreeElement fieldTreeElement = new TreeElement("field", DEFAULT_MULTIPLICITY);
       fieldTreeElement.setDataType(dataType.value);
 
@@ -302,7 +307,7 @@ public class CsvFieldMappersTest {
       instanceTreeElement.setParent(rootTreeElement);
       fieldTreeElement.setParent(instanceTreeElement);
 
-      return new Scenario("instance_" + instanceIdSeq++, "data", "field", new Model(fieldTreeElement));
+      return new Model(fieldTreeElement);
     }
 
     private static Scenario group(String instanceId, DataType dataType, int fieldCount, boolean repeatable) {

--- a/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersEncodeMainValueTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersEncodeMainValueTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.export;
+
+import static org.junit.Assert.assertThat;
+import static org.opendatakit.briefcase.export.CsvFieldMappersTest.Scenario.createField;
+import static org.opendatakit.briefcase.export.CsvSubmissionMappers.encodeMainValue;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.hamcrest.Matchers;
+import org.javarosa.core.model.DataType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.opendatakit.briefcase.reused.Pair;
+
+@RunWith(value = Parameterized.class)
+public class CsvSubmissionMappersEncodeMainValueTest {
+  private static final String ESCAPED_EMPTY_STRING_VALUE = "\"\"";
+  private static final String EMPTY_STRING_VALUE = "";
+  @Parameterized.Parameter(value = 0)
+  public String testCase;
+
+  @Parameterized.Parameter(value = 1)
+  public Model field;
+
+  @Parameterized.Parameter(value = 2)
+  public String expectedOutput;
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> data() {
+    // For some reason, empty values are managed differently depending on their related data types
+    // This is inconsistent across main or repeat rows, meta fields and missing values, as discussed
+    // in https://github.com/opendatakit/briefcase/blob/master/docs/export-format.md#empty-value-codification
+    return Arrays.asList(new Object[][]{
+        {"GEOPOINT allows empty cols", createField(DataType.GEOPOINT), EMPTY_STRING_VALUE},
+        {"DATE allows empty cols", createField(DataType.DATE), EMPTY_STRING_VALUE},
+        {"TIME allows empty cols", createField(DataType.TIME), EMPTY_STRING_VALUE},
+        {"DATE_TIME allows empty cols", createField(DataType.DATE_TIME), EMPTY_STRING_VALUE},
+        {"UNSUPPORTED encodes an empty string", createField(DataType.UNSUPPORTED), ESCAPED_EMPTY_STRING_VALUE},
+        {"NULL encodes an empty string", createField(DataType.NULL), ESCAPED_EMPTY_STRING_VALUE},
+        {"TEXT encodes an empty string", createField(DataType.TEXT), ESCAPED_EMPTY_STRING_VALUE},
+        {"INTEGER encodes an empty string", createField(DataType.INTEGER), ESCAPED_EMPTY_STRING_VALUE},
+        {"DECIMAL encodes an empty string", createField(DataType.DECIMAL), ESCAPED_EMPTY_STRING_VALUE},
+        {"CHOICE encodes an empty string", createField(DataType.CHOICE), ESCAPED_EMPTY_STRING_VALUE},
+        {"CHOICE_LIST encodes an empty string", createField(DataType.CHOICE_LIST), ESCAPED_EMPTY_STRING_VALUE},
+        {"BOOLEAN encodes an empty string", createField(DataType.BOOLEAN), ESCAPED_EMPTY_STRING_VALUE},
+        {"BARCODE encodes an empty string", createField(DataType.BARCODE), ESCAPED_EMPTY_STRING_VALUE},
+        {"BINARY encodes an empty string", createField(DataType.BINARY), ESCAPED_EMPTY_STRING_VALUE},
+        {"LONG encodes an empty string", createField(DataType.LONG), ESCAPED_EMPTY_STRING_VALUE},
+        {"GEOSHAPE encodes an empty string", createField(DataType.GEOSHAPE), ESCAPED_EMPTY_STRING_VALUE},
+        {"GEOTRACE encodes an empty string", createField(DataType.GEOTRACE), ESCAPED_EMPTY_STRING_VALUE},
+    });
+  }
+
+  @Test
+  public void fields() {
+    assertThat(encodeMainValue(field, Pair.of("some-field", "")), Matchers.is(expectedOutput));
+  }
+}

--- a/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersEncodeTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersEncodeTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.export;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(value = Parameterized.class)
+public class CsvSubmissionMappersEncodeTest {
+
+  @Parameterized.Parameter(value = 0)
+  public String testCase;
+
+  @Parameterized.Parameter(value = 1)
+  public boolean allowNulls;
+
+  @Parameterized.Parameter(value = 2)
+  public String input;
+
+  @Parameterized.Parameter(value = 3)
+  public String expectedOutput;
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+        {"empty, no nulls allowed", false, "", "\"\""},
+        {"empty, nulls allowed", true, "", ""},
+        {"normal", false, "one two three", "one two three"},
+        {"text with commas", true, "one, two, three", "\"one, two, three\""},
+        {"text with double quotes", true, "one \"two\" three", "\"one \"\"two\"\" three\""},
+        {"text with new line chars", true, "one\ntwo\nthree", "\"one\ntwo\nthree\""},
+    });
+  }
+
+  @Test
+  public void encode() {
+    assertThat(CsvSubmissionMappers.encode(input, allowNulls), is(expectedOutput));
+  }
+}

--- a/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersEncodeValueTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersEncodeValueTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.export;
+
+import static org.junit.Assert.assertThat;
+import static org.opendatakit.briefcase.export.CsvFieldMappersTest.Scenario.createField;
+import static org.opendatakit.briefcase.export.CsvSubmissionMappers.encodeMainValue;
+import static org.opendatakit.briefcase.export.CsvSubmissionMappers.encodeRepeatValue;
+
+import org.hamcrest.Matchers;
+import org.javarosa.core.model.DataType;
+import org.junit.Test;
+import org.opendatakit.briefcase.reused.Pair;
+
+/**
+ * This test class complements {@link CsvSubmissionMappersEncodeMainValueTest}
+ */
+public class CsvSubmissionMappersEncodeValueTest {
+
+  @Test
+  public void meta_fields_in_main_rows_allow_empty_cols() {
+    // Text fields would normally avoid an empty column by encoding an empty string
+    assertThat(encodeMainValue(createField(DataType.TEXT), Pair.of("meta-some-field", "")), Matchers.is(""));
+  }
+
+  @Test
+  public void meta_fields_in_repeat_rows_allow_empty_cols() {
+    assertThat(encodeRepeatValue(Pair.of("meta-some-field", "")), Matchers.is(""));
+  }
+
+  @Test
+  public void set_of_fields_in_repeat_rows_allow_empty_cols() {
+    assertThat(encodeRepeatValue(Pair.of("SET-OF", "")), Matchers.is(""));
+  }
+
+  @Test
+  public void otherwise_repeat_rows_avoid_empty_cols() {
+    assertThat(encodeRepeatValue(Pair.of("some-field", "")), Matchers.is("\"\""));
+  }
+}


### PR DESCRIPTION
With special focus on encoding of empty values depending on data type, field name and location (main or repeat row)

This PR is the result of some verifications done while studying [this forum post](https://forum.opendatakit.org/t/change-delimiter-used-when-exporting-into-xml/14189/2)

#### What has been done to verify that this works as intended?
Run automated tests

#### Why is this the best possible solution? Were any other approaches considered?
N/A

#### Are there any risks to merging this code? If so, what are they?
No. It's just some new tests

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.