### PR TITLE
Issue 613 cli param to pull incomplete subs

### DIFF
--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -27,7 +27,6 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
-
 import org.opendatakit.briefcase.export.ExportConfiguration;
 import org.opendatakit.briefcase.export.ExportToCsv;
 import org.opendatakit.briefcase.export.FormDefinition;
@@ -125,7 +124,8 @@ public class Export {
             new TerminationFuture(),
             Collections.singletonList(formStatus),
             briefcaseDir,
-            appPreferences.getPullInParallel().orElse(false)
+            appPreferences.getPullInParallel().orElse(false),
+            false
         );
       }
 

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -98,7 +98,7 @@ public class PullFormFromAggregate {
 
       FormStatus form = maybeForm.get();
       EventBus.publish(new StartPullEvent(form));
-      TransferFromServer.pull(remoteServer.asServerConnectionInfo(), briefcaseDir, pullInParallel, form);
+      TransferFromServer.pull(remoteServer.asServerConnectionInfo(), briefcaseDir, pullInParallel, includeIncomplete, form);
     }
   }
 

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -25,7 +25,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Optional;
 import org.bushe.swing.event.EventBus;
 import org.opendatakit.briefcase.model.FormStatus;
@@ -47,6 +46,7 @@ public class PullFormFromAggregate {
   public static final Param<Void> DEPRECATED_PULL_AGGREGATE = Param.flag("pa", "Pull form from an Aggregate instance");
   private static final Param<Void> PULL_AGGREGATE = Param.flag("plla", "pull_aggregate", "Pull form from an Aggregate instance");
   private static final Param<Void> PULL_IN_PARALLEL = Param.flag("pp", "parallel_pull", "Pull submissions in parallel");
+  private static final Param<Void> INCLUDE_INCOMPLETE = Param.flag("ii", "include_incomplete", "Include incomplete submissions");
 
   public static Operation PULL_FORM_FROM_AGGREGATE = Operation.of(
       PULL_AGGREGATE,
@@ -56,13 +56,14 @@ public class PullFormFromAggregate {
           args.get(ODK_USERNAME),
           args.get(ODK_PASSWORD),
           args.get(AGGREGATE_SERVER),
-          args.has(PULL_IN_PARALLEL)
+          args.has(PULL_IN_PARALLEL),
+          args.has(INCLUDE_INCOMPLETE)
       ),
       Arrays.asList(STORAGE_DIR, FORM_ID, ODK_USERNAME, ODK_PASSWORD, AGGREGATE_SERVER),
-      Collections.singletonList(PULL_IN_PARALLEL)
+      Arrays.asList(PULL_IN_PARALLEL, INCLUDE_INCOMPLETE)
   );
 
-  public static void pullFormFromAggregate(String storageDir, String formid, String username, String password, String server, boolean pullInParallel) {
+  public static void pullFormFromAggregate(String storageDir, String formid, String username, String password, String server, boolean pullInParallel, boolean includeIncomplete) {
     CliEventsCompanion.attach(log);
     Path briefcaseDir = Common.getOrCreateBriefcaseDir(storageDir);
     FormCache formCache = FormCache.from(briefcaseDir);

--- a/src/org/opendatakit/briefcase/transfer/NewTransferAction.java
+++ b/src/org/opendatakit/briefcase/transfer/NewTransferAction.java
@@ -30,13 +30,14 @@ import org.slf4j.LoggerFactory;
 public class NewTransferAction {
   private static final Logger log = LoggerFactory.getLogger(NewTransferAction.class);
 
-  public static void transferServerToBriefcase(ServerConnectionInfo transferSettings, TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Path briefcaseDir, Boolean pullInParallel) {
+  public static void transferServerToBriefcase(ServerConnectionInfo transferSettings, TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete) {
     TransferFromServer action = new TransferFromServer(
         transferSettings,
         terminationFuture,
         formsToTransfer,
         briefcaseDir,
-        pullInParallel
+        pullInParallel,
+        includeIncomplete
     );
     try {
       boolean allSuccessful = action.doAction();

--- a/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
+++ b/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
@@ -305,7 +305,7 @@ public class BriefcaseCLI {
         importODK(storageDir, Paths.get(odkDir), Optional.empty());
 
       if (odkDir == null && server != null)
-        pullFormFromAggregate(storageDir, formid, username, password, server, false);
+        pullFormFromAggregate(storageDir, formid, username, password, server, false, false);
 
       if (exportPath != null)
         export(

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -194,7 +194,8 @@ public class ExportPanel {
                   new TerminationFuture(),
                   Collections.singletonList(form),
                   appPreferences.getBriefcaseDir().orElseThrow(BriefcaseException::new),
-                  appPreferences.getPullInParallel().orElse(false)
+                  appPreferences.getPullInParallel().orElse(false),
+                  false
               ));
             BriefcaseFormDefinition formDefinition = (BriefcaseFormDefinition) form.getFormDefinition();
             ExportToCsv.export(FormDefinition.from(formDefinition), configuration);

--- a/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
+++ b/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
@@ -93,7 +93,7 @@ public class PullPanel {
     view.onAction(() -> {
       view.setWorking();
       forms.forEach(FormStatus::clearStatusHistory);
-      source.ifPresent(s -> s.pull(forms.getSelectedForms(), terminationFuture, appPreferences.getBriefcaseDir().orElseThrow(BriefcaseException::new), appPreferences.getPullInParallel().orElse(false)));
+      source.ifPresent(s -> s.pull(forms.getSelectedForms(), terminationFuture, appPreferences.getBriefcaseDir().orElseThrow(BriefcaseException::new), appPreferences.getPullInParallel().orElse(false), false));
     });
 
     view.onCancel(() -> terminationFuture.markAsCancelled(new PullEvent.Abort("Cancelled by the user")));

--- a/src/org/opendatakit/briefcase/ui/reused/source/Source.java
+++ b/src/org/opendatakit/briefcase/ui/reused/source/Source.java
@@ -174,8 +174,10 @@ public interface Source<T> {
    *
    * @param forms             {@link List} of forms to be pulled
    * @param terminationFuture object that to make the operation cancellable
+   * @param includeIncomplete when passed true, it enables requesting the incomplete
+   *                          submissions. This needs to be supported by the selected source
    */
-  void pull(List<FormStatus> forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel);
+  void pull(List<FormStatus> forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete);
 
   /**
    * Pushes forms to this configured {@link Source}.
@@ -239,8 +241,8 @@ public interface Source<T> {
     }
 
     @Override
-    public void pull(List<FormStatus> forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel) {
-      TransferAction.transferServerToBriefcase(server.asServerConnectionInfo(), terminationFuture, forms, briefcaseDir, pullInParallel);
+    public void pull(List<FormStatus> forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete) {
+      TransferAction.transferServerToBriefcase(server.asServerConnectionInfo(), terminationFuture, forms, briefcaseDir, pullInParallel, includeIncomplete);
     }
 
     @Override
@@ -318,7 +320,7 @@ public interface Source<T> {
     }
 
     @Override
-    public void pull(List<FormStatus> forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel) {
+    public void pull(List<FormStatus> forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete) {
       TransferAction.transferODKToBriefcase(briefcaseDir, path.toFile(), terminationFuture, forms);
     }
 
@@ -394,7 +396,7 @@ public interface Source<T> {
     }
 
     @Override
-    public void pull(List<FormStatus> forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel) {
+    public void pull(List<FormStatus> forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete) {
       SwingUtilities.invokeLater(() -> FormInstaller.install(briefcaseDir, form));
     }
 

--- a/src/org/opendatakit/briefcase/util/ServerFetcher.java
+++ b/src/org/opendatakit/briefcase/util/ServerFetcher.java
@@ -73,6 +73,7 @@ public class ServerFetcher {
   public static String SUCCESS_STATUS = "Success.";
   public static String FAILED_STATUS = "Failed.";
   private final Path briefcaseDir;
+  private final Boolean includeIncomplete;
 
   public static class FormListException extends Exception {
 
@@ -123,8 +124,9 @@ public class ServerFetcher {
     }
   }
 
-  ServerFetcher(ServerConnectionInfo serverInfo, TerminationFuture future, Path briefcaseDir, Boolean pullInParallel) {
+  ServerFetcher(ServerConnectionInfo serverInfo, TerminationFuture future, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete) {
     this.briefcaseDir = briefcaseDir;
+    this.includeIncomplete = includeIncomplete;
     AnnotationProcessor.process(this);// if not using AOP
     this.serverInfo = serverInfo;
     this.terminationFuture = future;
@@ -408,6 +410,8 @@ public class ServerFetcher {
       params.put("numEntries", Integer.toString(MAX_ENTRIES));
       params.put("formId", formId);
       params.put("cursor", cursor);
+      if (includeIncomplete)
+        params.put("includeIncomplete", "true");
       return WebUtils.createLinkWithProperties(baseUrl, params);
     }
 

--- a/src/org/opendatakit/briefcase/util/TransferAction.java
+++ b/src/org/opendatakit/briefcase/util/TransferAction.java
@@ -97,8 +97,8 @@ public class TransferAction {
     backgroundExecutorService.execute(new GatherTransferRunnable(src, formsToTransfer));
   }
 
-  public static void transferServerToBriefcase(ServerConnectionInfo originServerInfo, TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Path briefcaseDir, Boolean pullInParallel) {
-    TransferFromServer source = new TransferFromServer(originServerInfo, terminationFuture, formsToTransfer, briefcaseDir, pullInParallel);
+  public static void transferServerToBriefcase(ServerConnectionInfo originServerInfo, TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete) {
+    TransferFromServer source = new TransferFromServer(originServerInfo, terminationFuture, formsToTransfer, briefcaseDir, pullInParallel, includeIncomplete);
     backgroundRun(source, formsToTransfer);
   }
 

--- a/src/org/opendatakit/briefcase/util/TransferFromServer.java
+++ b/src/org/opendatakit/briefcase/util/TransferFromServer.java
@@ -32,20 +32,22 @@ public class TransferFromServer implements ITransferFromSourceAction {
   final TerminationFuture terminationFuture;
   final List<FormStatus> formsToTransfer;
   private final Boolean pullInParallel;
+  private final Boolean includeIncomplete;
   private Path briefcaseDir;
 
-  public TransferFromServer(ServerConnectionInfo originServerInfo, TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Path briefcaseDir, Boolean pullInParallel) {
+  public TransferFromServer(ServerConnectionInfo originServerInfo, TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete) {
     this.originServerInfo = originServerInfo;
     this.terminationFuture = terminationFuture;
     this.formsToTransfer = formsToTransfer;
     this.briefcaseDir = briefcaseDir;
     this.pullInParallel = pullInParallel;
+    this.includeIncomplete = includeIncomplete;
   }
 
   @Override
   public boolean doAction() {
 
-    ServerFetcher fetcher = new ServerFetcher(originServerInfo, terminationFuture, briefcaseDir, pullInParallel);
+    ServerFetcher fetcher = new ServerFetcher(originServerInfo, terminationFuture, briefcaseDir, pullInParallel, includeIncomplete);
 
     return fetcher.downloadFormAndSubmissionFiles(formsToTransfer);
   }
@@ -55,9 +57,9 @@ public class TransferFromServer implements ITransferFromSourceAction {
     return false;
   }
 
-  public static void pull(ServerConnectionInfo transferSettings, Path briefcaseDir, Boolean pullInParallel, FormStatus... forms) {
+  public static void pull(ServerConnectionInfo transferSettings, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete, FormStatus... forms) {
     List<FormStatus> formList = Arrays.asList(forms);
-    TransferFromServer action = new TransferFromServer(transferSettings, new TerminationFuture(), formList, briefcaseDir, pullInParallel);
+    TransferFromServer action = new TransferFromServer(transferSettings, new TerminationFuture(), formList, briefcaseDir, pullInParallel, includeIncomplete);
 
     try {
       boolean allSuccessful = action.doAction();


### PR DESCRIPTION
Closes #613

This PR adds a new CLI param to enable requesting incomplete submissions when pulling from Aggregate.

It would be easier to test this PR with an Aggregate server that supports the new parameter. (Will post here the PR/version when it's available)

#### What has been done to verify that this works as intended?
Used the CLI pull from aggregate op with the new flag and verified on the logs that the requested URL included the `&includeIncomplete=true` part in its query string (INFO log level has to be enabled in the logback conf settings).

#### Why is this the best possible solution? Were any other approaches considered?
Although the code is quite coupled and I've had to pass a new arg around changing many classes, this is the narrowest change I could come up with.

#### Are there any risks to merging this code? If so, what are they?
Aggregate doesn't complain about the new arg, even if it doesn't support it (maybe it's an older version without support for this). I can't say the same about other compatible servers.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No, since CLI op params are not included in the docs.