### PR TITLE
Force utf8 encoding

### DIFF
--- a/src/org/opendatakit/briefcase/reused/RemoteServer.java
+++ b/src/org/opendatakit/briefcase/reused/RemoteServer.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.briefcase.reused;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.javarosa.xform.parse.XFormParser.getXMLText;
@@ -166,7 +167,7 @@ public class RemoteServer {
         .orElseThrow(BriefcaseException::new);
 
     Path tmpFile = UncheckedFiles.createTempFile("briefcase_", "_form_definition");
-    UncheckedFiles.write(tmpFile, blankForm.getBytes());
+    UncheckedFiles.write(tmpFile, blankForm);
     return tmpFile;
   }
 
@@ -209,7 +210,7 @@ public class RemoteServer {
   }
 
   private static Document parse(String content) {
-    try (InputStream is = new ByteArrayInputStream(content.getBytes());
+    try (InputStream is = new ByteArrayInputStream(content.getBytes(UTF_8));
          InputStreamReader isr = new InputStreamReader(is)) {
       Document doc = new Document();
       KXmlParser parser = new KXmlParser();

--- a/src/org/opendatakit/briefcase/reused/RemoteServer.java
+++ b/src/org/opendatakit/briefcase/reused/RemoteServer.java
@@ -211,7 +211,7 @@ public class RemoteServer {
 
   private static Document parse(String content) {
     try (InputStream is = new ByteArrayInputStream(content.getBytes(UTF_8));
-         InputStreamReader isr = new InputStreamReader(is)) {
+         InputStreamReader isr = new InputStreamReader(is, "UTF-8")) {
       Document doc = new Document();
       KXmlParser parser = new KXmlParser();
       parser.setInput(isr);

--- a/src/org/opendatakit/briefcase/reused/UncheckedFiles.java
+++ b/src/org/opendatakit/briefcase/reused/UncheckedFiles.java
@@ -16,6 +16,8 @@
 
 package org.opendatakit.briefcase.reused;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -67,15 +69,15 @@ public class UncheckedFiles {
 
   public static Path write(Path path, Stream<String> lines, OpenOption... options) {
     try {
-      return Files.write(path, (Iterable<String>) lines::iterator, options);
+      return Files.write(path, (Iterable<String>) lines::iterator, UTF_8, options);
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
   }
 
-  public static Path write(Path path, byte[] bytes, OpenOption... options) {
+  public static Path write(Path path, String contents, OpenOption... options) {
     try {
-      return Files.write(path, bytes, options);
+      return Files.write(path, contents.getBytes(UTF_8), options);
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
@@ -322,6 +324,6 @@ public class UncheckedFiles {
   public static void createBriefcaseDir(Path briefcaseDir) {
     createDirectories(briefcaseDir);
     createDirectories(briefcaseDir.resolve("forms"));
-    write(briefcaseDir.resolve("readme.txt"), README_CONTENTS.getBytes());
+    write(briefcaseDir.resolve("readme.txt"), README_CONTENTS);
   }
 }

--- a/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
@@ -30,7 +30,6 @@ import static org.opendatakit.briefcase.export.CsvFieldMappersTest.Scenario.repe
 import static org.opendatakit.briefcase.matchers.PathMatchers.exists;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.createTempDirectory;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.list;
-import static org.opendatakit.briefcase.reused.UncheckedFiles.write;
 
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -140,7 +139,7 @@ public class CsvFieldMappersTest {
   @Test
   public void binary_value_given_user_does_not_want_to_export_media_files() {
     scenario = nonGroup(DataType.BINARY);
-    write(scenario.getWorkDir().resolve("some_file.bin"), UUID.randomUUID().toString().getBytes());
+    UncheckedFiles.write(scenario.getWorkDir().resolve("some_file.bin"), UUID.randomUUID().toString());
 
     List<Pair<String, String>> outputWithoutMedia = scenario.mapSimpleValue("some_file.bin", false);
 
@@ -152,7 +151,7 @@ public class CsvFieldMappersTest {
   @Test
   public void binary_value_given_user_wants_to_export_media_files() {
     scenario = nonGroup(DataType.BINARY);
-    write(scenario.getWorkDir().resolve("some_file.bin"), UUID.randomUUID().toString().getBytes());
+    UncheckedFiles.write(scenario.getWorkDir().resolve("some_file.bin"), UUID.randomUUID().toString());
 
     List<Pair<String, String>> outputWithMedia = scenario.mapSimpleValue("some_file.bin", true);
 
@@ -177,7 +176,7 @@ public class CsvFieldMappersTest {
   @Test
   public void binary_value_given_output_file_does_not_exist() {
     scenario = nonGroup(DataType.BINARY);
-    write(scenario.getWorkDir().resolve("some_file.bin"), UUID.randomUUID().toString().getBytes());
+    UncheckedFiles.write(scenario.getWorkDir().resolve("some_file.bin"), UUID.randomUUID().toString());
 
     List<Pair<String, String>> outputWithMedia = scenario.mapSimpleValue("some_file.bin", true);
 
@@ -196,8 +195,8 @@ public class CsvFieldMappersTest {
   public void binary_value_given_exact_same_output_file_exist() {
     scenario = nonGroup(DataType.BINARY);
     String fileContents = UUID.randomUUID().toString();
-    write(scenario.getWorkDir().resolve("some_file.bin"), fileContents.getBytes());
-    write(scenario.getOutputMediaDir().resolve("some_file.bin"), fileContents.getBytes());
+    UncheckedFiles.write(scenario.getWorkDir().resolve("some_file.bin"), fileContents);
+    UncheckedFiles.write(scenario.getOutputMediaDir().resolve("some_file.bin"), fileContents);
 
     List<Pair<String, String>> outputWithMedia = scenario.mapSimpleValue("some_file.bin", true);
 
@@ -215,8 +214,8 @@ public class CsvFieldMappersTest {
   @Test
   public void binary_value_given_different_output_file_exist() {
     scenario = nonGroup(DataType.BINARY);
-    write(scenario.getWorkDir().resolve("some_file.bin"), UUID.randomUUID().toString().getBytes());
-    write(scenario.getOutputMediaDir().resolve("some_file.bin"), UUID.randomUUID().toString().getBytes());
+    UncheckedFiles.write(scenario.getWorkDir().resolve("some_file.bin"), UUID.randomUUID().toString());
+    UncheckedFiles.write(scenario.getOutputMediaDir().resolve("some_file.bin"), UUID.randomUUID().toString());
 
     List<Pair<String, String>> outputWithMedia = scenario.mapSimpleValue("some_file.bin", true);
 
@@ -233,9 +232,9 @@ public class CsvFieldMappersTest {
   @Test
   public void binary_value_given_different_output_files_exist() {
     scenario = nonGroup(DataType.BINARY);
-    write(scenario.getWorkDir().resolve("some_file.bin"), UUID.randomUUID().toString().getBytes());
-    write(scenario.getOutputMediaDir().resolve("some_file.bin"), UUID.randomUUID().toString().getBytes());
-    write(scenario.getOutputMediaDir().resolve("some_file-2.bin"), UUID.randomUUID().toString().getBytes());
+    UncheckedFiles.write(scenario.getWorkDir().resolve("some_file.bin"), UUID.randomUUID().toString());
+    UncheckedFiles.write(scenario.getOutputMediaDir().resolve("some_file.bin"), UUID.randomUUID().toString());
+    UncheckedFiles.write(scenario.getOutputMediaDir().resolve("some_file-2.bin"), UUID.randomUUID().toString());
 
     List<Pair<String, String>> outputWithMedia = scenario.mapSimpleValue("some_file.bin", true);
 

--- a/test/java/org/opendatakit/briefcase/export/ExportToCsvScenario.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportToCsvScenario.java
@@ -29,7 +29,6 @@ import static org.opendatakit.briefcase.reused.UncheckedFiles.readAllBytes;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.readFirstLine;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.toURI;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.walk;
-import static org.opendatakit.briefcase.reused.UncheckedFiles.write;
 import static org.opendatakit.briefcase.util.StringUtils.stripIllegalChars;
 
 import java.nio.file.Files;
@@ -193,14 +192,14 @@ class ExportToCsvScenario {
     Path instanceDir = formDir.resolve("instances").resolve(instanceId);
     createDirectories(instanceDir);
     Path instanceFile = instanceDir.resolve("submission.xml");
-    write(instanceFile, instanceContent.getBytes());
+    UncheckedFiles.write(instanceFile, instanceContent);
   }
 
   void createOutputFile(String dir, String file) {
     createDirectories(outputDir.resolve("old").resolve(dir));
-    write(outputDir.resolve("old").resolve(dir).resolve(file), "Some content".getBytes());
+    UncheckedFiles.write(outputDir.resolve("old").resolve(dir).resolve(file), "Some content");
     createDirectories(outputDir.resolve("new").resolve(dir));
-    write(outputDir.resolve("new").resolve(dir).resolve(file), "Some content".getBytes());
+    UncheckedFiles.write(outputDir.resolve("new").resolve(dir).resolve(file), "Some content");
   }
 
   void assertNoOutputMediaDir() {


### PR DESCRIPTION
Closes #593 

This PR explicitly uses UTF-8 for all NIO2 file writing operations and some `InputStreamReader` that was using the default charset.

This reportedly solves a [forum user's issues](https://forum.opendatakit.org/t/csv-file-lao-characters-not-showing-after-export-from-odk-briefcase/14075/17) with Lao characters being incorrectly encoded while exporting forms in Briefcase.

#### What has been done to verify that this works as intended?
Run the automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
This changes code that depended on the JDK's default charsets while writing to files with an explicit use of UTF-8 in write operations, which will have a consistent behavior across different platforms and environments.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.