### PR TITLE
Issue 625 export subs without instance id

### DIFF
--- a/src/org/opendatakit/briefcase/export/CsvSubmissionMappers.java
+++ b/src/org/opendatakit/briefcase/export/CsvSubmissionMappers.java
@@ -20,6 +20,7 @@ import static java.text.DateFormat.getDateTimeInstance;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
+
 import static org.javarosa.core.model.DataType.DATE;
 import static org.javarosa.core.model.DataType.DATE_TIME;
 import static org.javarosa.core.model.DataType.GEOPOINT;
@@ -33,6 +34,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import org.javarosa.core.model.DataType;
 import org.javarosa.core.model.SelectChoice;
 import org.opendatakit.briefcase.reused.Pair;
@@ -55,13 +57,13 @@ final class CsvSubmissionMappers {
       List<String> cols = new ArrayList<>();
       cols.add(encode(submission.getSubmissionDate().map(CsvSubmissionMappers::format).orElse(null), false));
       cols.addAll(formDefinition.getModel().flatMap(field -> getMapper(field, configuration.resolveExplodeChoiceLists()).apply(
-          submission.getInstanceId(),
+          submission.getInstanceId(formDefinition.hasRepeatableFields()),
           submission.getWorkingDir(),
           field,
           submission.findElement(field.getName()),
           configuration
       ).map(value -> encodeMainValue(field, value))).collect(Collectors.toList()));
-      cols.add(submission.getInstanceId());
+      cols.add(submission.getInstanceId(formDefinition.hasRepeatableFields()));
       if (formDefinition.isFileEncryptedForm())
         cols.add(submission.getValidationStatus().asCsvValue());
       return CsvLines.of(
@@ -83,15 +85,15 @@ final class CsvSubmissionMappers {
         submission.getElements(groupModel.fqn()).stream().map(element -> {
           List<String> cols = new ArrayList<>();
           cols.addAll(groupModel.flatMap(field -> getMapper(field, configuration.resolveExplodeChoiceLists()).apply(
-              element.getCurrentLocalId(submission.getInstanceId()),
+              element.getCurrentLocalId(submission.getInstanceId(true)),
               submission.getWorkingDir(),
               field,
               element.findElement(field.getName()),
               configuration
           ).map(CsvSubmissionMappers::encodeRepeatValue)).collect(toList()));
-          cols.add(encode(element.getParentLocalId(submission.getInstanceId()), false));
-          cols.add(encode(element.getCurrentLocalId(submission.getInstanceId()), false));
-          cols.add(encode(element.getGroupLocalId(submission.getInstanceId()), false));
+          cols.add(encode(element.getParentLocalId(submission.getInstanceId(true)), false));
+          cols.add(encode(element.getCurrentLocalId(submission.getInstanceId(true)), false));
+          cols.add(encode(element.getGroupLocalId(submission.getInstanceId(true)), false));
           return cols.stream().collect(joining(","));
         }).collect(toList())
     );

--- a/src/org/opendatakit/briefcase/export/ExportToCsv.java
+++ b/src/org/opendatakit/briefcase/export/ExportToCsv.java
@@ -84,6 +84,12 @@ public class ExportToCsv {
         .map(path -> parseSubmission(path, formDef.isFileEncryptedForm(), configuration.getPrivateKey(), onParsingError))
         .filter(Optional::isPresent)
         .map(Optional::get)
+        .filter(submission -> {
+          boolean valid = submission.isValid();
+          if (!valid)
+            onParsingError.accept(submission.getPath());
+          return valid;
+        })
         // Track the submission
         .peek(s -> exportTracker.incAndReport())
         // Use the mapper of each Csv instance to map the submission into their respective outputs

--- a/src/org/opendatakit/briefcase/export/ExportToCsv.java
+++ b/src/org/opendatakit/briefcase/export/ExportToCsv.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiConsumer;
 import org.bushe.swing.event.EventBus;
 import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
 import org.opendatakit.briefcase.reused.BriefcaseException;
@@ -76,7 +75,7 @@ public class ExportToCsv {
 
     csvs.forEach(Csv::prepareOutputFiles);
 
-    BiConsumer<Path, String> onParsingError = buildParsingErrorCallback(configuration.getErrorsDir(formDef.getFormName()));
+    SubmissionExportErrorCallback onParsingError = buildParsingErrorCallback(configuration.getErrorsDir(formDef.getFormName()));
 
     // Generate csv lines grouped by the fqdn of the model they belong to
     Map<String, CsvLines> csvLinesPerModel = submissionFiles.parallelStream()
@@ -124,7 +123,7 @@ public class ExportToCsv {
     return exportOutcome;
   }
 
-  private static BiConsumer<Path, String> buildParsingErrorCallback(Path errorsDir) {
+  private static SubmissionExportErrorCallback buildParsingErrorCallback(Path errorsDir) {
     AtomicInteger errorSeq = new AtomicInteger(1);
     // Remove errors from a previous export attempt
     if (exists(errorsDir))

--- a/src/org/opendatakit/briefcase/export/ExportToCsv.java
+++ b/src/org/opendatakit/briefcase/export/ExportToCsv.java
@@ -153,7 +153,7 @@ public class ExportToCsv {
       if (!exists(errorsDir))
         createDirectories(errorsDir);
       copy(path, errorsDir.resolve("failed_submission_" + errorSeq.getAndIncrement() + ".xml"));
-      log.info("Failed submission XML file ({}) moved to the output errors directory at {}", message, errorsDir);
+      log.warn("A submission has been excluded from the export output due to some problem ({}). If you didn't expect this, please ask for support at https://forum.opendatakit.org/c/support", message);
     };
   }
 

--- a/src/org/opendatakit/briefcase/export/ExportToCsv.java
+++ b/src/org/opendatakit/briefcase/export/ExportToCsv.java
@@ -19,6 +19,7 @@ package org.opendatakit.briefcase.export;
 import static java.util.stream.Collectors.groupingByConcurrent;
 import static java.util.stream.Collectors.reducing;
 import static java.util.stream.Collectors.toList;
+
 import static org.opendatakit.briefcase.export.ExportOutcome.ALL_EXPORTED;
 import static org.opendatakit.briefcase.export.ExportOutcome.ALL_SKIPPED;
 import static org.opendatakit.briefcase.export.ExportOutcome.SOME_SKIPPED;
@@ -35,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import org.bushe.swing.event.EventBus;
 import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
 import org.opendatakit.briefcase.reused.BriefcaseException;
@@ -69,7 +71,7 @@ public class ExportToCsv {
     //  - one for each repeat group
     List<Csv> csvs = new ArrayList<>();
     csvs.add(Csv.main(formDef, configuration));
-    csvs.addAll(formDef.getModel().getRepeatableFields().stream()
+    csvs.addAll(formDef.getRepeatableFields().stream()
         .map(groupModel -> Csv.repeat(formDef, groupModel, configuration))
         .collect(toList()));
 
@@ -84,7 +86,7 @@ public class ExportToCsv {
         .filter(Optional::isPresent)
         .map(Optional::get)
         .filter(submission -> {
-          boolean valid = submission.isValid();
+          boolean valid = submission.isValid(formDef.hasRepeatableFields());
           if (!valid)
             onParsingError.accept(submission.getPath(), "invalid submission");
           return valid;

--- a/src/org/opendatakit/briefcase/export/Submission.java
+++ b/src/org/opendatakit/briefcase/export/Submission.java
@@ -84,6 +84,10 @@ class Submission {
     return new Submission(path, workingDir, root, metaData, NOT_VALIDATED, cipherFactory, signature);
   }
 
+  public boolean isValid() {
+    return metaData.getInstanceId().isPresent();
+  }
+
   /**
    * Returns the submission's instance ID.
    *

--- a/src/org/opendatakit/briefcase/export/Submission.java
+++ b/src/org/opendatakit/briefcase/export/Submission.java
@@ -84,6 +84,10 @@ class Submission {
     return new Submission(path, workingDir, root, metaData, NOT_VALIDATED, cipherFactory, signature);
   }
 
+  public Path getPath() {
+    return path;
+  }
+
   public boolean isValid() {
     return metaData.getInstanceId().isPresent();
   }

--- a/src/org/opendatakit/briefcase/export/SubmissionExportErrorCallback.java
+++ b/src/org/opendatakit/briefcase/export/SubmissionExportErrorCallback.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.export;
+
+import java.nio.file.Path;
+
+@FunctionalInterface
+public interface SubmissionExportErrorCallback {
+  void accept(Path path, String message);
+}

--- a/src/org/opendatakit/briefcase/export/SubmissionParser.java
+++ b/src/org/opendatakit/briefcase/export/SubmissionParser.java
@@ -40,7 +40,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.CipherInputStream;
@@ -118,9 +118,9 @@ class SubmissionParser {
    *                    {@link Optional#empty()} otherwise
    * @return the {@link Submission} wrapped inside an {@link Optional} when it meets all the
    *     criteria, or {@link Optional#empty()} otherwise
-   * @see #decrypt(Submission, Consumer)
+   * @see #decrypt(Submission, BiConsumer)
    */
-  static Optional<Submission> parseSubmission(Path path, boolean isEncrypted, Optional<PrivateKey> privateKey, Consumer<Path> onParsingError) {
+  static Optional<Submission> parseSubmission(Path path, boolean isEncrypted, Optional<PrivateKey> privateKey, BiConsumer<Path, String> onParsingError) {
     Path workingDir = isEncrypted ? createTempDirectory("briefcase") : path.getParent();
     return parse(path, onParsingError).flatMap(document -> {
       XmlElement root = XmlElement.of(document);
@@ -183,7 +183,7 @@ class SubmissionParser {
   }
 
 
-  private static Optional<Submission> decrypt(Submission submission, Consumer<Path> onParsingError) {
+  private static Optional<Submission> decrypt(Submission submission, BiConsumer<Path, String> onParsingError) {
     List<Path> mediaPaths = submission.getMediaPaths();
 
     if (mediaPaths.size() != submission.countMedia())
@@ -219,7 +219,7 @@ class SubmissionParser {
     }
   }
 
-  private static Optional<Document> parse(Path submission, Consumer<Path> onParsingError) {
+  private static Optional<Document> parse(Path submission, BiConsumer<Path, String> onParsingError) {
     try (InputStream is = Files.newInputStream(submission);
          InputStreamReader isr = new InputStreamReader(is, "UTF-8")) {
       Document tempDoc = new Document();
@@ -230,7 +230,7 @@ class SubmissionParser {
       return Optional.of(tempDoc);
     } catch (IOException | XmlPullParserException e) {
       log.error("Can't parse submission", e);
-      onParsingError.accept(submission);
+      onParsingError.accept(submission, "parsing error");
       return Optional.empty();
     }
   }

--- a/src/org/opendatakit/briefcase/export/SubmissionParser.java
+++ b/src/org/opendatakit/briefcase/export/SubmissionParser.java
@@ -40,7 +40,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.BiConsumer;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.CipherInputStream;
@@ -118,11 +117,11 @@ class SubmissionParser {
    *                    {@link Optional#empty()} otherwise
    * @return the {@link Submission} wrapped inside an {@link Optional} when it meets all the
    *     criteria, or {@link Optional#empty()} otherwise
-   * @see #decrypt(Submission, BiConsumer)
+   * @see #decrypt(Submission, SubmissionExportErrorCallback)
    */
-  static Optional<Submission> parseSubmission(Path path, boolean isEncrypted, Optional<PrivateKey> privateKey, BiConsumer<Path, String> onParsingError) {
+  static Optional<Submission> parseSubmission(Path path, boolean isEncrypted, Optional<PrivateKey> privateKey, SubmissionExportErrorCallback onError) {
     Path workingDir = isEncrypted ? createTempDirectory("briefcase") : path.getParent();
-    return parse(path, onParsingError).flatMap(document -> {
+    return parse(path, onError).flatMap(document -> {
       XmlElement root = XmlElement.of(document);
       SubmissionMetaData metaData = new SubmissionMetaData(root);
 
@@ -142,7 +141,7 @@ class SubmissionParser {
       Submission submission = Submission.notValidated(path, workingDir, root, metaData, cipherFactory, signature);
       return isEncrypted
           // If it's encrypted, validate the parsed contents with the attached signature
-          ? decrypt(submission, onParsingError).map(s -> s.copy(ValidationStatus.of(isValid(submission, s))))
+          ? decrypt(submission, onError).map(s -> s.copy(ValidationStatus.of(isValid(submission, s))))
           // Return the original submission otherwise
           : Optional.of(submission);
     });
@@ -183,7 +182,7 @@ class SubmissionParser {
   }
 
 
-  private static Optional<Submission> decrypt(Submission submission, BiConsumer<Path, String> onParsingError) {
+  private static Optional<Submission> decrypt(Submission submission, SubmissionExportErrorCallback onError) {
     List<Path> mediaPaths = submission.getMediaPaths();
 
     if (mediaPaths.size() != submission.countMedia())
@@ -197,7 +196,7 @@ class SubmissionParser {
     Path decryptedSubmission = decryptFile(submission.getEncryptedFilePath(), submission.getWorkingDir(), submission.getNextCipher());
 
     // Parse the document and, if everything goes well, return a decripted copy of the submission
-    return parse(decryptedSubmission, onParsingError).map(document -> submission.copy(decryptedSubmission, document));
+    return parse(decryptedSubmission, onError).map(document -> submission.copy(decryptedSubmission, document));
   }
 
   private static Path decryptFile(Path encFile, Path workingDir, Cipher cipher) {
@@ -219,7 +218,7 @@ class SubmissionParser {
     }
   }
 
-  private static Optional<Document> parse(Path submission, BiConsumer<Path, String> onParsingError) {
+  private static Optional<Document> parse(Path submission, SubmissionExportErrorCallback onError) {
     try (InputStream is = Files.newInputStream(submission);
          InputStreamReader isr = new InputStreamReader(is, "UTF-8")) {
       Document tempDoc = new Document();
@@ -230,7 +229,7 @@ class SubmissionParser {
       return Optional.of(tempDoc);
     } catch (IOException | XmlPullParserException e) {
       log.error("Can't parse submission", e);
-      onParsingError.accept(submission, "parsing error");
+      onError.accept(submission, "parsing error");
       return Optional.empty();
     }
   }

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -18,6 +18,7 @@ package org.opendatakit.briefcase.ui.export;
 import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
+
 import static org.opendatakit.briefcase.export.ExportForms.buildCustomConfPrefix;
 import static org.opendatakit.briefcase.model.FormStatus.TransferType.EXPORT;
 import static org.opendatakit.briefcase.ui.ODKOptionPane.showErrorDialog;
@@ -26,6 +27,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
+
 import org.bushe.swing.event.annotation.AnnotationProcessor;
 import org.bushe.swing.event.annotation.EventSubscriber;
 import org.opendatakit.briefcase.export.ExportConfiguration;
@@ -198,7 +200,7 @@ public class ExportPanel {
                   false
               ));
             BriefcaseFormDefinition formDefinition = (BriefcaseFormDefinition) form.getFormDefinition();
-            ExportToCsv.export(FormDefinition.from(formDefinition), configuration);
+            ExportToCsv.export(FormDefinition.from(formDefinition), configuration, analytics);
           });
     } catch (Throwable t) {
       log.error("Error while exporting forms", t);

--- a/test/java/org/opendatakit/briefcase/export/SubmissionTest.java
+++ b/test/java/org/opendatakit/briefcase/export/SubmissionTest.java
@@ -22,14 +22,13 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
-import java.util.function.BiConsumer;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
 @SuppressWarnings({"OptionalGetWithoutIsPresent", "checkstyle:ParameterName"})
 public class SubmissionTest {
 
-  private static final BiConsumer<Path, String> NO_OP = (__, ___) -> {
+  private static final SubmissionExportErrorCallback NO_OP = (__, ___) -> {
   };
 
   @Test

--- a/test/java/org/opendatakit/briefcase/export/SubmissionTest.java
+++ b/test/java/org/opendatakit/briefcase/export/SubmissionTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -36,14 +37,22 @@ public class SubmissionTest {
     Path path = Files.createTempFile("submission_", ".xml");
     Files.write(path, "<data id=\"simple-form\" instanceID=\"123456789\" xmlns=\"http://opendatakit.org/submissions\"><field>value</field></data>".getBytes());
     Submission sub = SubmissionParser.parseSubmission(path, false, Optional.empty(), NO_OP).get();
-    assertThat(sub.isValid(), Matchers.is(true));
+    assertThat(sub.isValid(false), Matchers.is(true));
   }
 
   @Test
-  public void it_is_not_valid_if_it_does_not_have_instance_id() throws IOException {
+  public void it_is_valid_if_it_does_not_have_instance_id_and_it_does_not_have_repeat_groups() throws IOException {
     Path path = Files.createTempFile("submission_", ".xml");
     Files.write(path, "<data id=\"simple-form\" xmlns=\"http://opendatakit.org/submissions\"><field>value</field></data>".getBytes());
     Submission sub = SubmissionParser.parseSubmission(path, false, Optional.empty(), NO_OP).get();
-    assertThat(sub.isValid(), Matchers.is(false));
+    assertThat(sub.isValid(false), Matchers.is(true));
+  }
+
+  @Test
+  public void it_is_not_valid_if_it_does_not_have_instance_id_and_it_has_repeat_groups() throws IOException {
+    Path path = Files.createTempFile("submission_", ".xml");
+    Files.write(path, "<data id=\"simple-form\" xmlns=\"http://opendatakit.org/submissions\"><field>value</field></data>".getBytes());
+    Submission sub = SubmissionParser.parseSubmission(path, false, Optional.empty(), NO_OP).get();
+    assertThat(sub.isValid(true), Matchers.is(false));
   }
 }

--- a/test/java/org/opendatakit/briefcase/export/SubmissionTest.java
+++ b/test/java/org/opendatakit/briefcase/export/SubmissionTest.java
@@ -22,14 +22,14 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
 @SuppressWarnings({"OptionalGetWithoutIsPresent", "checkstyle:ParameterName"})
 public class SubmissionTest {
 
-  private static final Consumer<Path> NO_OP = __ -> {
+  private static final BiConsumer<Path, String> NO_OP = (__, ___) -> {
   };
 
   @Test

--- a/test/java/org/opendatakit/briefcase/export/SubmissionTest.java
+++ b/test/java/org/opendatakit/briefcase/export/SubmissionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.export;
+
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.function.Consumer;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+@SuppressWarnings({"OptionalGetWithoutIsPresent", "checkstyle:ParameterName"})
+public class SubmissionTest {
+
+  private static final Consumer<Path> NO_OP = __ -> {
+  };
+
+  @Test
+  public void it_is_valid_if_it_has_instance_id() throws IOException {
+    Path path = Files.createTempFile("submission_", ".xml");
+    Files.write(path, "<data id=\"simple-form\" instanceID=\"123456789\" xmlns=\"http://opendatakit.org/submissions\"><field>value</field></data>".getBytes());
+    Submission sub = SubmissionParser.parseSubmission(path, false, Optional.empty(), NO_OP).get();
+    assertThat(sub.isValid(), Matchers.is(true));
+  }
+
+  @Test
+  public void it_is_not_valid_if_it_does_not_have_instance_id() throws IOException {
+    Path path = Files.createTempFile("submission_", ".xml");
+    Files.write(path, "<data id=\"simple-form\" xmlns=\"http://opendatakit.org/submissions\"><field>value</field></data>".getBytes());
+    Submission sub = SubmissionParser.parseSubmission(path, false, Optional.empty(), NO_OP).get();
+    assertThat(sub.isValid(), Matchers.is(false));
+  }
+}


### PR DESCRIPTION
Addresses #625

This PR fixes a regression that produces an error when some of the exported submissions have no instance ID.

Now, no error will be shown and the invalid submissions will be excluded and copied to the error output directory.

The definition of a valid submission is:
- The form it belongs to doesn't define repeat groups
OR 
- it has an instance id

This means that for a submission with repeat groups to be valid, it needs to have an instance id. This makes sense because, otherwise, it wouldn't be possible to link the lines from the output repeat CSV file to their corresponding lines on the on the main CSV output files.

When a form doesn't define repeat groups, though, it's perfectly reasonable to not have instance ids, and the output CSV file will have blank values on that column.

#### What has been done to verify that this works as intended?
(Provided you have pulled some form that defines repeat groups with submissions)
- If all the submissions have instance IDs, edit one and remove it
- Export the form
- Verify that no error is shown on the UI
- Verify that the details dialog tells that not all the submissions have been exported
- Verify that there are some submissions missing in the output files
- Verify that there are some submissions in the errors output directory

(Provided you have pulled another form that doesn't define repeat groups with submissions)
- If all the submissions have instance IDs, edit one and remove it
- Export the form
- Verify that no error is shown on the UI
- Verify that the details dialog tells that all the submissions have been exported
- Verify that there are no submissions missing in the output files
- Verify that there are no submissions in the errors output directory

#### Why is this the best possible solution? Were any other approaches considered?
This is the narrowest change to reuse the current system to handle errors while exporting submissions, by adding a new error case.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.