### PR TITLE
Fix default value of the overwrite files param of the export conf

### DIFF
--- a/src/org/opendatakit/briefcase/export/ExportConfiguration.java
+++ b/src/org/opendatakit/briefcase/export/ExportConfiguration.java
@@ -255,7 +255,7 @@ public class ExportConfiguration {
    * @return false if the algorithm resolves that we don't need to overwrite files, true otherwise
    */
   boolean resolveOverwriteExistingFiles() {
-    return overwriteFiles.resolve(true);
+    return overwriteFiles.resolve(false);
   }
 
   private boolean isDateRangeValid() {


### PR DESCRIPTION
This PR fixes a regression introduced by #604, where the overwrite files export conf param would be true instead of false by default.

#### What has been done to verify that this works as intended?
Manually tested from a clean storage dir, clean prefs scenario:
- Pull a form with submissions
- Export it twice setting only the output dir
- Check that the output CSV file contains dupe lines
- Toggle the overwrite files conf param
- Export it twice
- Check that the output CSV file has no dupe lines

#### Why is this the best possible solution? Were any other approaches considered?
This is a narrow fix for a regression introduced in a previous PR

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.