### PR TITLE
Issue 628 change export button behavior

### DIFF
--- a/src/org/opendatakit/briefcase/export/Csv.java
+++ b/src/org/opendatakit/briefcase/export/Csv.java
@@ -3,6 +3,7 @@ package org.opendatakit.briefcase.export;
 import static java.nio.file.StandardOpenOption.APPEND;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+
 import static org.opendatakit.briefcase.export.CsvSubmissionMappers.getMainHeader;
 import static org.opendatakit.briefcase.export.CsvSubmissionMappers.getRepeatHeader;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.write;
@@ -11,7 +12,7 @@ import static org.opendatakit.briefcase.util.StringUtils.stripIllegalChars;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
-import org.opendatakit.briefcase.reused.BriefcaseException;
+
 import org.opendatakit.briefcase.reused.UncheckedFiles;
 
 /**
@@ -39,9 +40,9 @@ class Csv {
    * Factory for the main CSV export file of a form.
    */
   static Csv main(FormDefinition formDefinition, ExportConfiguration configuration) {
-    Path output = configuration.getExportDir()
-        .orElseThrow(BriefcaseException::new)
-        .resolve(configuration.getExportFileName().orElse(stripIllegalChars(formDefinition.getFormName()) + ".csv"));
+    Path output = configuration.getExportDir().resolve(
+        configuration.getExportFileName().orElse(stripIllegalChars(formDefinition.getFormName()) + ".csv")
+    );
     return new Csv(
         formDefinition.getModel().fqn(),
         getMainHeader(formDefinition.getModel(), formDefinition.isFileEncryptedForm(), configuration.resolveExplodeChoiceLists()),
@@ -59,9 +60,9 @@ class Csv {
     String repeatFileNameBase = configuration.getExportFileName()
         .map(UncheckedFiles::stripFileExtension)
         .orElse(stripIllegalChars(formDefinition.getFormName()));
-    Path output = configuration.getExportDir()
-        .orElseThrow(BriefcaseException::new)
-        .resolve(repeatFileNameBase + "-" + groupModel.getName() + ".csv");
+    Path output = configuration.getExportDir().resolve(
+        repeatFileNameBase + "-" + groupModel.getName() + ".csv"
+    );
     return new Csv(
         groupModel.fqn(),
         getRepeatHeader(groupModel, configuration.resolveExplodeChoiceLists()),

--- a/src/org/opendatakit/briefcase/export/ExportConfiguration.java
+++ b/src/org/opendatakit/briefcase/export/ExportConfiguration.java
@@ -42,6 +42,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
 import org.bouncycastle.openssl.PEMReader;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.reused.BriefcaseException;
@@ -418,10 +419,10 @@ public class ExportConfiguration {
     try (PEMReader rdr = new PEMReader(new BufferedReader(new InputStreamReader(Files.newInputStream(pemFile), "UTF-8")))) {
       Optional<Object> o = Optional.ofNullable(rdr.readObject());
       if (!o.isPresent())
-        return ErrorsOr.errors("The supplied file is not in PEM format.");
+        return ErrorsOr.errors("The supplied file is not in PEM format");
       Optional<PrivateKey> pk = extractPrivateKey(o.get());
       if (!pk.isPresent())
-        return ErrorsOr.errors("The supplied file does not contain a private key.");
+        return ErrorsOr.errors("The supplied file does not contain a private key");
       return ErrorsOr.some(pk.get());
     } catch (IOException e) {
       return ErrorsOr.errors("Briefcase can't read the provided file: " + e.getMessage());

--- a/src/org/opendatakit/briefcase/export/ExportConfiguration.java
+++ b/src/org/opendatakit/briefcase/export/ExportConfiguration.java
@@ -166,9 +166,8 @@ public class ExportConfiguration {
     );
   }
 
-  // TODO Change this to return a Path or throw a BriefcaseException (we always do that on calling sites)
-  public Optional<Path> getExportDir() {
-    return exportDir;
+  public Path getExportDir() {
+    return exportDir.orElseThrow(BriefcaseException::new);
   }
 
   public ExportConfiguration setExportDir(Path path) {
@@ -189,19 +188,9 @@ public class ExportConfiguration {
     return pemFile.isPresent();
   }
 
-  // TODO Remove this (only used in tests)
-  public Optional<LocalDate> getStartDate() {
-    return startDate;
-  }
-
   public ExportConfiguration setStartDate(LocalDate date) {
     this.startDate = Optional.ofNullable(date);
     return this;
-  }
-
-  // TODO Remove this (only used in tests)
-  public Optional<LocalDate> getEndDate() {
-    return endDate;
   }
 
   public ExportConfiguration setEndDate(LocalDate date) {

--- a/src/org/opendatakit/briefcase/export/ExportToCsv.java
+++ b/src/org/opendatakit/briefcase/export/ExportToCsv.java
@@ -39,7 +39,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.bushe.swing.event.EventBus;
 import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
-import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.ui.reused.Analytics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,7 +78,7 @@ public class ExportToCsv {
     List<Path> submissionFiles = getListOfSubmissionFiles(formDef, configuration.getDateRange());
     exportTracker.trackTotal(submissionFiles.size());
 
-    createDirectories(configuration.getExportDir().orElseThrow(BriefcaseException::new));
+    createDirectories(configuration.getExportDir());
 
     // Prepare the list of csv files we will export:
     //  - one for the main instance

--- a/src/org/opendatakit/briefcase/model/FormStatus.java
+++ b/src/org/opendatakit/briefcase/model/FormStatus.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2011 University of Washington.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -21,7 +21,10 @@ public class FormStatus {
 
   public static final int STATUS_HISTORY_MAX_BYTES = 1024 * 1024;
 
-  public enum TransferType { GATHER, UPLOAD, EXPORT };
+  public enum TransferType {
+    GATHER, UPLOAD, EXPORT
+  }
+
   private final TransferType transferType;
   private boolean isSelected = false;
   private IFormDefinition form;
@@ -37,7 +40,7 @@ public class FormStatus {
   public synchronized TransferType getTransferType() {
     return transferType;
   }
-  
+
   public synchronized boolean isSelected() {
     return isSelected;
   }
@@ -77,7 +80,7 @@ public class FormStatus {
   public synchronized String getStatusHistory() {
     return statusHistory.toString();
   }
-  
+
   public synchronized boolean isSuccessful() {
     return isSuccessful;
   }
@@ -88,5 +91,13 @@ public class FormStatus {
 
   public synchronized IFormDefinition getFormDefinition() {
     return form;
+  }
+
+  public boolean isEncrypted() {
+    return ((BriefcaseFormDefinition) form).isFileEncryptedForm();
+  }
+
+  public String getFormId() {
+    return form.getFormId();
   }
 }

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -75,13 +75,11 @@ public class ExportPanel {
       forms.updateDefaultConfiguration(conf);
       preferences.removeAll(ExportConfiguration.keys());
       preferences.putAll(conf.asMap());
-      updateExportButton();
     });
 
     form.onDefaultConfReset(() -> {
       forms.updateDefaultConfiguration(ExportConfiguration.empty());
       preferences.removeAll(ExportConfiguration.keys());
-      updateExportButton();
     });
 
     forms.onSuccessfulExport((String formId, LocalDateTime exportDateTime) ->
@@ -90,7 +88,6 @@ public class ExportPanel {
 
     form.onChange(() -> {
       updateCustomConfPreferences();
-      updateExportButton();
       updateSelectButtons();
     });
 
@@ -106,7 +103,6 @@ public class ExportPanel {
       }
     });
 
-    updateExportButton();
     updateSelectButtons();
   }
 
@@ -136,13 +132,6 @@ public class ExportPanel {
     forms.getCustomConfigurations().forEach((formId, configuration) ->
         preferences.putAll(configuration.asMap(buildCustomConfPrefix(formId)))
     );
-  }
-
-  private void updateExportButton() {
-    if (forms.someSelected() && forms.allSelectedFormsHaveConfiguration())
-      form.enableExport();
-    else
-      form.disableExport();
   }
 
   private void updateSelectButtons() {

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -125,8 +125,9 @@ public class ExportPanel {
         errors.add("- The form " + formStatus.getFormName() + " is encrypted. Please, configure a PEM file.");
 
       if (needsPemFile && conf.isPemFilePresent())
-        for (String error : ExportConfiguration.readPemFile(conf.getPemFile().orElseThrow(BriefcaseException::new)).getErrors())
-          errors.add("- Can't read the PEM file for form " + formStatus.getFormName() + ": " + error + ". Please, review configurations.");
+        ExportConfiguration
+            .readPemFile(conf.getPemFile())
+            .ifError(error -> errors.add("- Can't read the PEM file for form " + formStatus.getFormName() + ": " + error + ". Please, review configurations."));
     }
     return errors;
   }

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -92,14 +92,16 @@ public class ExportPanel {
     });
 
     form.onExport(() -> {
-      form.setExporting();
-      List<String> errors = getErrors();
-      if (errors.isEmpty()) {
-        new Thread(this::export).start();
-      } else {
-        analytics.event("Export", "Export", "Configuration errors", null);
-        showErrorDialog(getForm().getContainer(), errors.stream().collect(joining("\n")), "Export errors");
-        form.unsetExporting();
+      if (forms.someSelected() && forms.allSelectedFormsHaveConfiguration()) {
+        form.setExporting();
+        List<String> errors = getErrors();
+        if (errors.isEmpty()) {
+          new Thread(this::export).start();
+        } else {
+          analytics.event("Export", "Export", "Configuration errors", null);
+          showErrorDialog(getForm().getContainer(), errors.stream().collect(joining("\n")), "Export errors");
+          form.unsetExporting();
+        }
       }
     });
 

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -24,6 +24,7 @@ import static org.opendatakit.briefcase.model.FormStatus.TransferType.EXPORT;
 import static org.opendatakit.briefcase.ui.ODKOptionPane.showErrorDialog;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
@@ -102,6 +103,14 @@ public class ExportPanel {
           showErrorDialog(getForm().getContainer(), errors.stream().collect(joining("\n")), "Export errors");
           form.unsetExporting();
         }
+      } else {
+        List<String> requirementMessages = new ArrayList<>();
+        requirementMessages.add("You can't start an export process until you solve these issues:");
+        if (!forms.someSelected())
+          requirementMessages.add("- No forms have been selected. Please, select a form.");
+        if (!forms.allSelectedFormsHaveConfiguration())
+          requirementMessages.add("- Some forms are missing their export directory. Please, ensure that there's a default export directory or that you have set one in all custom configurations.");
+        showErrorDialog(form.getContainer(), String.join("\n", requirementMessages), "You can't export yet");
       }
     });
 

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanelForm.form
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanelForm.form
@@ -57,7 +57,6 @@
               <component id="74e1" class="javax.swing.JButton" binding="exportButton">
                 <constraints/>
                 <properties>
-                  <enabled value="false"/>
                   <name value="export"/>
                   <text value="Export"/>
                 </properties>

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanelForm.java
@@ -29,6 +29,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JProgressBar;
 import javax.swing.JScrollPane;
+
 import org.opendatakit.briefcase.export.ExportConfiguration;
 import org.opendatakit.briefcase.export.ExportForms;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
@@ -108,14 +109,6 @@ public class ExportPanelForm {
 
   void onChange(Runnable callback) {
     formsTable.onChange(callback);
-  }
-
-  void enableExport() {
-    exportButton.setEnabled(true);
-  }
-
-  void disableExport() {
-    exportButton.setEnabled(false);
   }
 
   void toggleClearAll() {
@@ -209,7 +202,6 @@ public class ExportPanelForm {
     exportProgressBar.setVisible(false);
     rightActions.add(exportProgressBar);
     exportButton = new JButton();
-    exportButton.setEnabled(false);
     exportButton.setName("export");
     exportButton.setText("Export");
     rightActions.add(exportButton);

--- a/src/org/opendatakit/briefcase/util/ErrorOr.java
+++ b/src/org/opendatakit/briefcase/util/ErrorOr.java
@@ -15,38 +15,38 @@
  */
 package org.opendatakit.briefcase.util;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 // TODO Replace this with an Either<List<String>, T>
-public class ErrorsOr<T> {
-  private final Optional<T> t;
-  private final List<String> errors;
+public class ErrorOr<T> {
+  private final Optional<T> value;
+  private final Optional<String> error;
 
-  public ErrorsOr(Optional<T> t, List<String> errors) {
-    this.t = t;
-    this.errors = errors;
+  private ErrorOr(Optional<T> value, Optional<String> error) {
+    this.value = value;
+    this.error = error;
   }
 
-  public static <U> ErrorsOr<U> some(U u) {
-    return new ErrorsOr<>(Optional.of(u), Collections.emptyList());
+  public static <U> ErrorOr<U> some(U value) {
+    return new ErrorOr<>(Optional.of(value), Optional.empty());
   }
 
-  public static <U> ErrorsOr<U> errors(String... errors) {
-    return new ErrorsOr<>(Optional.empty(), Arrays.asList(errors));
+  public static <U> ErrorOr<U> error(String error) {
+    return new ErrorOr<>(Optional.empty(), Optional.of(error));
   }
 
-  public List<String> getErrors() {
-    return errors;
+  public static <U> ErrorOr<U> from(Optional<U> maybeValue, String errorIfEmpty) {
+    return maybeValue
+        .map(ErrorOr::some)
+        .orElseGet(() -> error(errorIfEmpty));
   }
 
-  public T get() {
-    return t.get();
+  public void ifError(Consumer<String> consumer) {
+    error.ifPresent(consumer);
   }
 
   public Optional<T> asOptional() {
-    return t;
+    return value;
   }
 }

--- a/test/java/org/opendatakit/briefcase/export/ExportConfigurationTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportConfigurationTest.java
@@ -18,9 +18,11 @@ package org.opendatakit.briefcase.export;
 import static java.nio.file.Files.createTempDirectory;
 import static java.nio.file.Files.write;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.opendatakit.briefcase.export.ExportConfiguration.empty;
@@ -94,14 +96,9 @@ public class ExportConfigurationTest {
 
   @Test
   public void knows_how_to_clone_an_instance() {
-    ExportConfiguration clonedConfig = validConfig.copy();
-    assertThat(clonedConfig == validConfig, is(false));
-    assertThat(clonedConfig, is(validConfig));
-    // Pump the coverage up making the test go through the getters as well
-    assertThat(clonedConfig.getExportDir(), is(validConfig.getExportDir()));
-    assertThat(clonedConfig.getPemFile(), is(validConfig.getPemFile()));
-    assertThat(clonedConfig.getStartDate(), is(validConfig.getStartDate()));
-    assertThat(clonedConfig.getEndDate(), is(validConfig.getEndDate()));
+    ExportConfiguration copiedConf = validConfig.copy();
+    assertThat(copiedConf, not(sameInstance(validConfig)));
+    assertThat(copiedConf, equalTo(validConfig));
   }
 
   @Test

--- a/test/java/org/opendatakit/briefcase/export/ExportToCsvEncryptedMediaTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportToCsvEncryptedMediaTest.java
@@ -19,21 +19,19 @@ package org.opendatakit.briefcase.export;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.delete;
 
 import java.nio.file.Path;
-import java.security.PrivateKey;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 public class ExportToCsvEncryptedMediaTest {
   private ExportToCsvScenario scenario;
-  private PrivateKey privateKey;
   private Path pemFile;
 
   @Before
   public void setUp() {
     scenario = ExportToCsvScenario.setUp("encrypted-form-media");
     pemFile = ExportToCsvScenario.getPath("encrypted-form-media-key.pem");
-    privateKey = ExportConfiguration.readPemFile(pemFile).get();
   }
 
   @After

--- a/test/java/org/opendatakit/briefcase/export/ExportToCsvEncryptionTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportToCsvEncryptionTest.java
@@ -17,21 +17,19 @@
 package org.opendatakit.briefcase.export;
 
 import java.nio.file.Path;
-import java.security.PrivateKey;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 public class ExportToCsvEncryptionTest {
   private ExportToCsvScenario scenario;
-  private PrivateKey privateKey;
   private Path pemFile;
 
   @Before
   public void setUp() {
     scenario = ExportToCsvScenario.setUp("encrypted-form");
     pemFile = ExportToCsvScenario.getPath("encrypted-form-key.pem");
-    privateKey = ExportConfiguration.readPemFile(pemFile).get();
   }
 
   @After

--- a/test/java/org/opendatakit/briefcase/ui/export/ExportPanelTest.java
+++ b/test/java/org/opendatakit/briefcase/ui/export/ExportPanelTest.java
@@ -16,7 +16,6 @@
 package org.opendatakit.briefcase.ui.export;
 
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.opendatakit.briefcase.matchers.SwingMatchers.enabled;
 
@@ -33,8 +32,8 @@ public class ExportPanelTest extends AssertJSwingJUnitTestCase {
   }
 
   @Test
-  public void export_button_should_be_disabled_by_default() {
-    assertThat(page.exportButton(), is(not(enabled())));
+  public void export_button_should_be_enabled_by_default() {
+    assertThat(page.exportButton(), is(enabled()));
   }
 
 }

--- a/test/java/org/opendatakit/briefcase/ui/export/ExportPanelUnitTest.java
+++ b/test/java/org/opendatakit/briefcase/ui/export/ExportPanelUnitTest.java
@@ -17,6 +17,7 @@ package org.opendatakit.briefcase.ui.export;
 
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresent;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.opendatakit.briefcase.export.ExportForms.buildCustomConfPrefix;
 import static org.opendatakit.briefcase.export.ExportForms.buildExportDateTimePrefix;
@@ -27,6 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.junit.Test;
 import org.opendatakit.briefcase.export.ExportConfiguration;
 import org.opendatakit.briefcase.export.ExportEvent;
@@ -60,10 +62,9 @@ public class ExportPanelUnitTest {
         FormCache.empty()
     );
 
-    assertThat(ExportConfiguration.load(exportPreferences).getExportDir(), isEmpty());
     exportPanelForm.setDefaultConf(initialDefaultConf.setExportDir(Paths.get(Files.createTempDirectory("briefcase_test").toUri())));
 
-    assertThat(ExportConfiguration.load(exportPreferences).getExportDir(), isPresent());
+    assertThat(ExportConfiguration.load(exportPreferences).getExportDir(), notNullValue());
   }
 
   @Test
@@ -89,12 +90,10 @@ public class ExportPanelUnitTest {
     ExportConfiguration conf = ExportConfiguration.empty();
     conf.setExportDir(Paths.get(Files.createTempDirectory("briefcase_test").toUri()));
 
-    assertThat(ExportConfiguration.load(exportPreferences, buildCustomConfPrefix(formId)).getExportDir(), isEmpty());
-
     forms.putConfiguration(form, conf);
     exportPanelForm.getFormsTable().getViewModel().triggerChange();
 
-    assertThat(ExportConfiguration.load(exportPreferences, buildCustomConfPrefix(formId)).getExportDir(), isPresent());
+    assertThat(ExportConfiguration.load(exportPreferences, buildCustomConfPrefix(formId)).getExportDir(), notNullValue());
   }
 
   @Test

--- a/test/java/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelTest.java
+++ b/test/java/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelTest.java
@@ -18,6 +18,7 @@ package org.opendatakit.briefcase.ui.export.components;
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresent;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.opendatakit.briefcase.matchers.GenericUIMatchers.containsText;
@@ -29,6 +30,7 @@ import static org.opendatakit.briefcase.reused.TriStateBoolean.TRUE;
 import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
 import org.hamcrest.CoreMatchers;
 import org.junit.Ignore;
@@ -111,7 +113,7 @@ public class ConfigurationPanelTest extends AssertJSwingJUnitTestCase {
     component = ConfigurationPanelPageObject.setUpDefaultPanel(robot(), expectedConfiguration, true, true);
     component.show();
     assertThat(component.exportDirField(), containsText(expectedConfiguration.getExportDir().get().toString()));
-    assertThat(component.pemFileField(), containsText(expectedConfiguration.getPemFile().get().toString()));
+    assertThat(component.pemFileField(), containsText(expectedConfiguration.getPemFile().toString()));
     assertThat(component.startDateField().getDate(), is(expectedConfiguration.getStartDate().get()));
     assertThat(component.endDateField().getDate(), is(expectedConfiguration.getEndDate().get()));
     assertThat(component.pullBeforeField(), is(selected()));
@@ -154,7 +156,7 @@ public class ConfigurationPanelTest extends AssertJSwingJUnitTestCase {
     component.setPullBefore(true);
     ExportConfiguration conf = component.getConfiguration();
     assertThat(conf.getExportDir(), isPresent());
-    assertThat(conf.getPemFile(), isPresent());
+    assertThat(conf.getPemFile(), notNullValue());
     assertThat(conf.getStartDate(), isPresent());
     assertThat(conf.getEndDate(), isPresent());
     assertThat(conf.pullBefore.isEmpty(), is(false));
@@ -187,7 +189,7 @@ public class ConfigurationPanelTest extends AssertJSwingJUnitTestCase {
     component = ConfigurationPanelPageObject.setUpOverridePanel(robot(), expectedConfiguration, true, true);
     component.show();
     assertThat(component.exportDirField(), containsText(expectedConfiguration.getExportDir().get().toString()));
-    assertThat(component.pemFileField(), containsText(expectedConfiguration.getPemFile().get().toString()));
+    assertThat(component.pemFileField(), containsText(expectedConfiguration.getPemFile().toString()));
     assertThat(component.startDateField().getDate(), is(expectedConfiguration.getStartDate().get()));
     assertThat(component.endDateField().getDate(), is(expectedConfiguration.getEndDate().get()));
     assertThat(component.pullBeforeOverrideField().get(), is(TRUE));
@@ -234,7 +236,7 @@ public class ConfigurationPanelTest extends AssertJSwingJUnitTestCase {
     component.setPullBeforeOverride(TRUE);
     ExportConfiguration conf = component.getConfiguration();
     assertThat(conf.getExportDir(), isPresent());
-    assertThat(conf.getPemFile(), isPresent());
+    assertThat(conf.getPemFile(), notNullValue());
     assertThat(conf.getStartDate(), isPresent());
     assertThat(conf.getEndDate(), isPresent());
     assertThat(conf.pullBefore.isEmpty(), is(false));

--- a/test/java/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelTest.java
+++ b/test/java/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelTest.java
@@ -15,7 +15,6 @@
  */
 package org.opendatakit.briefcase.ui.export.components;
 
-import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresent;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -112,10 +111,10 @@ public class ConfigurationPanelTest extends AssertJSwingJUnitTestCase {
     expectedConfiguration.pullBefore.set(true);
     component = ConfigurationPanelPageObject.setUpDefaultPanel(robot(), expectedConfiguration, true, true);
     component.show();
-    assertThat(component.exportDirField(), containsText(expectedConfiguration.getExportDir().get().toString()));
+    assertThat(component.exportDirField(), containsText(expectedConfiguration.getExportDir().toString()));
     assertThat(component.pemFileField(), containsText(expectedConfiguration.getPemFile().toString()));
-    assertThat(component.startDateField().getDate(), is(expectedConfiguration.getStartDate().get()));
-    assertThat(component.endDateField().getDate(), is(expectedConfiguration.getEndDate().get()));
+    assertThat(component.startDateField().getDate(), notNullValue());
+    assertThat(component.endDateField().getDate(), notNullValue());
     assertThat(component.pullBeforeField(), is(selected()));
   }
 
@@ -155,10 +154,10 @@ public class ConfigurationPanelTest extends AssertJSwingJUnitTestCase {
     component.setSomeEndDate();
     component.setPullBefore(true);
     ExportConfiguration conf = component.getConfiguration();
-    assertThat(conf.getExportDir(), isPresent());
+    assertThat(conf.getExportDir(), notNullValue());
     assertThat(conf.getPemFile(), notNullValue());
-    assertThat(conf.getStartDate(), isPresent());
-    assertThat(conf.getEndDate(), isPresent());
+    assertThat(conf.mapStartDate(__ -> true).orElse(false), is(true)); // Kind of indirect check, but this field is not accessible
+    assertThat(conf.mapEndDate(__ -> true).orElse(false), is(true)); // Kind of indirect check, but this field is not accessible
     assertThat(conf.pullBefore.isEmpty(), is(false));
   }
 
@@ -188,10 +187,10 @@ public class ConfigurationPanelTest extends AssertJSwingJUnitTestCase {
     expectedConfiguration.pullBefore.overrideWith(TRUE);
     component = ConfigurationPanelPageObject.setUpOverridePanel(robot(), expectedConfiguration, true, true);
     component.show();
-    assertThat(component.exportDirField(), containsText(expectedConfiguration.getExportDir().get().toString()));
+    assertThat(component.exportDirField(), containsText(expectedConfiguration.getExportDir().toString()));
     assertThat(component.pemFileField(), containsText(expectedConfiguration.getPemFile().toString()));
-    assertThat(component.startDateField().getDate(), is(expectedConfiguration.getStartDate().get()));
-    assertThat(component.endDateField().getDate(), is(expectedConfiguration.getEndDate().get()));
+    assertThat(component.startDateField().getDate(), notNullValue());
+    assertThat(component.endDateField().getDate(), notNullValue());
     assertThat(component.pullBeforeOverrideField().get(), is(TRUE));
   }
 
@@ -235,10 +234,10 @@ public class ConfigurationPanelTest extends AssertJSwingJUnitTestCase {
     component.setSomeEndDate();
     component.setPullBeforeOverride(TRUE);
     ExportConfiguration conf = component.getConfiguration();
-    assertThat(conf.getExportDir(), isPresent());
+    assertThat(conf.getExportDir(), notNullValue());
     assertThat(conf.getPemFile(), notNullValue());
-    assertThat(conf.getStartDate(), isPresent());
-    assertThat(conf.getEndDate(), isPresent());
+    assertThat(conf.mapStartDate(__ -> true).orElse(false), is(true)); // Kind of indirect check, but this field is not accessible
+    assertThat(conf.mapEndDate(__ -> true).orElse(false), is(true)); // Kind of indirect check, but this field is not accessible
     assertThat(conf.pullBefore.isEmpty(), is(false));
   }
 


### PR DESCRIPTION
Closes #628

This PR changes the behavior of the export button on the UI.

Now, the button will be always enabled & clickable by the user, except while an export process is on the way.

When the button is clicked we check that:
- at least one form has been selected
- all selected forms have been configured with an export directory
  - Either by the default configuration
  - Or by custom individual configurations
- all encrypted forms have been configured with a PEM file
  - Either by the default configuration
  - Or by custom individual configurations

If any of these checks fail, we show a dialog informing the user about this and calling for action.

If none of these checks fail, the export process starts.

#### What has been done to verify that this works as intended?
- Tested manually on the UI each check in isolation and combined with unencrypted forms and encrypted forms. Any will do.
- Run automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
We discarded the alternative of showing some label because users could miss it.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.