### PR TITLE
Issue 230 ensure safe dir and file names

### DIFF
--- a/src/org/opendatakit/briefcase/export/ExportConfiguration.java
+++ b/src/org/opendatakit/briefcase/export/ExportConfiguration.java
@@ -22,6 +22,7 @@ import static org.opendatakit.briefcase.ui.MessageStrings.DIR_NOT_EXIST;
 import static org.opendatakit.briefcase.ui.MessageStrings.INVALID_DATE_RANGE_MESSAGE;
 import static org.opendatakit.briefcase.ui.reused.FileChooser.isUnderBriefcaseFolder;
 import static org.opendatakit.briefcase.util.FileSystemUtils.isUnderODKFolder;
+import static org.opendatakit.briefcase.util.StringUtils.stripIllegalChars;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -454,6 +455,6 @@ public class ExportConfiguration {
   }
 
   public Path getErrorsDir(String formName) {
-    return exportDir.map(dir -> dir.resolve(formName + " - errors")).orElseThrow(BriefcaseException::new);
+    return exportDir.map(dir -> dir.resolve(stripIllegalChars(formName) + " - errors")).orElseThrow(BriefcaseException::new);
   }
 }

--- a/src/org/opendatakit/briefcase/ui/pull/FormInstaller.java
+++ b/src/org/opendatakit/briefcase/ui/pull/FormInstaller.java
@@ -22,6 +22,7 @@ import static org.opendatakit.briefcase.reused.UncheckedFiles.createDirectories;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.deleteRecursive;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.exists;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.walk;
+import static org.opendatakit.briefcase.util.StringUtils.stripIllegalChars;
 
 import java.nio.file.Path;
 import java.util.Collections;
@@ -91,7 +92,7 @@ public class FormInstaller {
   }
 
   private static Path getTargetFormDir(Path briefcaseDir, FormStatus form) {
-    return briefcaseDir.resolve("forms").resolve(form.getFormName());
+    return briefcaseDir.resolve("forms").resolve(stripIllegalChars(form.getFormName()));
   }
 
   private static Path getSourceFormFile(FormStatus form) {

--- a/src/org/opendatakit/briefcase/util/FileSystemUtils.java
+++ b/src/org/opendatakit/briefcase/util/FileSystemUtils.java
@@ -132,6 +132,7 @@ public class FileSystemUtils {
     return new File(briefcaseFolder, FORMS_DIR);
   }
 
+  // TODO Ensure this is OK, as opposed to using stripIllegalChars()
   public static String asFilesystemSafeName(String formName) {
     return formName.replaceAll("[/\\\\:]", "").trim();
   }


### PR DESCRIPTION
Closes #230

This ensures that file and directories created by Briefcase don't have illegal characters:
- Export errors output directory
- A form's directory in the storage dir when it's installed individually

This PR also flags legacy places that should be reviewed when refactored.

#### What has been done to verify that this works as intended?
Since the `stripIllegalChars` method has been already tested, no special checks have been made, other than compiling and running the automated test.

#### Why is this the best possible solution? Were any other approaches considered?
We could refactor the legacy places but it doesn't feel worth it:
- It feels risky changing a piece of code that nobody's complained for a long time ago
- We will probably have to change it when we implement planned features like the central Database, or when we refactor the low-level form pulling code to improve the concurrency model

My gut feeling is that changing that now will produce rework.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.