### PR TITLE
Issue 611 export save failed submissions

### DIFF
--- a/src/org/opendatakit/briefcase/export/ExportConfiguration.java
+++ b/src/org/opendatakit/briefcase/export/ExportConfiguration.java
@@ -452,4 +452,8 @@ public class ExportConfiguration {
   public Optional<String> getExportFileName() {
     return exportFileName;
   }
+
+  public Path getErrorsDir(String formName) {
+    return exportDir.map(dir -> dir.resolve(formName + " - errors")).orElseThrow(BriefcaseException::new);
+  }
 }

--- a/src/org/opendatakit/briefcase/export/ExportToCsv.java
+++ b/src/org/opendatakit/briefcase/export/ExportToCsv.java
@@ -82,7 +82,7 @@ public class ExportToCsv {
     // Generate csv lines grouped by the fqdn of the model they belong to
     Map<String, CsvLines> csvLinesPerModel = submissionFiles.parallelStream()
         // Parse the submission and leave only those OK to be exported
-        .map(path -> parseSubmission(path, formDef.isFileEncryptedForm(), configuration.getPrivateKey(), errorsDir, errorSeq))
+        .map(path -> parseSubmission(path, formDef.isFileEncryptedForm(), configuration.getPrivateKey(), errorsDir, errorSeq, p -> {}))
         .filter(Optional::isPresent)
         .map(Optional::get)
         // Track the submission

--- a/src/org/opendatakit/briefcase/export/ExportToCsv.java
+++ b/src/org/opendatakit/briefcase/export/ExportToCsv.java
@@ -73,10 +73,16 @@ public class ExportToCsv {
 
     csvs.forEach(Csv::prepareOutputFiles);
 
+    // Reset errors management for this export attemp
+    Path errorsDir = configuration.getErrorsDir(formDef.getFormName());
+    AtomicInteger errorSeq = new AtomicInteger(1);
+    if (exists(errorsDir))
+      deleteRecursive(errorsDir);
+
     // Generate csv lines grouped by the fqdn of the model they belong to
     Map<String, CsvLines> csvLinesPerModel = submissionFiles.parallelStream()
         // Parse the submission and leave only those OK to be exported
-        .map(path -> parseSubmission(path, formDef.isFileEncryptedForm(), configuration.getPrivateKey(), configuration.getErrorsDir(formDef.getFormName()), new AtomicInteger(1)))
+        .map(path -> parseSubmission(path, formDef.isFileEncryptedForm(), configuration.getPrivateKey(), errorsDir, errorSeq))
         .filter(Optional::isPresent)
         .map(Optional::get)
         // Track the submission

--- a/src/org/opendatakit/briefcase/export/ExportToCsv.java
+++ b/src/org/opendatakit/briefcase/export/ExportToCsv.java
@@ -24,8 +24,10 @@ import static org.opendatakit.briefcase.export.ExportOutcome.ALL_SKIPPED;
 import static org.opendatakit.briefcase.export.ExportOutcome.SOME_SKIPPED;
 import static org.opendatakit.briefcase.export.SubmissionParser.getListOfSubmissionFiles;
 import static org.opendatakit.briefcase.export.SubmissionParser.parseSubmission;
-import static org.opendatakit.briefcase.reused.UncheckedFiles.*;
+import static org.opendatakit.briefcase.reused.UncheckedFiles.copy;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.createDirectories;
+import static org.opendatakit.briefcase.reused.UncheckedFiles.deleteRecursive;
+import static org.opendatakit.briefcase.reused.UncheckedFiles.exists;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -82,7 +84,7 @@ public class ExportToCsv {
     // Generate csv lines grouped by the fqdn of the model they belong to
     Map<String, CsvLines> csvLinesPerModel = submissionFiles.parallelStream()
         // Parse the submission and leave only those OK to be exported
-        .map(path -> parseSubmission(path, formDef.isFileEncryptedForm(), configuration.getPrivateKey(), errorsDir, errorSeq, p -> {
+        .map(path -> parseSubmission(path, formDef.isFileEncryptedForm(), configuration.getPrivateKey(), p -> {
           if (!exists(errorsDir))
             createDirectories(errorsDir);
           copy(p, errorsDir.resolve("failed_submission_" + errorSeq.getAndIncrement() + ".xml"));

--- a/src/org/opendatakit/briefcase/export/ExportToCsv.java
+++ b/src/org/opendatakit/briefcase/export/ExportToCsv.java
@@ -74,7 +74,7 @@ public class ExportToCsv {
     // Generate csv lines grouped by the fqdn of the model they belong to
     Map<String, CsvLines> csvLinesPerModel = submissionFiles.parallelStream()
         // Parse the submission and leave only those OK to be exported
-        .map(path -> parseSubmission(path, formDef.isFileEncryptedForm(), configuration.getPrivateKey()))
+        .map(path -> parseSubmission(path, formDef.isFileEncryptedForm(), configuration.getPrivateKey(), configuration.getErrorsDir(formDef.getFormName())))
         .filter(Optional::isPresent)
         .map(Optional::get)
         // Track the submission

--- a/src/org/opendatakit/briefcase/export/ExportToCsv.java
+++ b/src/org/opendatakit/briefcase/export/ExportToCsv.java
@@ -82,7 +82,12 @@ public class ExportToCsv {
     // Generate csv lines grouped by the fqdn of the model they belong to
     Map<String, CsvLines> csvLinesPerModel = submissionFiles.parallelStream()
         // Parse the submission and leave only those OK to be exported
-        .map(path -> parseSubmission(path, formDef.isFileEncryptedForm(), configuration.getPrivateKey(), errorsDir, errorSeq, p -> {}))
+        .map(path -> parseSubmission(path, formDef.isFileEncryptedForm(), configuration.getPrivateKey(), errorsDir, errorSeq, p -> {
+          if (!exists(errorsDir))
+            createDirectories(errorsDir);
+          copy(p, errorsDir.resolve("failed_submission_" + errorSeq.getAndIncrement() + ".xml"));
+          log.info("Failed submission XML file moved to the output errors directory at " + errorsDir);
+        }))
         .filter(Optional::isPresent)
         .map(Optional::get)
         // Track the submission

--- a/src/org/opendatakit/briefcase/export/ExportToCsv.java
+++ b/src/org/opendatakit/briefcase/export/ExportToCsv.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import org.bushe.swing.event.EventBus;
 import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
 import org.opendatakit.briefcase.reused.BriefcaseException;
@@ -75,21 +76,12 @@ public class ExportToCsv {
 
     csvs.forEach(Csv::prepareOutputFiles);
 
-    // Reset errors management for this export attemp
-    Path errorsDir = configuration.getErrorsDir(formDef.getFormName());
-    AtomicInteger errorSeq = new AtomicInteger(1);
-    if (exists(errorsDir))
-      deleteRecursive(errorsDir);
+    Consumer<Path> onParsingError = buildParsingErrorCallback(configuration.getErrorsDir(formDef.getFormName()));
 
     // Generate csv lines grouped by the fqdn of the model they belong to
     Map<String, CsvLines> csvLinesPerModel = submissionFiles.parallelStream()
         // Parse the submission and leave only those OK to be exported
-        .map(path -> parseSubmission(path, formDef.isFileEncryptedForm(), configuration.getPrivateKey(), p -> {
-          if (!exists(errorsDir))
-            createDirectories(errorsDir);
-          copy(p, errorsDir.resolve("failed_submission_" + errorSeq.getAndIncrement() + ".xml"));
-          log.info("Failed submission XML file moved to the output errors directory at " + errorsDir);
-        }))
+        .map(path -> parseSubmission(path, formDef.isFileEncryptedForm(), configuration.getPrivateKey(), onParsingError))
         .filter(Optional::isPresent)
         .map(Optional::get)
         // Track the submission
@@ -124,6 +116,19 @@ public class ExportToCsv {
       EventBus.publish(ExportEvent.failure(formDef, "All submissions have been skipped"));
 
     return exportOutcome;
+  }
+
+  private static Consumer<Path> buildParsingErrorCallback(Path errorsDir) {
+    AtomicInteger errorSeq = new AtomicInteger(1);
+    // Remove errors from a previous export attempt
+    if (exists(errorsDir))
+      deleteRecursive(errorsDir);
+    return path -> {
+      if (!exists(errorsDir))
+        createDirectories(errorsDir);
+      copy(path, errorsDir.resolve("failed_submission_" + errorSeq.getAndIncrement() + ".xml"));
+      log.info("Failed submission XML file moved to the output errors directory at " + errorsDir);
+    };
   }
 
 }

--- a/src/org/opendatakit/briefcase/export/ExportToCsv.java
+++ b/src/org/opendatakit/briefcase/export/ExportToCsv.java
@@ -24,6 +24,7 @@ import static org.opendatakit.briefcase.export.ExportOutcome.ALL_SKIPPED;
 import static org.opendatakit.briefcase.export.ExportOutcome.SOME_SKIPPED;
 import static org.opendatakit.briefcase.export.SubmissionParser.getListOfSubmissionFiles;
 import static org.opendatakit.briefcase.export.SubmissionParser.parseSubmission;
+import static org.opendatakit.briefcase.reused.UncheckedFiles.*;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.createDirectories;
 
 import java.nio.file.Path;
@@ -31,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.bushe.swing.event.EventBus;
 import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
 import org.opendatakit.briefcase.reused.BriefcaseException;
@@ -74,7 +76,7 @@ public class ExportToCsv {
     // Generate csv lines grouped by the fqdn of the model they belong to
     Map<String, CsvLines> csvLinesPerModel = submissionFiles.parallelStream()
         // Parse the submission and leave only those OK to be exported
-        .map(path -> parseSubmission(path, formDef.isFileEncryptedForm(), configuration.getPrivateKey(), configuration.getErrorsDir(formDef.getFormName())))
+        .map(path -> parseSubmission(path, formDef.isFileEncryptedForm(), configuration.getPrivateKey(), configuration.getErrorsDir(formDef.getFormName()), new AtomicInteger(1)))
         .filter(Optional::isPresent)
         .map(Optional::get)
         // Track the submission

--- a/src/org/opendatakit/briefcase/export/SubmissionParser.java
+++ b/src/org/opendatakit/briefcase/export/SubmissionParser.java
@@ -44,6 +44,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.CipherInputStream;
@@ -122,11 +123,11 @@ class SubmissionParser {
    * @param errorSeq
    * @return the {@link Submission} wrapped inside an {@link Optional} when it meets all the
    *     criteria, or {@link Optional#empty()} otherwise
-   * @see #decrypt(Submission, Path, AtomicInteger)
+   * @see #decrypt(Submission, Path, AtomicInteger, Consumer)
    */
-  static Optional<Submission> parseSubmission(Path path, boolean isEncrypted, Optional<PrivateKey> privateKey, Path errorsDir, AtomicInteger errorSeq) {
+  static Optional<Submission> parseSubmission(Path path, boolean isEncrypted, Optional<PrivateKey> privateKey, Path errorsDir, AtomicInteger errorSeq, Consumer<Path> onParsingError) {
     Path workingDir = isEncrypted ? createTempDirectory("briefcase") : path.getParent();
-    return parse(path, errorsDir, errorSeq).flatMap(document -> {
+    return parse(path, errorsDir, errorSeq, onParsingError).flatMap(document -> {
       XmlElement root = XmlElement.of(document);
       SubmissionMetaData metaData = new SubmissionMetaData(root);
 
@@ -146,7 +147,7 @@ class SubmissionParser {
       Submission submission = Submission.notValidated(path, workingDir, root, metaData, cipherFactory, signature);
       return isEncrypted
           // If it's encrypted, validate the parsed contents with the attached signature
-          ? decrypt(submission, errorsDir, errorSeq).map(s -> s.copy(ValidationStatus.of(isValid(submission, s))))
+          ? decrypt(submission, errorsDir, errorSeq, onParsingError).map(s -> s.copy(ValidationStatus.of(isValid(submission, s))))
           // Return the original submission otherwise
           : Optional.of(submission);
     });
@@ -187,7 +188,7 @@ class SubmissionParser {
   }
 
 
-  private static Optional<Submission> decrypt(Submission submission, Path errorsDir, AtomicInteger errorSeq) {
+  private static Optional<Submission> decrypt(Submission submission, Path errorsDir, AtomicInteger errorSeq, Consumer<Path> onParsingError) {
     List<Path> mediaPaths = submission.getMediaPaths();
 
     if (mediaPaths.size() != submission.countMedia())
@@ -201,7 +202,7 @@ class SubmissionParser {
     Path decryptedSubmission = decryptFile(submission.getEncryptedFilePath(), submission.getWorkingDir(), submission.getNextCipher());
 
     // Parse the document and, if everything goes well, return a decripted copy of the submission
-    return parse(decryptedSubmission, errorsDir, errorSeq).map(document -> submission.copy(decryptedSubmission, document));
+    return parse(decryptedSubmission, errorsDir, errorSeq, onParsingError).map(document -> submission.copy(decryptedSubmission, document));
   }
 
   private static Path decryptFile(Path encFile, Path workingDir, Cipher cipher) {
@@ -223,7 +224,7 @@ class SubmissionParser {
     }
   }
 
-  private static Optional<Document> parse(Path submission, Path errorsDir, AtomicInteger errorSeq) {
+  private static Optional<Document> parse(Path submission, Path errorsDir, AtomicInteger errorSeq, Consumer<Path> onParsingError) {
     try (InputStream is = Files.newInputStream(submission);
          InputStreamReader isr = new InputStreamReader(is, "UTF-8")) {
       Document tempDoc = new Document();
@@ -238,6 +239,7 @@ class SubmissionParser {
         createDirectories(errorsDir);
       copy(submission, errorsDir.resolve("failed_submission_" + errorSeq.getAndIncrement() + ".xml"));
       log.info("Failed submission XML file moved to the output errors directory at " + errorsDir);
+      onParsingError.accept(submission);
       return Optional.empty();
     }
   }

--- a/src/org/opendatakit/briefcase/export/SubmissionParser.java
+++ b/src/org/opendatakit/briefcase/export/SubmissionParser.java
@@ -55,7 +55,6 @@ import org.bushe.swing.event.EventBus;
 import org.kxml2.io.KXmlParser;
 import org.kxml2.kdom.Document;
 import org.opendatakit.briefcase.model.CryptoException;
-import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.reused.OptionalProduct;
 import org.opendatakit.briefcase.reused.Pair;
 import org.opendatakit.briefcase.reused.UncheckedFiles;
@@ -234,11 +233,12 @@ class SubmissionParser {
       tempDoc.parse(parser);
       return Optional.of(tempDoc);
     } catch (IOException | XmlPullParserException e) {
+      log.error("Can't parse submission", e);
       if (!exists(errorsDir))
         createDirectories(errorsDir);
       copy(submission, errorsDir.resolve("failed_submission_" + errorSeq.getAndIncrement() + ".xml"));
       log.info("Failed submission XML file moved to the output errors directory at " + errorsDir);
-      throw new BriefcaseException(e);
+      return Optional.empty();
     }
   }
 

--- a/src/org/opendatakit/briefcase/export/SubmissionParser.java
+++ b/src/org/opendatakit/briefcase/export/SubmissionParser.java
@@ -235,10 +235,6 @@ class SubmissionParser {
       return Optional.of(tempDoc);
     } catch (IOException | XmlPullParserException e) {
       log.error("Can't parse submission", e);
-      if (!exists(errorsDir))
-        createDirectories(errorsDir);
-      copy(submission, errorsDir.resolve("failed_submission_" + errorSeq.getAndIncrement() + ".xml"));
-      log.info("Failed submission XML file moved to the output errors directory at " + errorsDir);
       onParsingError.accept(submission);
       return Optional.empty();
     }

--- a/src/org/opendatakit/briefcase/reused/UncheckedFiles.java
+++ b/src/org/opendatakit/briefcase/reused/UncheckedFiles.java
@@ -326,4 +326,12 @@ public class UncheckedFiles {
     createDirectories(briefcaseDir.resolve("forms"));
     write(briefcaseDir.resolve("readme.txt"), README_CONTENTS);
   }
+
+  public static Path move(Path source, Path target, CopyOption... options) {
+    try {
+      return Files.move(source, target, options);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
 }


### PR DESCRIPTION
Addresses #611

This PR doesn't change Briefcase's behavior.

This PR changes the export process to copy failed submissions to a new error directory inside the export directory. This will let users attach the specific submissions that are failing when reporting issues with Briefcase.

To test this PR, use this storage dir which includes two forms with failing submissions.

[storage_dir.zip](https://github.com/opendatakit/briefcase/files/2331987/storage_dir.zip)

#### What has been done to verify that this works as intended?
- Pull a form with submissions
- Tamper with a submission by introducing XML syntax errors
- Export the form
- Verify that the invalid form is inside an `errors of NAME OF THE FORM` directory inside the choosen export directory. The submission should have a `failed_submission_1.xml` filename. The number should follow a sequence if there are more than one failing submissions.

#### Why is this the best possible solution? Were any other approaches considered?
This is the narrowest change I could come up with to have this, but it's based on new implicit side-effects during the parsing process, which is not desirable.

A proper way to go about this would involve changing the parsing process to return a `Pair<Path, Optional<Submission>>` instead. This would enable us to group "parsing results" by success/failure and explicitly deal with the new side effects as a "first-class citizen" of the exporting process.

In `ExportToCsv` we're currently doing:
```java
// Generate csv lines grouped by the fqdn of the model they belong to
Map<String, CsvLines> csvLinesPerModel = submissionFiles.parallelStream()
    // Parse the submission and leave only those OK to be exported
    .map(path -> parseSubmission(path, formDef.isFileEncryptedForm(), configuration.getPrivateKey(), configuration.getErrorsDir(formDef.getFormName())))
    .filter(Optional::isPresent)
    .map(Optional::get)
    // Track the submission
    .peek(s -> exportTracker.incAndReport())
    // Use the mapper of each Csv instance to map the submission into their respective outputs
    .flatMap(submission -> csvs.stream()
        .map(Csv::getMapper)
        .map(mapper -> mapper.apply(submission)))
    // Group and merge the CsvLines by the model they belong to
    .collect(groupingByConcurrent(
        CsvLines::getModelFqn,
        reducing(CsvLines.empty(), CsvLines::merge)
    ));
```

Now we would do:
```java
// Parse all submission files
Map<Boolean, List<Pair<Path, Optional<Submission>>>> parsingResults = submissionFiles.parallelStream()
    // Parse the submission and leave only those OK to be exported
    .map(path -> parseSubmission(path, formDef.isFileEncryptedForm(), configuration.getPrivateKey()))
    .collect(groupingByConcurrent(pair -> pair.getRight().isPresent()));

// Copy failed submissions to the errors dir
parsingResults.get(false) // failed ones
    .forEach(pair -> {
      log.error("Can't parse submission", e);
      Path errorsDir = configuration.getErrorsDir(formDef.getFormName());
      if (!exists(errorsDir))
        createDirectories(errorsDir);
      copy(pair.getLeft(), errorsDir.resolve("failed_submission_" + errorSeq.getAndIncrement() + ".xml"));
    });

// Generate csv lines grouped by the fqdn of the model they belong to
Map<String, CsvLines> csvLinesPerModel = parsingResults.get(true) // successfully parsed ones
    .map(Pair::getRight)
    .map(Optional::get)
    // Track the submission
    .peek(s -> exportTracker.incAndReport())
    // Use the mapper of each Csv instance to map the submission into their respective outputs
    .flatMap(submission -> csvs.stream()
        .map(Csv::getMapper)
        .map(mapper -> mapper.apply(submission)))
    // Group and merge the CsvLines by the model they belong to
    .collect(groupingByConcurrent(
        CsvLines::getModelFqn,
        reducing(CsvLines.empty(), CsvLines::merge)
    ));
```

I think that the solution on this PR, although technically less sound, could be better at this point.

#### Are there any risks to merging this code? If so, what are they?
Nope

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No
