### PR TITLE
Remove the sentry appender from the prod example conf file

### DIFF
--- a/res/logback.xml.example-release
+++ b/res/logback.xml.example-release
@@ -1,10 +1,4 @@
 <configuration>
-  <appender name="SENTRY" class="io.sentry.logback.SentryAppender">
-    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-      <level>WARN</level>
-    </filter>
-  </appender>
-
   <appender name="ROLLINGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>briefcase.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
@@ -18,7 +12,6 @@
   </appender>
 
   <root level="info">
-    <appender-ref ref="SENTRY" />
     <appender-ref ref="ROLLINGFILE" />
   </root>
 </configuration>


### PR DESCRIPTION
This PR doesn't change Briefcase's behavior.

This PR removes the Sentry appender from the Logback production example conf file, since won't be relying on that to get error reports to Sentry after #564.

#### What has been done to verify that this works as intended?
There are no code changes. Nothing to verify :)

#### Why is this the best possible solution? Were any other approaches considered?
This is just something I forgot to do in #564. It's surfaced after doing a release and realizing that the file still had the appender.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Users won't notice a thing.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.