### PR TITLE
Make the test less brittle by narrowing the assertion

### DIFF
--- a/test/java/org/opendatakit/briefcase/reused/http/CommonsHttpTest.java
+++ b/test/java/org/opendatakit/briefcase/reused/http/CommonsHttpTest.java
@@ -32,7 +32,7 @@ public class CommonsHttpTest {
   public void can_execute_a_GET_request() throws MalformedURLException {
     Http http = new CommonsHttp();
     Response<String> output = http.execute(Request.get(new URL("https://docs.opendatakit.org/")));
-    assertThat(output.orElseThrow(BriefcaseException::new), containsString("Welcome to Open Data Kit"));
+    assertThat(output.orElseThrow(BriefcaseException::new), containsString("Open Data Kit"));
   }
 
   @Test


### PR DESCRIPTION
This PR fixes a test of the real http adapter. We used to get the main ODK docs page and assert that the text "Welcome to Open Data Kit", but they just changed that :P

Now we narrow the expected text to just "Open Data Kit".

#### What has been done to verify that this works as intended?
Run the automated test

#### Why is this the best possible solution? Were any other approaches considered?
We could spin a lightweight http server from the test to ensure this problem never happens again, but that's too complex right, although we could eventually consider doing it.

#### Are there any risks to merging this code? If so, what are they?
Nope. It's just a fix on an assertion of a test to avoid false negatives.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope