### PR TITLE
603 pull sources

### DIFF
--- a/src/org/opendatakit/briefcase/export/ExportForms.java
+++ b/src/org/opendatakit/briefcase/export/ExportForms.java
@@ -78,7 +78,9 @@ public class ExportForms {
                 .orElseThrow(() -> new RuntimeException("Null value saved for " + passwordKey)).toCharArray()
         ));
 
-      if (appPreferences.hasKey(urlKey) && !appPreferences.hasKey(usernameKey) && !appPreferences.hasKey(passwordKey))
+      if (appPreferences.nullSafeGet(urlKey).filter(s -> !s.isEmpty()).isPresent()
+          && !appPreferences.nullSafeGet(usernameKey).filter(s -> !s.isEmpty()).isPresent()
+          && !appPreferences.nullSafeGet(passwordKey).filter(s -> !s.isEmpty()).isPresent())
         transferSettings.put(formId, new ServerConnectionInfo(
             appPreferences.nullSafeGet(urlKey)
                 .orElseThrow(() -> new RuntimeException("Null value saved for " + urlKey)),

--- a/src/org/opendatakit/briefcase/export/ExportForms.java
+++ b/src/org/opendatakit/briefcase/export/ExportForms.java
@@ -78,6 +78,13 @@ public class ExportForms {
                 .orElseThrow(() -> new RuntimeException("Null value saved for " + passwordKey)).toCharArray()
         ));
 
+      if (appPreferences.hasKey(urlKey) && !appPreferences.hasKey(usernameKey) && !appPreferences.hasKey(passwordKey))
+        transferSettings.put(formId, new ServerConnectionInfo(
+            appPreferences.nullSafeGet(urlKey)
+                .orElseThrow(() -> new RuntimeException("Null value saved for " + urlKey)),
+            null, null
+        ));
+
     });
     return new ExportForms(
         forms,


### PR DESCRIPTION
Closes #603 

#### What has been done to verify that this works as intended?
I tried to reproduce the issue following the steps mentioned in the issue description. I can't see that issue anymore.
![screenshot from 2018-09-06 12-44-46](https://user-images.githubusercontent.com/5601566/45172469-6c6b7e80-b1d3-11e8-9a0e-ba0a8a35ef4d.png)

Manual testing instructions:
- Ensure that the remember passwords setting is enabled
- Pull a form from an Aggregate server using the anon account (enter no credentials)
- Close Briefcase
- Open Briefcase
- Go to the export tab
- Open the custom conf dialog for the form you've pulled on step 2
- Verify that now you can override the "Pull before export" conf param
  
  On master, you wouldn't be able to do so.

#### Why is this the best possible solution? Were any other approaches considered?
For anonymous account, we check if username and password is null or empty.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.