### PR TITLE
Modified Export overwriting files confirmation message. Fix #586

### DIFF
--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
@@ -316,7 +316,7 @@ public class ConfigurationPanelForm extends JComponent {
   }
 
   private boolean confirmOverwriteFiles() {
-    if (showConfirmDialog(this, "Overwrite existing files?", "", YES_NO_OPTION, PLAIN_MESSAGE) == YES_OPTION)
+    if (showConfirmDialog(this, "The default behavior is to append to existing files. Are you sure you want to overwrite existing files?", "", YES_NO_OPTION, PLAIN_MESSAGE) == YES_OPTION)
       return true;
     overwriteFilesField.setSelected(false);
     return false;


### PR DESCRIPTION
Closes #586 

#### What has been done to verify that this works as intended?
I have checked the confirmation message on Export tab. Once the user clicks on Overwrite Existing FIles checkbox, the confirmation message is displayed as follows:

![screenshot_20180727_151639](https://user-images.githubusercontent.com/5601566/43344573-3e481abc-91b8-11e8-8092-9cf6d5678b5d.png)

#### Why is this the best possible solution? Were any other approaches considered?
It is a simple change of confirmation message.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.