### PR TITLE
Issue #612 Reload button for Aggregate option under pull tab

### DIFF
--- a/src/org/opendatakit/briefcase/ui/reused/source/SelectSourceForm.java
+++ b/src/org/opendatakit/briefcase/ui/reused/source/SelectSourceForm.java
@@ -51,6 +51,10 @@ public class SelectSourceForm extends JComponent {
     sourceComboBox.addItem(source);
   }
 
+  public Optional<Source> getSelectedSource() {
+    return Optional.ofNullable((Source) sourceComboBox.getSelectedItem());
+  }
+
   @Override
   public void setEnabled(boolean enabled) {
     super.setEnabled(enabled);

--- a/src/org/opendatakit/briefcase/ui/reused/source/ShowSourceForm.form
+++ b/src/org/opendatakit/briefcase/ui/reused/source/ShowSourceForm.form
@@ -27,7 +27,7 @@
       </component>
       <component id="45a9d" class="javax.swing.JButton" binding="resetButton">
         <constraints>
-          <grid row="0" column="2" row-span="2" col-span="1" vsize-policy="0" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="4" row-span="2" col-span="1" vsize-policy="0" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties>
@@ -37,6 +37,21 @@
       <hspacer id="6fcbd">
         <constraints>
           <grid row="0" column="1" row-span="2" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <gridbag weightx="0.0" weighty="0.0"/>
+        </constraints>
+      </hspacer>
+      <component id="cb9ba" class="javax.swing.JButton" binding="reloadButton">
+        <constraints>
+          <grid row="0" column="2" row-span="2" col-span="1" vsize-policy="0" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+          <gridbag weightx="0.0" weighty="0.0"/>
+        </constraints>
+        <properties>
+          <text value="Reload"/>
+        </properties>
+      </component>
+      <hspacer id="d72f6">
+        <constraints>
+          <grid row="0" column="3" row-span="2" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
       </hspacer>

--- a/src/org/opendatakit/briefcase/ui/reused/source/ShowSourceForm.java
+++ b/src/org/opendatakit/briefcase/ui/reused/source/ShowSourceForm.java
@@ -50,8 +50,8 @@ public class ShowSourceForm extends JComponent {
 
     onReloadCallbacks.add(() -> {
       reloadButton.setEnabled(false);
-      this.reloadTimerElapsed = false;
-      this.reloadOperationCompleted = false;
+      reloadTimerElapsed = false;
+      reloadOperationCompleted = false;
       Timer t = new Timer(5000, (e) -> markReloadTimerElapsed());
       t.setRepeats(false);
       t.start();
@@ -99,17 +99,17 @@ public class ShowSourceForm extends JComponent {
   }
 
   private void markReloadTimerElapsed() {
-    this.reloadTimerElapsed = true;
+    reloadTimerElapsed = true;
     updateReloadButton();
   }
 
   private void markReloadOperationCompleted() {
-    this.reloadOperationCompleted = true;
+    reloadOperationCompleted = true;
     updateReloadButton();
   }
 
   private void updateReloadButton() {
-    if (this.reloadTimerElapsed && this.reloadOperationCompleted)
+    if (reloadTimerElapsed && reloadOperationCompleted)
       reloadButton.setEnabled(true);
   }
 

--- a/src/org/opendatakit/briefcase/ui/reused/source/ShowSourceForm.java
+++ b/src/org/opendatakit/briefcase/ui/reused/source/ShowSourceForm.java
@@ -20,12 +20,11 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.Timer;
 
 @SuppressWarnings("checkstyle:MethodName")
 public class ShowSourceForm extends JComponent {
@@ -38,6 +37,8 @@ public class ShowSourceForm extends JComponent {
   private List<Runnable> onResetCallbacks = new ArrayList<>();
   private List<Runnable> onReloadCallbacks = new ArrayList<>();
   private boolean showReloadButton;
+  private boolean reloadTimerElapsed;
+  private boolean reloadOperationCompleted;
 
   private ShowSourceForm(String action, boolean showReloadButton) {
     $$$setupUI$$$();
@@ -49,14 +50,11 @@ public class ShowSourceForm extends JComponent {
 
     onReloadCallbacks.add(() -> {
       reloadButton.setEnabled(false);
-      TimerTask task = new TimerTask() {
-        public void run() {
-          reloadButton.setEnabled(true);
-        }
-      };
-      Timer timer = new Timer();
-      long delayMillis = 5000L;
-      timer.schedule(task, delayMillis);
+      this.reloadTimerElapsed = false;
+      this.reloadOperationCompleted = false;
+      Timer t = new Timer(5000, (e) -> markReloadTimerElapsed());
+      t.setRepeats(false);
+      t.start();
     });
     if (!showReloadButton)
       reloadButton.setVisible(false);
@@ -82,6 +80,7 @@ public class ShowSourceForm extends JComponent {
     actionLabel.setText(action + ": " + source.toString());
     sourceLabel.setText(source.getDescription());
     reloadButton.setVisible(source.canBeReloaded() && showReloadButton);
+    markReloadOperationCompleted();
   }
 
   private void createUIComponents() {
@@ -97,6 +96,21 @@ public class ShowSourceForm extends JComponent {
     super.setEnabled(enabled);
     resetButton.setEnabled(enabled);
     reloadButton.setEnabled(enabled);
+  }
+
+  private void markReloadTimerElapsed() {
+    this.reloadTimerElapsed = true;
+    updateReloadButton();
+  }
+
+  private void markReloadOperationCompleted() {
+    this.reloadOperationCompleted = true;
+    updateReloadButton();
+  }
+
+  private void updateReloadButton() {
+    if (this.reloadTimerElapsed && this.reloadOperationCompleted)
+      reloadButton.setEnabled(true);
   }
 
   /**

--- a/src/org/opendatakit/briefcase/ui/reused/source/ShowSourceForm.java
+++ b/src/org/opendatakit/briefcase/ui/reused/source/ShowSourceForm.java
@@ -32,26 +32,44 @@ public class ShowSourceForm extends JComponent {
   private JLabel sourceLabel;
   private JButton resetButton;
   private JLabel actionLabel;
+  private JButton reloadButton;
   private List<Runnable> onResetCallbacks = new ArrayList<>();
+  private List<Runnable> onReloadCallbacks = new ArrayList<>();
+  private Operation type;
 
-  private ShowSourceForm(String action) {
+  private ShowSourceForm(String action, Operation type) {
     $$$setupUI$$$();
     this.action = action;
+    this.type = type;
 
     resetButton.addActionListener(__ -> onResetCallbacks.forEach(Runnable::run));
+    if (type.equals(Operation.PULL)) {
+      reloadButton.addActionListener(__ -> onReloadCallbacks.forEach(Runnable::run));
+    } else {
+      reloadButton.setVisible(false);
+    }
   }
 
-  static ShowSourceForm empty(String action) {
-    return new ShowSourceForm(action);
+  static ShowSourceForm pull(String action) {
+    return new ShowSourceForm(action, Operation.PULL);
+  }
+
+  static ShowSourceForm push(String action) {
+    return new ShowSourceForm(action, Operation.PUSH);
   }
 
   void onReset(Runnable callback) {
     onResetCallbacks.add(callback);
   }
 
+  void onReload(Runnable callback) {
+    onReloadCallbacks.add(callback);
+  }
+
   void showSource(Source source) {
     actionLabel.setText(action + ": " + source.toString());
     sourceLabel.setText(source.getDescription());
+    reloadButton.setVisible(source instanceof Source.Aggregate);
   }
 
   private void createUIComponents() {
@@ -66,6 +84,7 @@ public class ShowSourceForm extends JComponent {
   public void setEnabled(boolean enabled) {
     super.setEnabled(enabled);
     resetButton.setEnabled(enabled);
+    reloadButton.setEnabled(enabled);
   }
 
   /**
@@ -98,7 +117,7 @@ public class ShowSourceForm extends JComponent {
     resetButton = new JButton();
     resetButton.setText("Reset");
     gbc = new GridBagConstraints();
-    gbc.gridx = 2;
+    gbc.gridx = 4;
     gbc.gridy = 0;
     gbc.gridheight = 2;
     gbc.anchor = GridBagConstraints.EAST;
@@ -110,6 +129,21 @@ public class ShowSourceForm extends JComponent {
     gbc.gridheight = 2;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     container.add(spacer1, gbc);
+    reloadButton = new JButton();
+    reloadButton.setText("Reload");
+    gbc = new GridBagConstraints();
+    gbc.gridx = 2;
+    gbc.gridy = 0;
+    gbc.gridheight = 2;
+    gbc.anchor = GridBagConstraints.EAST;
+    container.add(reloadButton, gbc);
+    final JPanel spacer2 = new JPanel();
+    gbc = new GridBagConstraints();
+    gbc.gridx = 3;
+    gbc.gridy = 0;
+    gbc.gridheight = 2;
+    gbc.fill = GridBagConstraints.HORIZONTAL;
+    container.add(spacer2, gbc);
   }
 
   /**
@@ -118,4 +152,9 @@ public class ShowSourceForm extends JComponent {
   public JComponent $$$getRootComponent$$$() {
     return container;
   }
+
+  private enum Operation {
+    PUSH, PULL
+  }
+
 }

--- a/src/org/opendatakit/briefcase/ui/reused/source/Source.java
+++ b/src/org/opendatakit/briefcase/ui/reused/source/Source.java
@@ -186,6 +186,13 @@ public interface Source<T> {
   void push(List<FormStatus> forms, TerminationFuture terminationFuture);
 
   /**
+   * Returns whether or not this {@link Source} supports reloading.
+   *
+   * @return true if it supports reload, false otherwise
+   */
+  boolean canBeReloaded();
+
+  /**
    * Returns a textual description of this {@link Source}.
    */
   String getDescription();
@@ -246,6 +253,11 @@ public interface Source<T> {
     @Override
     public void push(List<FormStatus> forms, TerminationFuture terminationFuture) {
       TransferAction.transferBriefcaseToServer(server.asServerConnectionInfo(), terminationFuture, forms, http, server);
+    }
+
+    @Override
+    public boolean canBeReloaded() {
+      return true;
     }
 
     @Override
@@ -328,6 +340,11 @@ public interface Source<T> {
     }
 
     @Override
+    public boolean canBeReloaded() {
+      return false;
+    }
+
+    @Override
     public String getDescription() {
       return path.toString();
     }
@@ -401,6 +418,11 @@ public interface Source<T> {
     @Override
     public void push(List<FormStatus> forms, TerminationFuture terminationFuture) {
       throw new BriefcaseException("Can't push to this source");
+    }
+
+    @Override
+    public boolean canBeReloaded() {
+      return false;
     }
 
     @Override

--- a/src/org/opendatakit/briefcase/ui/reused/source/SourcePanel.java
+++ b/src/org/opendatakit/briefcase/ui/reused/source/SourcePanel.java
@@ -48,6 +48,7 @@ public class SourcePanel {
     this.selectView = selectView;
 
     showView.onReset(this::reset);
+    showView.onReload(this::reload);
 
     container.navigateTo(SELECT);
   }
@@ -55,7 +56,7 @@ public class SourcePanel {
   public static SourcePanel pull(Http http) {
     SourcePanel panel = new SourcePanel(
         new SelectSourceForm("Pull from"),
-        ShowSourceForm.empty("Pulling from")
+        ShowSourceForm.pull("Pulling from")
     );
     panel.addSource(Source.aggregatePull(http, panel::triggerOnSource));
     panel.addSource(Source.customDir(panel::triggerOnSource));
@@ -66,7 +67,7 @@ public class SourcePanel {
   public static SourcePanel push(Http http) {
     SourcePanel panel = new SourcePanel(
         new SelectSourceForm("Push to"),
-        ShowSourceForm.empty("Pushing to")
+        ShowSourceForm.push("Pushing to")
     );
     panel.addSource(Source.aggregatePush(http, panel::triggerOnSource));
     return panel;
@@ -75,6 +76,10 @@ public class SourcePanel {
   private void reset() {
     container.navigateTo(SELECT);
     triggerReset();
+  }
+
+  private void reload() {
+    triggerOnSource(selectView.getSelectedSource().get());
   }
 
   private void addSource(Source source) {


### PR DESCRIPTION
This closes issue #612 

#### What has been done to verify that this works as intended?
A form was both added and deleted from the Aggregate server. After each step the reload button was pressed and the 'pull' view reflected the new state of the Aggregate server.

#### Why is this the best possible solution? Were any other approaches considered?
This is the first implementation and is open to discussion.

#### Are there any risks to merging this code? If so, what are they?
There are no automated tests written to cover this functionality. I'm open to hear about how this feature can be automatically tested.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
I'm not sure if this feature mandates an update to the documentation.