### PR TITLE
Issue 608 Overwrite dialog displays behind Default export Conf instead of in front of on MacOS

### DIFF
--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
@@ -43,6 +43,7 @@ import java.util.function.Consumer;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
+import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
@@ -339,7 +340,9 @@ public class ConfigurationPanelForm extends JComponent {
   }
 
   private boolean confirmOverwriteFiles() {
-    if (showConfirmDialog(this, "The default behavior is to append to existing files. Are you sure you want to overwrite existing files?", "", YES_NO_OPTION, PLAIN_MESSAGE) == YES_OPTION)
+    JDialog dialog = new JDialog();
+    dialog.setAlwaysOnTop(true);
+    if (showConfirmDialog(dialog, "The default behavior is to append to existing files. Are you sure you want to overwrite existing files?", "", YES_NO_OPTION, PLAIN_MESSAGE) == YES_OPTION)
       return true;
     overwriteFilesField.setSelected(false);
     return false;


### PR DESCRIPTION
Closes #608 

This PR forces the overwrite confirmation dialog to appear using a dialog configured to be always on top as its parent component. This ensures that it stays on top of any other dialogs, even in a Mac computer.

#### What has been done to verify that this works as intended?
- Run in Linux and verified that it still works OK
- Run in Mac and verified that now it shows correctly on top

#### Why is this the best possible solution? Were any other approaches considered?
Although hacking Swing UI components is always a gamble, this change seems reasonably simple and safe.

#### Are there any risks to merging this code? If so, what are they?
None.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.