### PR TITLE
Issue 617 update jr to 2.11.2 and adapt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
         exclude group: 'commons-logging'
     }
     compile group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
-    compile(group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.10.0') {
+    compile(group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.11.2') {
         exclude group: 'org.slf4j'
     }
     compile group: 'org.hsqldb', name: 'hsqldb', version: '2.4.0'

--- a/src/org/opendatakit/briefcase/export/Model.java
+++ b/src/org/opendatakit/briefcase/export/Model.java
@@ -20,8 +20,8 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static org.javarosa.core.model.Constants.DATATYPE_NULL;
-import static org.javarosa.core.model.DataType.CHOICE_LIST;
 import static org.javarosa.core.model.DataType.GEOPOINT;
+import static org.javarosa.core.model.DataType.MULTIPLE_ITEMS;
 import static org.javarosa.core.model.DataType.NULL;
 import static org.opendatakit.briefcase.export.Model.ControlType.SELECT_MULTI;
 
@@ -260,7 +260,7 @@ class Model {
 
   public boolean isChoiceList() {
     return Optional.ofNullable(controls.get(fqn()))
-        .map(control -> getDataType() == CHOICE_LIST || ControlType.from(control.getControlType()) == SELECT_MULTI)
+        .map(control -> getDataType() == MULTIPLE_ITEMS || ControlType.from(control.getControlType()) == SELECT_MULTI)
         .orElse(false);
   }
 

--- a/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersEncodeMainValueTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersEncodeMainValueTest.java
@@ -58,7 +58,7 @@ public class CsvSubmissionMappersEncodeMainValueTest {
         {"INTEGER encodes an empty string", createField(DataType.INTEGER), ESCAPED_EMPTY_STRING_VALUE},
         {"DECIMAL encodes an empty string", createField(DataType.DECIMAL), ESCAPED_EMPTY_STRING_VALUE},
         {"CHOICE encodes an empty string", createField(DataType.CHOICE), ESCAPED_EMPTY_STRING_VALUE},
-        {"CHOICE_LIST encodes an empty string", createField(DataType.CHOICE_LIST), ESCAPED_EMPTY_STRING_VALUE},
+        {"MULTIPLE_ITEMS encodes an empty string", createField(DataType.MULTIPLE_ITEMS), ESCAPED_EMPTY_STRING_VALUE},
         {"BOOLEAN encodes an empty string", createField(DataType.BOOLEAN), ESCAPED_EMPTY_STRING_VALUE},
         {"BARCODE encodes an empty string", createField(DataType.BARCODE), ESCAPED_EMPTY_STRING_VALUE},
         {"BINARY encodes an empty string", createField(DataType.BINARY), ESCAPED_EMPTY_STRING_VALUE},


### PR DESCRIPTION
Closes #617

This PR doesn't change Briefcase's behavior

This PR updates the JR lib version and adapts to a breaking change that was introduced:
- `DataType.CHOICE_LIST` has been replaced by `DataType.MULTIPLE_ITEMS`

#### What has been done to verify that this works as intended?
Run the automated tests

#### Why is this the best possible solution? Were any other approaches considered?
We could always _not_ update the JR version but the longer we wait, the bigger the adaptation changes will be. Better to do have smaller changesets.

#### Are there any risks to merging this code? If so, what are they?
None.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.