### PR TITLE
Issue 594 Explore, document and add test cases of decimal numbers in the export output

### DIFF
--- a/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
@@ -82,6 +82,29 @@ public class CsvFieldMappersTest {
   }
 
   @Test
+  public void decimal_value() {
+    scenario = nonGroup(DataType.DECIMAL);
+
+    List<Pair<String, String>> output = scenario.mapSimpleValue("1.234");
+
+    assertThat(output, hasSize(1));
+    assertThat(output.get(0).getRight(), is("1.234"));
+  }
+
+  @Test
+  public void decimal_value_locale_ES() {
+    // es_ES locale formats decimal numbers using a comma as the decimal separator
+    // This would break the CSV file's structure
+    Locale.setDefault(Locale.forLanguageTag("es_ES"));
+    scenario = nonGroup(DataType.DECIMAL);
+
+    List<Pair<String, String>> output = scenario.mapSimpleValue("1.234");
+
+    assertThat(output, hasSize(1));
+    assertThat(output.get(0).getRight(), is("1.234"));
+  }
+
+  @Test
   public void date_value() {
     scenario = nonGroup(DataType.DATE);
 


### PR DESCRIPTION
Closes #594

This PR adds test cases for the decimal number field mapper
- It includes a case that uses a locale that would encode decimals using a comma for the decimals separator

Some insights after exploring the code for decimal number encoding issues:
- Fields with `DataType.DECIMAL` don't have a specific `CsvFieldMapper` instance, which means that whatever value comes in the XML submission, it comes out untouched
- The `CsvSubmissionMapper` takes care about escaping values before writing them to the CSV file. If the output of a `CsvFieldMapper` includes a comma, a `CsvSubmissionMapper` will wrap it with double quotes, making it safe.
	- There are tests for this.

All looks like we're safe at the moment. The new test cases aren't even strictly necessary, but they will prevent regression should we change the `CsvFieldMapper` mechanics.

#### What has been done to verify that this works as intended?
Run the automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
This is the least amount of tests that I could come up with to cover this issue.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.