### PR TITLE
Issue 637 merge audit files

### DIFF
--- a/src/org/opendatakit/briefcase/export/Csv.java
+++ b/src/org/opendatakit/briefcase/export/Csv.java
@@ -73,7 +73,7 @@ class Csv {
         output,
         false,
         configuration.resolveOverwriteExistingFiles(),
-        CsvSubmissionMappers.repeat(groupModel, configuration)
+        CsvSubmissionMappers.repeat(formDefinition, groupModel, configuration)
     );
   }
 

--- a/src/org/opendatakit/briefcase/export/CsvFieldMapper.java
+++ b/src/org/opendatakit/briefcase/export/CsvFieldMapper.java
@@ -36,4 +36,24 @@ interface CsvFieldMapper {
   // TODO Normalize the weird empty/null value encoding scheme and simplify this method to return a Stream<String> of just csv column values
   // TODO Simplify args by passing the ExportConfiguration object
   Stream<Pair<String, String>> apply(String formName, String localId, Path workingDir, Model model, Optional<XmlElement> maybeElement, ExportConfiguration configuration);
+
+  /**
+   * Returns a new mapper, result of composing this mapper with the given mapper
+   *
+   * @see #compose(CsvFieldMapper, CsvFieldMapper)
+   */
+  default CsvFieldMapper andThen(CsvFieldMapper other) {
+    return compose(this, other);
+  }
+
+  /**
+   * Composes two mappers into one that will execute them in order and
+   * return their combined output
+   */
+  static CsvFieldMapper compose(CsvFieldMapper a, CsvFieldMapper b) {
+    return (formName, localId, workingDir, model, maybeElement, configuration) -> Stream.concat(
+        a.apply(formName, localId, workingDir, model, maybeElement, configuration),
+        b.apply(formName, localId, workingDir, model, maybeElement, configuration)
+    );
+  }
 }

--- a/src/org/opendatakit/briefcase/export/CsvFieldMapper.java
+++ b/src/org/opendatakit/briefcase/export/CsvFieldMapper.java
@@ -24,16 +24,16 @@ import org.opendatakit.briefcase.reused.Pair;
  * This Functional Interface represents the operation of transformation of a
  * submission field's value to a stream of CSV key-value pairs.
  * <p>
- * The {@link CsvFieldMapper#apply(String, Path, Model, Optional, ExportConfiguration)} returns
+ * The {@link CsvFieldMapper#apply(String, String, Path, Model, Optional, ExportConfiguration)} returns
  * a list of column name and value pairs because we need to support a weird empty/null
  * value encoding scheme described <a href="https://github.com/opendatakit/briefcase/blob/master/docs/export-format.md#non-empty-value-codification">in the docs</a>.
  * <p>
- * Normally, the {@link CsvFieldMapper#apply(String, Path, Model, Optional, ExportConfiguration)} should return just a
+ * Normally, the {@link CsvFieldMapper#apply(String, String, Path, Model, Optional, ExportConfiguration)} should return just a
  * {@link Stream} of {@link String} values.
  */
 @FunctionalInterface
 interface CsvFieldMapper {
   // TODO Normalize the weird empty/null value encoding scheme and simplify this method to return a Stream<String> of just csv column values
   // TODO Simplify args by passing the ExportConfiguration object
-  Stream<Pair<String, String>> apply(String localId, Path workingDir, Model model, Optional<XmlElement> maybeElement, ExportConfiguration configuration);
+  Stream<Pair<String, String>> apply(String formName, String localId, Path workingDir, Model model, Optional<XmlElement> maybeElement, ExportConfiguration configuration);
 }

--- a/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
+++ b/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
@@ -65,49 +65,19 @@ final class CsvFieldMappers {
 
         String sourceFilename = e.getValue();
 
-        if (!configuration.resolveExportMedia())
-          return Stream.of(Pair.of(e.fqn(), sourceFilename));
-
-        if (!Files.exists(configuration.getExportMediaPath()))
-          createDirectories(configuration.getExportMediaPath());
-
         Path sourceFile = workingDir.resolve(sourceFilename);
 
+        /* We'll deal with this later
         // When the source file doesn't exist, we return the input value
         if (!exists(sourceFile))
           return Stream.of(Pair.of(e.fqn(), Paths.get("media").resolve(sourceFilename).toString()));
+        */
 
         // When the destination file doesn't exist, we copy the source file
         // there and return its path relative to the instance folder
-        Path destinationFile = configuration.getExportMediaPath().resolve(sourceFilename);
-        if (!exists(destinationFile)) {
-          copy(sourceFile, destinationFile);
-          return Stream.of(Pair.of(e.fqn(), Paths.get("media").resolve(destinationFile.getFileName()).toString()));
-        }
-
-        // When the destination file has the same hash as the source file,
-        // we don't do any side-effect and return its path relative to the
-        // instance folder
-        Boolean sameHash = OptionalProduct.all(getMd5Hash(sourceFile), getMd5Hash(destinationFile)).map(Objects::equals).orElse(false);
-        if (sameHash)
-          return Stream.of(Pair.of(e.fqn(), Paths.get("media").resolve(destinationFile.getFileName()).toString()));
-
-        // When the hashes are different, we compute the next sequential suffix for
-        // the a new destination file to avoid overwriting the one we found already
-        // there. We try every number in the sequence until we find one that won't
-        // produce a destination file that exists in the output directory.
-        String namePart = stripFileExtension(sourceFilename);
-        String extPart = getFileExtension(sourceFilename).map(extension -> "." + extension).orElse("");
-        int sequenceSuffix = 2;
-        Path sequentialDestinationFile;
-        do {
-          sequentialDestinationFile = configuration.getExportMediaPath().resolve(String.format("%s-%d%s", namePart, sequenceSuffix++, extPart));
-        } while (exists(sequentialDestinationFile));
-
-        // Now that we have a valid destination file, we copy the source file
-        // there and return its path relative to the instance folder
-        copy(sourceFile, sequentialDestinationFile);
-        return Stream.of(Pair.of(e.fqn(), Paths.get("media").resolve(sequentialDestinationFile.getFileName()).toString()));
+        Path destinationFile = configuration.getExportDir().resolve(formName + " - audit.csv");
+        copy(sourceFile, destinationFile);
+        return Stream.of(Pair.of(e.fqn(), destinationFile.getFileName().toString()));
       })
       .orElse(empty(model.fqn()));
 

--- a/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
+++ b/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
@@ -64,9 +64,11 @@ final class CsvFieldMappers {
       .map(e -> binary(e, workingDir, configuration))
       .orElse(empty(field.fqn()));
 
-  private static CsvFieldMapper AUDIT_MAPPER = BINARY_MAPPER.andThen((formName, localId, workingDir, model, maybeElement, configuration) -> maybeElement
-      .map(e -> audit(formName, localId, workingDir, configuration, e))
-      .orElse(empty(model.fqn())));
+  private static CsvFieldMapper AUDIT_MAPPER = BINARY_MAPPER
+      .andThen((formName, localId, workingDir, model, maybeElement, configuration) -> maybeElement
+          .map(e -> audit(formName, localId, workingDir, configuration, e))
+          .orElse(empty(model.fqn())))
+      .map(output -> output.filter(pair -> !pair.getLeft().contains("-aggregated")));
 
 
   // Register all non-text supported mappers

--- a/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
+++ b/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
@@ -226,13 +226,13 @@ final class CsvFieldMappers {
 
   private static Stream<Pair<String, String>> audit(String formName, String localId, Path workingDir, ExportConfiguration configuration, XmlElement e) {
     if (!e.hasValue())
-      return empty(e.fqn());
+      return empty(e.fqn() + "-aggregated");
 
     Path sourceFile = workingDir.resolve(e.getValue());
 
     // When the source file doesn't exist, we return an empty string
     if (!exists(sourceFile))
-      return Stream.of(Pair.of(e.fqn(), ""));
+      return Stream.of(Pair.of(e.fqn() + "-aggregated", ""));
 
     // Process the audit file contents and append the instance ID column to all lines
     List<String> sourceLines = lines(sourceFile).collect(toList());
@@ -243,7 +243,7 @@ final class CsvFieldMappers {
 
     Path destinationFile = configuration.getAuditPath(formName);
     write(destinationFile, bodyLines, APPEND);
-    return Stream.of(Pair.of(e.fqn(), destinationFile.getFileName().toString()));
+    return Stream.of(Pair.of(e.fqn() + "-aggregated", destinationFile.getFileName().toString()));
   }
 
   private static Stream<Pair<String, String>> repeatableGroup(String localId, Model current, XmlElement element) {

--- a/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
+++ b/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
@@ -86,9 +86,8 @@ final class CsvFieldMappers {
   }
 
   static CsvFieldMapper getMapper(Model field, boolean splitSelectMultiples) {
-    CsvFieldMapper mapper = Optional.ofNullable(mappers.get(field.getDataType()))
-        // If no mapper has been defined, we'll just output the text
-        .orElse(simpleMapper(CsvFieldMappers::text));
+    // If no mapper is available for this field, default to a simple text mapper
+    CsvFieldMapper mapper = Optional.ofNullable(mappers.get(field.getDataType())).orElse(simpleMapper(CsvFieldMappers::text));
     return splitSelectMultiples ? SplitSelectMultiples.decorate(mapper) : mapper;
   }
 

--- a/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
+++ b/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
@@ -57,7 +57,58 @@ final class CsvFieldMappers {
   private static final Map<DataType, CsvFieldMapper> mappers = new HashMap<>();
 
   private static CsvFieldMapper AUDIT_MAPPER = (formName, localId, workingDir, model, maybeElement, configuration) -> maybeElement
-      .map(e -> binary(e, workingDir, configuration))
+      .map(e -> {
+        // TODO We should separate the side effect of writing files to disk from the csv output generation
+
+        if (!e.hasValue())
+          return empty(e.fqn());
+
+        String sourceFilename = e.getValue();
+
+        if (!configuration.resolveExportMedia())
+          return Stream.of(Pair.of(e.fqn(), sourceFilename));
+
+        if (!Files.exists(configuration.getExportMediaPath()))
+          createDirectories(configuration.getExportMediaPath());
+
+        Path sourceFile = workingDir.resolve(sourceFilename);
+
+        // When the source file doesn't exist, we return the input value
+        if (!exists(sourceFile))
+          return Stream.of(Pair.of(e.fqn(), Paths.get("media").resolve(sourceFilename).toString()));
+
+        // When the destination file doesn't exist, we copy the source file
+        // there and return its path relative to the instance folder
+        Path destinationFile = configuration.getExportMediaPath().resolve(sourceFilename);
+        if (!exists(destinationFile)) {
+          copy(sourceFile, destinationFile);
+          return Stream.of(Pair.of(e.fqn(), Paths.get("media").resolve(destinationFile.getFileName()).toString()));
+        }
+
+        // When the destination file has the same hash as the source file,
+        // we don't do any side-effect and return its path relative to the
+        // instance folder
+        Boolean sameHash = OptionalProduct.all(getMd5Hash(sourceFile), getMd5Hash(destinationFile)).map(Objects::equals).orElse(false);
+        if (sameHash)
+          return Stream.of(Pair.of(e.fqn(), Paths.get("media").resolve(destinationFile.getFileName()).toString()));
+
+        // When the hashes are different, we compute the next sequential suffix for
+        // the a new destination file to avoid overwriting the one we found already
+        // there. We try every number in the sequence until we find one that won't
+        // produce a destination file that exists in the output directory.
+        String namePart = stripFileExtension(sourceFilename);
+        String extPart = getFileExtension(sourceFilename).map(extension -> "." + extension).orElse("");
+        int sequenceSuffix = 2;
+        Path sequentialDestinationFile;
+        do {
+          sequentialDestinationFile = configuration.getExportMediaPath().resolve(String.format("%s-%d%s", namePart, sequenceSuffix++, extPart));
+        } while (exists(sequentialDestinationFile));
+
+        // Now that we have a valid destination file, we copy the source file
+        // there and return its path relative to the instance folder
+        copy(sourceFile, sequentialDestinationFile);
+        return Stream.of(Pair.of(e.fqn(), Paths.get("media").resolve(sequentialDestinationFile.getFileName()).toString()));
+      })
       .orElse(empty(model.fqn()));
 
   // Register all non-text supported mappers

--- a/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
+++ b/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
@@ -72,11 +72,9 @@ final class CsvFieldMappers {
 
         Path sourceFile = workingDir.resolve(sourceFilename);
 
-        /* We'll deal with this later
-        // When the source file doesn't exist, we return the input value
+        // When the source file doesn't exist, we return an empty string
         if (!exists(sourceFile))
-          return Stream.of(Pair.of(e.fqn(), Paths.get("media").resolve(sourceFilename).toString()));
-        */
+          return Stream.of(Pair.of(e.fqn(), ""));
 
         // When the destination file doesn't exist, we copy the source file
         // there and return its path relative to the instance folder

--- a/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
+++ b/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
@@ -60,13 +60,14 @@ import org.opendatakit.briefcase.reused.Pair;
 final class CsvFieldMappers {
   private static final Map<DataType, CsvFieldMapper> mappers = new HashMap<>();
 
-  private static CsvFieldMapper AUDIT_MAPPER = (formName, localId, workingDir, model, maybeElement, configuration) -> maybeElement
-      .map(e -> audit(formName, localId, workingDir, configuration, e))
-      .orElse(empty(model.fqn()));
-
   private static final CsvFieldMapper BINARY_MAPPER = (__, ___, workingDir, field, element, configuration) -> element
       .map(e -> binary(e, workingDir, configuration))
       .orElse(empty(field.fqn()));
+
+  private static CsvFieldMapper AUDIT_MAPPER = BINARY_MAPPER.andThen((formName, localId, workingDir, model, maybeElement, configuration) -> maybeElement
+      .map(e -> audit(formName, localId, workingDir, configuration, e))
+      .orElse(empty(model.fqn())));
+
 
   // Register all non-text supported mappers
   static {
@@ -98,7 +99,7 @@ final class CsvFieldMappers {
   static CsvFieldMapper getMapper(Model field, boolean splitSelectMultiples) {
     // If no mapper is available for this field, default to a simple text mapper
     CsvFieldMapper mapper = field.isMetaAudit()
-        ? BINARY_MAPPER.andThen(AUDIT_MAPPER)
+        ? AUDIT_MAPPER
         : Optional.ofNullable(mappers.get(field.getDataType())).orElse(simpleMapper(CsvFieldMappers::text));
     return splitSelectMultiples ? SplitSelectMultiples.decorate(mapper) : mapper;
   }

--- a/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
+++ b/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
@@ -40,7 +40,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.DateFormat;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -236,23 +235,13 @@ final class CsvFieldMappers {
 
     // Process the audit file contents and append the instance ID column to all lines
     List<String> sourceLines = lines(sourceFile).collect(toList());
-    // We prepend a new column header for the instance ID
-    String header = "instance ID," + sourceLines.get(0);
     // We prepend the submission's instance ID to all body lines
     List<String> bodyLines = sourceLines.subList(1, sourceLines.size()).stream()
         .map(line -> localId + "," + line)
         .collect(toList());
 
     Path destinationFile = configuration.getAuditPath(formName);
-    // We could improve this block by first writing the header (if the destination
-    // file doesn't exist) and then *always* appending body lines, but this would
-    if (!Files.exists(destinationFile)) {
-      List<String> lines = new ArrayList<>();
-      lines.add(header);
-      lines.addAll(bodyLines);
-      write(destinationFile, lines);
-    } else
-      write(destinationFile, bodyLines, APPEND);
+    write(destinationFile, bodyLines, APPEND);
     return Stream.of(Pair.of(e.fqn(), destinationFile.getFileName().toString()));
   }
 

--- a/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
+++ b/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
@@ -87,7 +87,10 @@ final class CsvFieldMappers {
 
   static CsvFieldMapper getMapper(Model field, boolean splitSelectMultiples) {
     // If no mapper is available for this field, default to a simple text mapper
-    CsvFieldMapper mapper = Optional.ofNullable(mappers.get(field.getDataType())).orElse(simpleMapper(CsvFieldMappers::text));
+    CsvFieldMapper mapper = field.isMetaAudit()
+        ? mappers.get(DataType.BINARY)
+        : Optional.ofNullable(mappers.get(field.getDataType()))
+        .orElse(simpleMapper(CsvFieldMappers::text));
     return splitSelectMultiples ? SplitSelectMultiples.decorate(mapper) : mapper;
   }
 

--- a/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
+++ b/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
@@ -243,7 +243,7 @@ final class CsvFieldMappers {
         .map(line -> localId + "," + line)
         .collect(toList());
 
-    Path destinationFile = configuration.getExportDir().resolve(formName + " - audit.csv");
+    Path destinationFile = configuration.getAuditPath(formName);
     // We could improve this block by first writing the header (if the destination
     // file doesn't exist) and then *always* appending body lines, but this would
     if (!Files.exists(destinationFile)) {

--- a/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
+++ b/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
@@ -64,6 +64,10 @@ final class CsvFieldMappers {
       .map(e -> audit(formName, localId, workingDir, configuration, e))
       .orElse(empty(model.fqn()));
 
+  private static final CsvFieldMapper BINARY_MAPPER = (__, ___, workingDir, field, element, configuration) -> element
+      .map(e -> binary(e, workingDir, configuration))
+      .orElse(empty(field.fqn()));
+
   // Register all non-text supported mappers
   static {
     // All these are simple, 1 column fields
@@ -75,9 +79,7 @@ final class CsvFieldMappers {
     mappers.put(GEOPOINT, simpleMapper(CsvFieldMappers::geopoint, 4));
 
     // Binary fields require knowledge of the export configuration and working dir
-    mappers.put(BINARY, (__, ___, workingDir, field, element, configuration) -> element
-        .map(e -> binary(e, workingDir, configuration))
-        .orElse(empty(field.fqn())));
+    mappers.put(BINARY, BINARY_MAPPER);
 
     // Null fields encode groups (repeating and non-repeating), therefore,
     // they require the full context

--- a/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
+++ b/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
@@ -98,9 +98,8 @@ final class CsvFieldMappers {
   static CsvFieldMapper getMapper(Model field, boolean splitSelectMultiples) {
     // If no mapper is available for this field, default to a simple text mapper
     CsvFieldMapper mapper = field.isMetaAudit()
-        ? AUDIT_MAPPER
-        : Optional.ofNullable(mappers.get(field.getDataType()))
-        .orElse(simpleMapper(CsvFieldMappers::text));
+        ? BINARY_MAPPER.andThen(AUDIT_MAPPER)
+        : Optional.ofNullable(mappers.get(field.getDataType())).orElse(simpleMapper(CsvFieldMappers::text));
     return splitSelectMultiples ? SplitSelectMultiples.decorate(mapper) : mapper;
   }
 

--- a/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
+++ b/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
@@ -56,6 +56,10 @@ import org.opendatakit.briefcase.reused.Pair;
 final class CsvFieldMappers {
   private static final Map<DataType, CsvFieldMapper> mappers = new HashMap<>();
 
+  private static CsvFieldMapper AUDIT_MAPPER = (formName, localId, workingDir, model, maybeElement, configuration) -> maybeElement
+      .map(e -> binary(e, workingDir, configuration))
+      .orElse(empty(model.fqn()));
+
   // Register all non-text supported mappers
   static {
     // All these are simple, 1 column fields
@@ -88,7 +92,7 @@ final class CsvFieldMappers {
   static CsvFieldMapper getMapper(Model field, boolean splitSelectMultiples) {
     // If no mapper is available for this field, default to a simple text mapper
     CsvFieldMapper mapper = field.isMetaAudit()
-        ? mappers.get(DataType.BINARY)
+        ? AUDIT_MAPPER
         : Optional.ofNullable(mappers.get(field.getDataType()))
         .orElse(simpleMapper(CsvFieldMappers::text));
     return splitSelectMultiples ? SplitSelectMultiples.decorate(mapper) : mapper;

--- a/src/org/opendatakit/briefcase/export/CsvSubmissionMappers.java
+++ b/src/org/opendatakit/briefcase/export/CsvSubmissionMappers.java
@@ -55,6 +55,7 @@ final class CsvSubmissionMappers {
       List<String> cols = new ArrayList<>();
       cols.add(encode(submission.getSubmissionDate().map(CsvSubmissionMappers::format).orElse(null), false));
       cols.addAll(formDefinition.getModel().flatMap(field -> getMapper(field, configuration.resolveSplitSelectMultiples()).apply(
+          formDefinition.getFormName(),
           submission.getInstanceId(formDefinition.hasRepeatableFields()),
           submission.getWorkingDir(),
           field,
@@ -76,13 +77,14 @@ final class CsvSubmissionMappers {
    * Factory that will produce {@link CsvLines} corresponding to any repeat output file
    * of a form.
    */
-  static CsvSubmissionMapper repeat(Model groupModel, ExportConfiguration configuration) {
+  static CsvSubmissionMapper repeat(FormDefinition formDefinition, Model groupModel, ExportConfiguration configuration) {
     return submission -> CsvLines.of(
         groupModel.fqn(),
         submission.getSubmissionDate().orElse(MIN_SUBMISSION_DATE),
         submission.getElements(groupModel.fqn()).stream().map(element -> {
           List<String> cols = new ArrayList<>();
           cols.addAll(groupModel.flatMap(field -> getMapper(field, configuration.resolveSplitSelectMultiples()).apply(
+              formDefinition.getFormName(),
               element.getCurrentLocalId(field, submission.getInstanceId(true)),
               submission.getWorkingDir(),
               field,

--- a/src/org/opendatakit/briefcase/export/ExportConfiguration.java
+++ b/src/org/opendatakit/briefcase/export/ExportConfiguration.java
@@ -454,4 +454,8 @@ public class ExportConfiguration {
   public Path getErrorsDir(String formName) {
     return exportDir.map(dir -> dir.resolve(stripIllegalChars(formName) + " - errors")).orElseThrow(BriefcaseException::new);
   }
+
+  public Path getAuditPath(String formName) {
+    return exportDir.orElseThrow(BriefcaseException::new).resolve(formName + " - audit.csv");
+  }
 }

--- a/src/org/opendatakit/briefcase/export/ExportToCsv.java
+++ b/src/org/opendatakit/briefcase/export/ExportToCsv.java
@@ -91,8 +91,8 @@ public class ExportToCsv {
 
     csvs.forEach(Csv::prepareOutputFiles);
 
-    // Remove the audit output file if it exists and user wants to overwrite files
-    Path audit = configuration.getExportDir().resolve(formDef.getFormName() + " - audit.csv");
+    // Remove the audit output file if it exists
+    Path audit = configuration.getAuditPath(formDef.getFormName());
     if (configuration.resolveOverwriteExistingFiles() && exists(audit))
       delete(audit);
 

--- a/src/org/opendatakit/briefcase/export/ExportToCsv.java
+++ b/src/org/opendatakit/briefcase/export/ExportToCsv.java
@@ -26,6 +26,7 @@ import static org.opendatakit.briefcase.export.SubmissionParser.getListOfSubmiss
 import static org.opendatakit.briefcase.export.SubmissionParser.parseSubmission;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.copy;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.createDirectories;
+import static org.opendatakit.briefcase.reused.UncheckedFiles.delete;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.deleteRecursive;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.exists;
 
@@ -89,6 +90,11 @@ public class ExportToCsv {
         .collect(toList()));
 
     csvs.forEach(Csv::prepareOutputFiles);
+
+    // Remove the audit output file if it exists and user wants to overwrite files
+    Path audit = configuration.getExportDir().resolve(formDef.getFormName() + " - audit.csv");
+    if (configuration.resolveOverwriteExistingFiles() && exists(audit))
+      delete(audit);
 
     // Generate csv lines grouped by the fqdn of the model they belong to
     Map<String, CsvLines> csvLinesPerModel = submissionFiles.parallelStream()

--- a/src/org/opendatakit/briefcase/export/Model.java
+++ b/src/org/opendatakit/briefcase/export/Model.java
@@ -244,7 +244,7 @@ class Model {
     return model.getNumChildren();
   }
 
-  private List<Model> children() {
+  List<Model> children() {
     Set<String> fqns = new HashSet<>();
     List<Model> children = new ArrayList<>(model.getNumChildren());
     for (int i = 0, max = model.getNumChildren(); i < max; i++) {
@@ -271,6 +271,10 @@ class Model {
 
   public boolean isMetaAudit() {
     return model.getName().equals("audit") && model.getParent() != null && model.getParent().getName().equals("meta");
+  }
+
+  public boolean hasChildren() {
+    return model.hasChildren();
   }
 
   // TODO This should be defined in JavaRosa, like the DataType enum

--- a/src/org/opendatakit/briefcase/export/Model.java
+++ b/src/org/opendatakit/briefcase/export/Model.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import org.javarosa.core.model.DataType;
 import org.javarosa.core.model.QuestionDef;
@@ -275,6 +276,22 @@ class Model {
 
   public boolean hasChildren() {
     return model.hasChildren();
+  }
+
+  public boolean hasAuditField() {
+    return children().stream()
+        .filter(modelWithName("meta"))
+        .findFirst()
+        .map(meta -> meta.hasChild("audit"))
+        .orElse(false);
+  }
+
+  public boolean hasChild(String name) {
+    return children().stream().anyMatch(modelWithName(name));
+  }
+
+  private static Predicate<Model> modelWithName(String name) {
+    return child -> child.getName().equals(name);
   }
 
   // TODO This should be defined in JavaRosa, like the DataType enum

--- a/src/org/opendatakit/briefcase/export/Model.java
+++ b/src/org/opendatakit/briefcase/export/Model.java
@@ -269,6 +269,10 @@ class Model {
     return Optional.ofNullable(controls.get(fqn()).getChoices()).orElse(emptyList());
   }
 
+  public boolean isMetaAudit() {
+    return model.getName().equals("audit") && model.getParent() != null && model.getParent().getName().equals("meta");
+  }
+
   // TODO This should be defined in JavaRosa, like the DataType enum
   enum ControlType {
     UNTYPED(-1),

--- a/src/org/opendatakit/briefcase/export/SplitSelectMultiples.java
+++ b/src/org/opendatakit/briefcase/export/SplitSelectMultiples.java
@@ -25,9 +25,9 @@ import org.opendatakit.briefcase.reused.Pair;
 
 class SplitSelectMultiples {
   static CsvFieldMapper decorate(CsvFieldMapper mapper) {
-    return (localId, workingDir, model, element, configuration) -> {
+    return (formName, localId, workingDir, model, element, configuration) -> {
       List<Pair<String, String>> output = new ArrayList<>();
-      output.addAll(mapper.apply(localId, workingDir, model, element, configuration).collect(toList()));
+      output.addAll(mapper.apply(formName, localId, workingDir, model, element, configuration).collect(toList()));
       if (model.isChoiceList()) {
         List<String> values = Arrays.stream(element
             .flatMap(XmlElement::maybeValue)

--- a/src/org/opendatakit/briefcase/reused/UncheckedFiles.java
+++ b/src/org/opendatakit/briefcase/reused/UncheckedFiles.java
@@ -38,6 +38,7 @@ import java.nio.file.attribute.FileAttribute;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
@@ -63,6 +64,10 @@ public class UncheckedFiles {
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
+  }
+
+  public static Path write(Path path, List<String> lines, OpenOption... options) {
+    return write(path, lines.stream(), options);
   }
 
   public static Path write(Path path, Stream<String> lines, OpenOption... options) {
@@ -301,4 +306,11 @@ public class UncheckedFiles {
     write(briefcaseDir.resolve("readme.txt"), README_CONTENTS);
   }
 
+  public static Stream<String> lines(Path path) {
+    try {
+      return Files.lines(path, UTF_8);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
 }

--- a/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
@@ -29,6 +29,7 @@ import static org.opendatakit.briefcase.matchers.PathMatchers.exists;
 import static org.opendatakit.briefcase.matchers.PathMatchers.fileContains;
 import static org.opendatakit.briefcase.matchers.PathMatchers.fileExactlyContains;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.list;
+import static org.opendatakit.briefcase.reused.UncheckedFiles.write;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -155,7 +156,7 @@ public class CsvFieldMappersTest {
   @Test
   public void binary_value_given_user_does_not_want_to_export_media_files() {
     scenario = nonGroup(DataType.BINARY);
-    UncheckedFiles.write(scenario.getWorkDir().resolve("some_file.bin"), UUID.randomUUID().toString());
+    write(scenario.getWorkDir().resolve("some_file.bin"), UUID.randomUUID().toString());
 
     List<Pair<String, String>> outputWithoutMedia = scenario.mapSimpleValue("some_file.bin", false);
 
@@ -167,7 +168,7 @@ public class CsvFieldMappersTest {
   @Test
   public void binary_value_given_user_wants_to_export_media_files() {
     scenario = nonGroup(DataType.BINARY);
-    UncheckedFiles.write(scenario.getWorkDir().resolve("some_file.bin"), UUID.randomUUID().toString());
+    write(scenario.getWorkDir().resolve("some_file.bin"), UUID.randomUUID().toString());
 
     List<Pair<String, String>> outputWithMedia = scenario.mapSimpleValue("some_file.bin", true);
 
@@ -192,7 +193,7 @@ public class CsvFieldMappersTest {
   @Test
   public void binary_value_given_output_file_does_not_exist() {
     scenario = nonGroup(DataType.BINARY);
-    UncheckedFiles.write(scenario.getWorkDir().resolve("some_file.bin"), UUID.randomUUID().toString());
+    write(scenario.getWorkDir().resolve("some_file.bin"), UUID.randomUUID().toString());
 
     List<Pair<String, String>> outputWithMedia = scenario.mapSimpleValue("some_file.bin", true);
 
@@ -211,8 +212,8 @@ public class CsvFieldMappersTest {
   public void binary_value_given_exact_same_output_file_exist() {
     scenario = nonGroup(DataType.BINARY);
     String fileContents = UUID.randomUUID().toString();
-    UncheckedFiles.write(scenario.getWorkDir().resolve("some_file.bin"), fileContents);
-    UncheckedFiles.write(scenario.getOutputMediaDir().resolve("some_file.bin"), fileContents);
+    write(scenario.getWorkDir().resolve("some_file.bin"), fileContents);
+    write(scenario.getOutputMediaDir().resolve("some_file.bin"), fileContents);
 
     List<Pair<String, String>> outputWithMedia = scenario.mapSimpleValue("some_file.bin", true);
 
@@ -230,8 +231,8 @@ public class CsvFieldMappersTest {
   @Test
   public void binary_value_given_different_output_file_exist() {
     scenario = nonGroup(DataType.BINARY);
-    UncheckedFiles.write(scenario.getWorkDir().resolve("some_file.bin"), UUID.randomUUID().toString());
-    UncheckedFiles.write(scenario.getOutputMediaDir().resolve("some_file.bin"), UUID.randomUUID().toString());
+    write(scenario.getWorkDir().resolve("some_file.bin"), UUID.randomUUID().toString());
+    write(scenario.getOutputMediaDir().resolve("some_file.bin"), UUID.randomUUID().toString());
 
     List<Pair<String, String>> outputWithMedia = scenario.mapSimpleValue("some_file.bin", true);
 
@@ -248,9 +249,9 @@ public class CsvFieldMappersTest {
   @Test
   public void binary_value_given_different_output_files_exist() {
     scenario = nonGroup(DataType.BINARY);
-    UncheckedFiles.write(scenario.getWorkDir().resolve("some_file.bin"), UUID.randomUUID().toString());
-    UncheckedFiles.write(scenario.getOutputMediaDir().resolve("some_file.bin"), UUID.randomUUID().toString());
-    UncheckedFiles.write(scenario.getOutputMediaDir().resolve("some_file-2.bin"), UUID.randomUUID().toString());
+    write(scenario.getWorkDir().resolve("some_file.bin"), UUID.randomUUID().toString());
+    write(scenario.getOutputMediaDir().resolve("some_file.bin"), UUID.randomUUID().toString());
+    write(scenario.getOutputMediaDir().resolve("some_file-2.bin"), UUID.randomUUID().toString());
 
     List<Pair<String, String>> outputWithMedia = scenario.mapSimpleValue("some_file.bin", true);
 
@@ -265,7 +266,7 @@ public class CsvFieldMappersTest {
   @Test
   public void audit_fields_write_the_first_submissions_content_to_the_output_audit_file() {
     scenario = Scenario.nonGroup("some-form", DataType.BINARY, "audit", "meta");
-    UncheckedFiles.write(scenario.getWorkDir().resolve("audit.csv"), "line 1");
+    write(scenario.getWorkDir().resolve("audit.csv"), "line 1");
 
     List<Pair<String, String>> output = scenario.mapSimpleValue("audit.csv", true);
     assertThat(output.get(0).getRight(), is(scenario.getFormName() + " - audit.csv"));
@@ -279,7 +280,7 @@ public class CsvFieldMappersTest {
   @Test
   public void audit_data_gets_a_new_column_with_the_instance_ID() {
     scenario = Scenario.nonGroup("some-form", DataType.BINARY, "audit", "meta");
-    UncheckedFiles.write(scenario.getWorkDir().resolve("audit.csv"), "event, node, start, end\nform start,,1536663986578,\n");
+    write(scenario.getWorkDir().resolve("audit.csv"), "event, node, start, end\nform start,,1536663986578,\n");
 
     List<Pair<String, String>> output = scenario.mapSimpleValue("audit.csv", true);
     assertThat(output.get(0).getRight(), is(scenario.getFormName() + " - audit.csv"));
@@ -294,14 +295,14 @@ public class CsvFieldMappersTest {
   public void further_audit_fields_append_their_contents_stripping_the_header() {
     scenario = Scenario.nonGroup("some-form", DataType.BINARY, "audit", "meta");
 
-    UncheckedFiles.write(scenario.getWorkDir().resolve("audit.csv"), "event, node, start, end\nform start,,1536663986578,\n");
+    write(scenario.getWorkDir().resolve("audit.csv"), "event, node, start, end\nform start,,1536663986578,\n");
     scenario.mapSimpleValue("audit.csv", true);
     String firstInstanceID = scenario.getInstanceId();
 
     // Jump to a new submission
     scenario.nextSubmission();
 
-    UncheckedFiles.write(scenario.getWorkDir().resolve("audit.csv"), "event, node, start, end\nform start,,1536664003229,\n", TRUNCATE_EXISTING);
+    write(scenario.getWorkDir().resolve("audit.csv"), "event, node, start, end\nform start,,1536664003229,\n", TRUNCATE_EXISTING);
     scenario.mapSimpleValue("audit.csv", true);
     String secondInstanceID = scenario.getInstanceId();
 

--- a/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
@@ -25,6 +25,7 @@ import static org.opendatakit.briefcase.export.Scenario.nonGroup;
 import static org.opendatakit.briefcase.export.Scenario.nonRepeatGroup;
 import static org.opendatakit.briefcase.export.Scenario.repeatGroup;
 import static org.opendatakit.briefcase.matchers.PathMatchers.exists;
+import static org.opendatakit.briefcase.matchers.PathMatchers.fileContains;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.list;
 
 import java.nio.file.Path;
@@ -36,7 +37,6 @@ import org.javarosa.core.model.DataType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.opendatakit.briefcase.matchers.PathMatchers;
 import org.opendatakit.briefcase.reused.Pair;
 import org.opendatakit.briefcase.reused.UncheckedFiles;
 
@@ -261,19 +261,17 @@ public class CsvFieldMappersTest {
   }
 
   @Test
-  public void audit_field() {
+  public void audit_fields_write_the_first_submissions_content_to_the_output_audit_file() {
     scenario = Scenario.nonGroup("some-form", DataType.BINARY, "audit", "meta");
     UncheckedFiles.write(scenario.getWorkDir().resolve("audit.csv"), "line 1");
 
-    String formName = scenario.getFormName();
-
     List<Pair<String, String>> output = scenario.mapSimpleValue("audit.csv", true);
-    assertThat(output.get(0).getRight(), is(formName + " - audit.csv"));
+    assertThat(output.get(0).getRight(), is(scenario.getFormName() + " - audit.csv"));
 
     Path outputAudit = scenario.getOutputDir().resolve(scenario.getFormName() + " - audit.csv");
 
     assertThat(outputAudit, exists());
-    assertThat(outputAudit, PathMatchers.fileContains("line 1"));
+    assertThat(outputAudit, fileContains("line 1"));
   }
 
   @Test

--- a/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
@@ -273,8 +273,7 @@ public class CsvFieldMappersTest {
 
     List<Pair<String, String>> output = scenario.mapSimpleValue("audit.csv", true);
     assertThat(output, contains(
-        Pair.of("data-audit", "media/audit.csv"),
-        Pair.of("data-audit-aggregated", "some-form - audit.csv")
+        Pair.of("data-audit", "media/audit.csv")
     ));
 
     Path outputAudit = scenario.getOutputDir().resolve(scenario.getFormName() + " - audit.csv");
@@ -290,8 +289,7 @@ public class CsvFieldMappersTest {
 
     List<Pair<String, String>> output = scenario.mapSimpleValue("audit.csv", true);
     assertThat(output, contains(
-        Pair.of("data-audit", "media/audit.csv"),
-        Pair.of("data-audit-aggregated", "some-form - audit.csv")
+        Pair.of("data-audit", "media/audit.csv")
     ));
 
     Path outputAudit = scenario.getOutputDir().resolve(scenario.getFormName() + " - audit.csv");
@@ -326,9 +324,8 @@ public class CsvFieldMappersTest {
     scenario = Scenario.nonGroup("some-form", DataType.BINARY, "audit", "meta");
 
     List<Pair<String, String>> output = scenario.mapSimpleValue("audit.csv", true);
-    assertThat(output, Matchers.containsInAnyOrder(
-        Pair.of("data-audit", "media/audit.csv"),
-        Pair.of("data-audit-aggregated", "")
+    assertThat(output, Matchers.contains(
+        Pair.of("data-audit", "media/audit.csv")
     ));
   }
 

--- a/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
@@ -265,9 +265,9 @@ public class CsvFieldMappersTest {
   }
 
   @Test
-  public void audit_fields_write_the_first_submissions_content_to_the_output_audit_file() {
+  public void audit_fields_append_the_submissions_content_to_the_output_audit_file() {
     scenario = Scenario.nonGroup("some-form", DataType.BINARY, "audit", "meta");
-    write(scenario.getWorkDir().resolve("audit.csv"), "line 1");
+    write(scenario.getWorkDir().resolve("audit.csv"), "event, node, start, end\nform start,,1536663986578,\n");
 
     List<Pair<String, String>> output = scenario.mapSimpleValue("audit.csv", true);
     assertThat(output.get(0).getRight(), is(scenario.getFormName() + " - audit.csv"));
@@ -275,7 +275,7 @@ public class CsvFieldMappersTest {
     Path outputAudit = scenario.getOutputDir().resolve(scenario.getFormName() + " - audit.csv");
 
     assertThat(outputAudit, exists());
-    assertThat(outputAudit, fileContains("line 1"));
+    assertThat(outputAudit, fileContains("form start,,1536663986578,"));
   }
 
   @Test
@@ -289,7 +289,7 @@ public class CsvFieldMappersTest {
     Path outputAudit = scenario.getOutputDir().resolve(scenario.getFormName() + " - audit.csv");
 
     assertThat(outputAudit, exists());
-    assertThat(outputAudit, fileExactlyContains("instance ID,event, node, start, end\n" + scenario.getInstanceId() + ",form start,,1536663986578,\n"));
+    assertThat(outputAudit, fileExactlyContains("instance ID, event, node, start, end\n" + scenario.getInstanceId() + ",form start,,1536663986578,\n"));
   }
 
   @Test
@@ -310,7 +310,7 @@ public class CsvFieldMappersTest {
     Path outputAudit = scenario.getOutputDir().resolve(scenario.getFormName() + " - audit.csv");
 
     assertThat(outputAudit, exists());
-    assertThat(outputAudit, fileContains("instance ID,event, node, start, end\n" + firstInstanceID + ",form start,,1536663986578,\n" + secondInstanceID + ",form start,,1536664003229,\n"));
+    assertThat(outputAudit, fileContains("instance ID, event, node, start, end\n" + firstInstanceID + ",form start,,1536663986578,\n" + secondInstanceID + ",form start,,1536664003229,\n"));
   }
 
   @Test

--- a/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
@@ -259,6 +259,18 @@ public class CsvFieldMappersTest {
   }
 
   @Test
+  public void audit_field() {
+    scenario = Scenario.nonGroup("some-form", DataType.BINARY, "audit", "meta");
+    UncheckedFiles.write(scenario.getWorkDir().resolve("audit.csv"), "line 1");
+
+    String formName = scenario.getFormName();
+
+    List<Pair<String, String>> output = scenario.mapSimpleValue("audit.csv", true);
+    assertThat(output.get(0).getRight(), is(formName + " - audit.csv"));
+//    assertThat(scenario.getOutputDir().resolve(scenario.getFormName() + " - audit.csv"), exists());
+  }
+
+  @Test
   public void repeat_group_value() {
     scenario = repeatGroup("instance_1", DataType.TEXT, 1);
 

--- a/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
@@ -26,6 +26,7 @@ import static org.opendatakit.briefcase.export.Scenario.nonRepeatGroup;
 import static org.opendatakit.briefcase.export.Scenario.repeatGroup;
 import static org.opendatakit.briefcase.matchers.PathMatchers.exists;
 import static org.opendatakit.briefcase.matchers.PathMatchers.fileContains;
+import static org.opendatakit.briefcase.matchers.PathMatchers.fileExactlyContains;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.list;
 
 import java.nio.file.Path;
@@ -272,6 +273,20 @@ public class CsvFieldMappersTest {
 
     assertThat(outputAudit, exists());
     assertThat(outputAudit, fileContains("line 1"));
+  }
+
+  @Test
+  public void audit_data_gets_a_new_column_with_the_instance_ID() {
+    scenario = Scenario.nonGroup("some-form", DataType.BINARY, "audit", "meta");
+    UncheckedFiles.write(scenario.getWorkDir().resolve("audit.csv"), "event, node, start, end\nform start,,1536663986578,\n");
+
+    List<Pair<String, String>> output = scenario.mapSimpleValue("audit.csv", true);
+    assertThat(output.get(0).getRight(), is(scenario.getFormName() + " - audit.csv"));
+
+    Path outputAudit = scenario.getOutputDir().resolve(scenario.getFormName() + " - audit.csv");
+
+    assertThat(outputAudit, exists());
+    assertThat(outputAudit, fileExactlyContains("instance ID,event, node, start, end\n" + scenario.getInstanceId() + ",form start,,1536663986578,\n"));
   }
 
   @Test

--- a/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
@@ -20,6 +20,7 @@ import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.opendatakit.briefcase.export.Scenario.nonGroup;
@@ -310,6 +311,14 @@ public class CsvFieldMappersTest {
 
     assertThat(outputAudit, exists());
     assertThat(outputAudit, fileContains("instance ID,event, node, start, end\n" + firstInstanceID + ",form start,,1536663986578,\n" + secondInstanceID + ",form start,,1536664003229,\n"));
+  }
+
+  @Test
+  public void when_the_audit_source_file_is_missing_we_leave_the_column_empty() {
+    scenario = Scenario.nonGroup("some-form", DataType.BINARY, "audit", "meta");
+
+    List<Pair<String, String>> output = scenario.mapSimpleValue("audit.csv", true);
+    assertThat(output.get(0).getRight(), isEmptyString());
   }
 
   @Test

--- a/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
@@ -16,7 +16,6 @@
 
 package org.opendatakit.briefcase.export;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -28,20 +27,16 @@ import static org.opendatakit.briefcase.export.Scenario.repeatGroup;
 import static org.opendatakit.briefcase.matchers.PathMatchers.exists;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.list;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
 import java.util.UUID;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeMatcher;
 import org.javarosa.core.model.DataType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.opendatakit.briefcase.matchers.PathMatchers;
 import org.opendatakit.briefcase.reused.Pair;
 import org.opendatakit.briefcase.reused.UncheckedFiles;
 
@@ -278,33 +273,7 @@ public class CsvFieldMappersTest {
     Path outputAudit = scenario.getOutputDir().resolve(scenario.getFormName() + " - audit.csv");
 
     assertThat(outputAudit, exists());
-    assertThat(outputAudit, fileContains("line 1"));
-  }
-
-  private Matcher<Path> fileContains(String content) {
-    return new TypeSafeMatcher<Path>() {
-      private String actualContents;
-
-      @Override
-      protected boolean matchesSafely(Path item) {
-        try {
-          actualContents = new String(Files.readAllBytes(item), UTF_8);
-          return actualContents.contains(content);
-        } catch (IOException e) {
-          throw new RuntimeException(e);
-        }
-      }
-
-      @Override
-      public void describeTo(Description description) {
-        description.appendText("a file containing ").appendValue(content);
-      }
-
-      @Override
-      protected void describeMismatchSafely(Path item, Description mismatchDescription) {
-        mismatchDescription.appendText("was a file containing ").appendValue(actualContents);
-      }
-    };
+    assertThat(outputAudit, PathMatchers.fileContains("line 1"));
   }
 
   @Test

--- a/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
@@ -18,9 +18,9 @@ package org.opendatakit.briefcase.export;
 
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
 import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.opendatakit.briefcase.export.Scenario.nonGroup;
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
 import java.util.UUID;
+import org.hamcrest.Matchers;
 import org.javarosa.core.model.DataType;
 import org.junit.After;
 import org.junit.Before;
@@ -44,6 +45,7 @@ import org.junit.Test;
 import org.opendatakit.briefcase.reused.Pair;
 import org.opendatakit.briefcase.reused.UncheckedFiles;
 
+@SuppressWarnings("unchecked")
 public class CsvFieldMappersTest {
   private TimeZone backupTimeZone;
   private Locale backupLocale;
@@ -270,7 +272,10 @@ public class CsvFieldMappersTest {
     write(scenario.getWorkDir().resolve("audit.csv"), "event, node, start, end\nform start,,1536663986578,\n");
 
     List<Pair<String, String>> output = scenario.mapSimpleValue("audit.csv", true);
-    assertThat(output.get(0).getRight(), is(scenario.getFormName() + " - audit.csv"));
+    assertThat(output, contains(
+        Pair.of("data-audit", "media/audit.csv"),
+        Pair.of("data-audit-aggregated", "some-form - audit.csv")
+    ));
 
     Path outputAudit = scenario.getOutputDir().resolve(scenario.getFormName() + " - audit.csv");
 
@@ -284,7 +289,10 @@ public class CsvFieldMappersTest {
     write(scenario.getWorkDir().resolve("audit.csv"), "event, node, start, end\nform start,,1536663986578,\n");
 
     List<Pair<String, String>> output = scenario.mapSimpleValue("audit.csv", true);
-    assertThat(output.get(0).getRight(), is(scenario.getFormName() + " - audit.csv"));
+    assertThat(output, contains(
+        Pair.of("data-audit", "media/audit.csv"),
+        Pair.of("data-audit-aggregated", "some-form - audit.csv")
+    ));
 
     Path outputAudit = scenario.getOutputDir().resolve(scenario.getFormName() + " - audit.csv");
 
@@ -318,7 +326,10 @@ public class CsvFieldMappersTest {
     scenario = Scenario.nonGroup("some-form", DataType.BINARY, "audit", "meta");
 
     List<Pair<String, String>> output = scenario.mapSimpleValue("audit.csv", true);
-    assertThat(output.get(0).getRight(), isEmptyString());
+    assertThat(output, Matchers.containsInAnyOrder(
+        Pair.of("data-audit", "media/audit.csv"),
+        Pair.of("data-audit-aggregated", "")
+    ));
   }
 
   @Test

--- a/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersEncodeMainValueTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersEncodeMainValueTest.java
@@ -17,8 +17,8 @@
 package org.opendatakit.briefcase.export;
 
 import static org.junit.Assert.assertThat;
-import static org.opendatakit.briefcase.export.CsvFieldMappersTest.Scenario.createField;
 import static org.opendatakit.briefcase.export.CsvSubmissionMappers.encodeMainValue;
+import static org.opendatakit.briefcase.export.Scenario.createField;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersEncodeValueTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersEncodeValueTest.java
@@ -17,9 +17,9 @@
 package org.opendatakit.briefcase.export;
 
 import static org.junit.Assert.assertThat;
-import static org.opendatakit.briefcase.export.CsvFieldMappersTest.Scenario.createField;
 import static org.opendatakit.briefcase.export.CsvSubmissionMappers.encodeMainValue;
 import static org.opendatakit.briefcase.export.CsvSubmissionMappers.encodeRepeatValue;
+import static org.opendatakit.briefcase.export.Scenario.createField;
 
 import org.hamcrest.Matchers;
 import org.javarosa.core.model.DataType;

--- a/test/java/org/opendatakit/briefcase/export/ExportConfigurationTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportConfigurationTest.java
@@ -46,6 +46,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.InMemoryPreferences;
+import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.reused.OverridableBoolean;
 
 @SuppressWarnings("checkstyle:MethodName")
@@ -217,6 +218,17 @@ public class ExportConfigurationTest {
   }
 
   @Test
+  public void knows_the_path_to_the_output_audit_file() {
+    assertThat(validConfig.getAuditPath("some-form").getFileName().toString(), is("some-form - audit.csv"));
+    assertThat(validConfig.getAuditPath("some-form").getFileName().toString(), is("some-form - audit.csv"));
+  }
+
+  @Test(expected = BriefcaseException.class)
+  public void an_empty_conf_will_throw_when_asked_for_the_output_audit_file() {
+    empty().getAuditPath("some-form");
+  }
+
+  @Test
   public void ensures_the_export_filename_has_csv_extension() {
     assertThat(buildConf("some_filename").getExportFileName(), OptionalMatchers.isPresentAnd(is("some_filename.csv")));
     assertThat(buildConf("some_filename.csv").getExportFileName(), OptionalMatchers.isPresentAnd(is("some_filename.csv")));
@@ -237,6 +249,4 @@ public class ExportConfigurationTest {
         OverridableBoolean.FALSE
     );
   }
-
-
 }

--- a/test/java/org/opendatakit/briefcase/export/ModelTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ModelTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.export;
+
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.Matchers.is;
+import static org.javarosa.core.model.instance.TreeReference.DEFAULT_MULTIPLICITY;
+import static org.junit.Assert.assertThat;
+
+import org.javarosa.core.model.instance.TreeElement;
+import org.junit.Test;
+
+public class ModelTest {
+
+  @Test
+  public void knows_if_it_is_the_meta_audit_field() {
+    assertThat(buildModel("some-field").isMetaAudit(), is(false));
+    assertThat(buildModel("audit").isMetaAudit(), is(false));
+    assertThat(buildModel("audit", "some-parent").isMetaAudit(), is(false));
+    assertThat(buildModel("audit", "meta").isMetaAudit(), is(true));
+  }
+
+  private Model buildModel(String name) {
+    return buildModel(name, null);
+  }
+
+  private Model buildModel(String name, String parentName) {
+    TreeElement element = new TreeElement(name, DEFAULT_MULTIPLICITY);
+    if (parentName != null) {
+      TreeElement parent = new TreeElement(parentName, DEFAULT_MULTIPLICITY);
+      element.setParent(parent);
+    }
+    return new Model(element, emptyMap());
+  }
+}

--- a/test/java/org/opendatakit/briefcase/export/ModelTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ModelTest.java
@@ -37,6 +37,15 @@ public class ModelTest {
     assertThat(lastDescendatOf(buildModel("data", "meta", "audit")).isMetaAudit(), is(true));
   }
 
+  @Test
+  public void knows_if_it_contains_a_meta_audit_field() {
+    assertThat(buildModel("data", "meta", "audit").hasAuditField(), is(true));
+    assertThat(buildModel("data", "meta", "instanceID").hasAuditField(), is(false));
+    assertThat(buildModel("data", "meta").hasAuditField(), is(false));
+    assertThat(buildModel("data", "some-field").hasAuditField(), is(false));
+    assertThat(buildModel("data", "some-field", "audit").hasAuditField(), is(false));
+  }
+
   private static Model buildModel(String... names) {
     List<TreeElement> elements = Stream.of(names)
         .map(name -> new TreeElement(name, DEFAULT_MULTIPLICITY))

--- a/test/java/org/opendatakit/briefcase/export/ModelTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ModelTest.java
@@ -30,15 +30,15 @@ public class ModelTest {
   public void knows_if_it_is_the_meta_audit_field() {
     assertThat(buildModel("some-field").isMetaAudit(), is(false));
     assertThat(buildModel("audit").isMetaAudit(), is(false));
-    assertThat(buildModel("audit", "some-parent").isMetaAudit(), is(false));
-    assertThat(buildModel("audit", "meta").isMetaAudit(), is(true));
+    assertThat(buildModel("some-parent", "audit").isMetaAudit(), is(false));
+    assertThat(buildModel("meta", "audit").isMetaAudit(), is(true));
   }
 
   private Model buildModel(String name) {
-    return buildModel(name, null);
+    return buildModel(null, name);
   }
 
-  private Model buildModel(String name, String parentName) {
+  private Model buildModel(String parentName, String name) {
     TreeElement element = new TreeElement(name, DEFAULT_MULTIPLICITY);
     if (parentName != null) {
       TreeElement parent = new TreeElement(parentName, DEFAULT_MULTIPLICITY);

--- a/test/java/org/opendatakit/briefcase/export/Scenario.java
+++ b/test/java/org/opendatakit/briefcase/export/Scenario.java
@@ -40,7 +40,8 @@ import org.opendatakit.briefcase.reused.UncheckedFiles;
 class Scenario {
   private static int instanceIdSeq = 1;
   private final Path workDir = createTempDirectory("briefcase_test_workdir");
-  private final Path outputMediaDir = UncheckedFiles.createDirectories(createTempDirectory("briefcase_test_media").resolve("media"));
+  private final Path outputDir = createTempDirectory("export_output");
+  private final Path outputMediaDir = UncheckedFiles.createDirectories(outputDir.resolve("media"));
   private final String formName;
   private final String instanceId;
   private final String instanceName;
@@ -238,5 +239,9 @@ class Scenario {
 
   public List<Path> getPaths() {
     return Arrays.asList(workDir, outputMediaDir);
+  }
+
+  public Path getOutputDir() {
+    return outputDir;
   }
 }

--- a/test/java/org/opendatakit/briefcase/export/Scenario.java
+++ b/test/java/org/opendatakit/briefcase/export/Scenario.java
@@ -98,7 +98,7 @@ class Scenario {
     elements.add(rootTreeElement);
 
     int maxIndex = elements.size() - 1;
-    for (int i = 0; i < maxIndex - 1; i++)
+    for (int i = 0; i < maxIndex; i++)
       elements.get(i).setParent(elements.get(i + 1));
     for (int i = maxIndex; i > 0; i--)
       elements.get(i).addChild(elements.get(i - 1));

--- a/test/java/org/opendatakit/briefcase/export/Scenario.java
+++ b/test/java/org/opendatakit/briefcase/export/Scenario.java
@@ -226,6 +226,7 @@ class Scenario {
     return CsvFieldMappers
         .getMapper(fieldModel, false)
         .apply(
+            formName,
             instanceId,
             getWorkDir(),
             fieldModel,

--- a/test/java/org/opendatakit/briefcase/export/Scenario.java
+++ b/test/java/org/opendatakit/briefcase/export/Scenario.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.export;
+
+import static java.util.stream.Collectors.toList;
+import static org.javarosa.core.model.instance.TreeReference.DEFAULT_MULTIPLICITY;
+import static org.kxml2.kdom.Node.ELEMENT;
+import static org.kxml2.kdom.Node.TEXT;
+import static org.opendatakit.briefcase.reused.UncheckedFiles.createTempDirectory;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import org.javarosa.core.model.DataType;
+import org.javarosa.core.model.instance.TreeElement;
+import org.kxml2.kdom.Document;
+import org.kxml2.kdom.Element;
+import org.opendatakit.briefcase.reused.OverridableBoolean;
+import org.opendatakit.briefcase.reused.Pair;
+import org.opendatakit.briefcase.reused.UncheckedFiles;
+
+class Scenario {
+  private static int instanceIdSeq = 1;
+  private final Path workDir = createTempDirectory("briefcase_test_workdir");
+  private final Path outputMediaDir = UncheckedFiles.createDirectories(createTempDirectory("briefcase_test_media").resolve("media"));
+  private final String formName;
+  private final String instanceId;
+  private final String instanceName;
+  private final String fieldName;
+  private final Model fieldModel;
+
+  Scenario(String formName, String instanceId, String instanceName, String fieldName, Model fieldModel) {
+    this.formName = formName;
+    this.instanceId = instanceId;
+    this.instanceName = instanceName;
+    this.fieldName = fieldName;
+    this.fieldModel = fieldModel;
+  }
+
+  static Scenario nonGroup(DataType dataType) {
+    return nonGroup("some-form", dataType, "field", null);
+  }
+
+  static Scenario nonGroup(DataType dataType, String fieldName) {
+    return nonGroup("some-form", dataType, fieldName, null);
+  }
+
+  static Scenario nonGroup(String formName, DataType dataType, String fieldName, String parentName) {
+    Model fieldModel = createField(dataType, fieldName, parentName);
+    return new Scenario(formName, "instance_" + instanceIdSeq++, "data", fieldName, fieldModel);
+  }
+
+  static Model createField(DataType dataType) {
+    return createField(dataType, "field", null);
+  }
+
+  static Model createField(DataType dataType, String fieldName) {
+    return createField(dataType, fieldName, null);
+  }
+
+  static Model createField(DataType dataType, String fieldName, String parentName) {
+    List<TreeElement> elements = new LinkedList<>();
+    TreeElement fieldTreeElement = new TreeElement(fieldName, DEFAULT_MULTIPLICITY);
+    fieldTreeElement.setDataType(dataType.value);
+    elements.add(fieldTreeElement);
+
+    if (parentName != null) {
+      TreeElement parentTreeElement = new TreeElement(parentName, DEFAULT_MULTIPLICITY);
+      parentTreeElement.setDataType(DataType.NULL.value);
+      elements.add(parentTreeElement);
+    }
+
+    TreeElement instanceTreeElement = new TreeElement("data", DEFAULT_MULTIPLICITY);
+    instanceTreeElement.setDataType(DataType.NULL.value);
+    elements.add(instanceTreeElement);
+
+    TreeElement rootTreeElement = new TreeElement("/", DEFAULT_MULTIPLICITY);
+    rootTreeElement.setDataType(DataType.NULL.value);
+    elements.add(rootTreeElement);
+
+    int maxIndex = elements.size() - 1;
+    for (int i = 0; i < maxIndex - 1; i++)
+      elements.get(i).setParent(elements.get(i + 1));
+    for (int i = maxIndex; i > 0; i--)
+      elements.get(i).addChild(elements.get(i - 1));
+
+    return new Model(fieldTreeElement, Collections.emptyMap());
+  }
+
+  private static Scenario group(String instanceId, DataType dataType, int fieldCount, boolean repeatable) {
+    List<TreeElement> groupFieldTreeElements = IntStream.range(0, fieldCount).boxed().map(i -> {
+      TreeElement field = new TreeElement("field_" + (i + 1), DEFAULT_MULTIPLICITY);
+      field.setDataType(dataType.value);
+      return field;
+    }).collect(toList());
+
+    TreeElement groupTreeElement = new TreeElement("group", DEFAULT_MULTIPLICITY);
+    groupTreeElement.setDataType(DataType.NULL.value);
+    groupTreeElement.setRepeatable(repeatable);
+
+    TreeElement instanceTreeElement = new TreeElement("data", DEFAULT_MULTIPLICITY);
+    instanceTreeElement.setDataType(DataType.NULL.value);
+
+    TreeElement rootTreeElement = new TreeElement("/", DEFAULT_MULTIPLICITY);
+    rootTreeElement.setDataType(DataType.NULL.value);
+
+    rootTreeElement.addChild(instanceTreeElement);
+    instanceTreeElement.addChild(groupTreeElement);
+    groupFieldTreeElements.forEach(groupTreeElement::addChild);
+
+    groupFieldTreeElements.forEach(field -> field.setParent(groupTreeElement));
+    groupTreeElement.setParent(instanceTreeElement);
+    instanceTreeElement.setParent(rootTreeElement);
+
+    return new Scenario("some-form", instanceId, "data", "group", new Model(groupTreeElement, Collections.emptyMap()));
+  }
+
+  static Scenario repeatGroup(String instanceId, DataType dataType, int fieldCount) {
+    return group(instanceId, dataType, fieldCount, true);
+  }
+
+  static Scenario nonRepeatGroup(DataType dataType, int fieldCount) {
+    return group("instance_" + instanceIdSeq++, dataType, fieldCount, false);
+  }
+
+  private XmlElement buildSimpleValueSubmission(String value) {
+    Document xmlDoc = new Document();
+
+    Element xmlRoot = new Element();
+
+    Element xmlInstance = new Element();
+    xmlInstance.setName(instanceName);
+
+    Element xmlField = new Element();
+    xmlField.setName(fieldName);
+
+    xmlDoc.addChild(ELEMENT, xmlRoot);
+    xmlRoot.addChild(ELEMENT, xmlInstance);
+    xmlInstance.addChild(ELEMENT, xmlField);
+    xmlField.addChild(TEXT, value);
+
+    return new XmlElement(xmlField);
+  }
+
+  private XmlElement buildGroupValueSubmission(String... values) {
+    Document xmlDoc = new Document();
+
+    Element xmlRoot = new Element();
+
+    Element xmlInstance = new Element();
+    xmlInstance.setName("data");
+
+    Element xmlGroup = new Element();
+    xmlGroup.setName("group");
+
+    List<Element> xmlFields = IntStream.range(0, values.length).boxed().map(i -> {
+      Element xmlField = new Element();
+      xmlField.setName("field_" + (i + 1));
+      xmlField.addChild(TEXT, values[i]);
+      return xmlField;
+    }).collect(toList());
+
+
+    xmlDoc.addChild(ELEMENT, xmlRoot);
+    xmlRoot.addChild(ELEMENT, xmlInstance);
+    xmlInstance.addChild(ELEMENT, xmlGroup);
+    xmlFields.forEach(field -> xmlGroup.addChild(ELEMENT, field));
+
+    return new XmlElement(xmlGroup);
+  }
+
+  String getFormName() {
+    return formName;
+  }
+
+  Path getWorkDir() {
+    return workDir;
+  }
+
+  Path getOutputMediaDir() {
+    return outputMediaDir;
+  }
+
+  List<Pair<String, String>> mapSimpleValue(String value) {
+    return mapValue(buildSimpleValueSubmission(value), true);
+  }
+
+  List<Pair<String, String>> mapSimpleValue(String value, boolean exportMedia) {
+    return mapValue(buildSimpleValueSubmission(value), exportMedia);
+  }
+
+  List<Pair<String, String>> mapGroupValue(String... values) {
+    return mapValue(buildGroupValueSubmission(values), true);
+  }
+
+  private List<Pair<String, String>> mapValue(XmlElement value, boolean exportMedia) {
+    ExportConfiguration configuration = new ExportConfiguration(
+        Optional.of("test_output.csv"),
+        Optional.of(getOutputMediaDir().getParent()),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        OverridableBoolean.FALSE,
+        OverridableBoolean.TRUE,
+        OverridableBoolean.of(exportMedia),
+        OverridableBoolean.FALSE
+    );
+    return CsvFieldMappers
+        .getMapper(fieldModel, false)
+        .apply(
+            instanceId,
+            getWorkDir(),
+            fieldModel,
+            Optional.of(value),
+            configuration
+        )
+        .collect(toList());
+  }
+
+  public List<Path> getPaths() {
+    return Arrays.asList(workDir, outputMediaDir);
+  }
+}

--- a/test/java/org/opendatakit/briefcase/export/Scenario.java
+++ b/test/java/org/opendatakit/briefcase/export/Scenario.java
@@ -244,4 +244,8 @@ class Scenario {
   public Path getOutputDir() {
     return outputDir;
   }
+
+  public String getInstanceId() {
+    return instanceId;
+  }
 }

--- a/test/java/org/opendatakit/briefcase/export/Scenario.java
+++ b/test/java/org/opendatakit/briefcase/export/Scenario.java
@@ -43,7 +43,7 @@ class Scenario {
   private final Path outputDir = createTempDirectory("export_output");
   private final Path outputMediaDir = UncheckedFiles.createDirectories(outputDir.resolve("media"));
   private final String formName;
-  private final String instanceId;
+  private String instanceId;
   private final String instanceName;
   private final String fieldName;
   private final Model fieldModel;
@@ -247,5 +247,9 @@ class Scenario {
 
   public String getInstanceId() {
     return instanceId;
+  }
+
+  public void nextSubmission() {
+    instanceId = "instance_" + instanceIdSeq++;
   }
 }

--- a/test/java/org/opendatakit/briefcase/export/Scenario.java
+++ b/test/java/org/opendatakit/briefcase/export/Scenario.java
@@ -16,11 +16,13 @@
 
 package org.opendatakit.briefcase.export;
 
+import static java.nio.file.StandardOpenOption.CREATE;
 import static java.util.stream.Collectors.toList;
 import static org.javarosa.core.model.instance.TreeReference.DEFAULT_MULTIPLICITY;
 import static org.kxml2.kdom.Node.ELEMENT;
 import static org.kxml2.kdom.Node.TEXT;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.createTempDirectory;
+import static org.opendatakit.briefcase.reused.UncheckedFiles.write;
 
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -54,6 +56,11 @@ class Scenario {
     this.instanceName = instanceName;
     this.fieldName = fieldName;
     this.fieldModel = fieldModel;
+
+    // Side effects:
+    // - ExportToCSV ensures that there is an audit output
+    //   CSV file with at least the headers on it.
+    write(outputDir.resolve(formName + " - audit.csv"), "instance ID, event, node, start, end\n", CREATE);
   }
 
   static Scenario nonGroup(DataType dataType) {

--- a/test/java/org/opendatakit/briefcase/matchers/PathMatchers.java
+++ b/test/java/org/opendatakit/briefcase/matchers/PathMatchers.java
@@ -74,4 +74,30 @@ public class PathMatchers {
       }
     };
   }
+
+  public static Matcher<Path> fileExactlyContains(String content) {
+    return new TypeSafeMatcher<Path>() {
+      private String actualContents;
+
+      @Override
+      protected boolean matchesSafely(Path item) {
+        try {
+          actualContents = new String(Files.readAllBytes(item), UTF_8);
+          return actualContents.equals(content);
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("a file containing ").appendValue(content);
+      }
+
+      @Override
+      protected void describeMismatchSafely(Path item, Description mismatchDescription) {
+        mismatchDescription.appendText("was a file containing ").appendValue(actualContents);
+      }
+    };
+  }
 }

--- a/test/java/org/opendatakit/briefcase/matchers/PathMatchers.java
+++ b/test/java/org/opendatakit/briefcase/matchers/PathMatchers.java
@@ -16,6 +16,9 @@
 
 package org.opendatakit.briefcase.matchers;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.hamcrest.Description;
@@ -42,6 +45,32 @@ public class PathMatchers {
       @Override
       protected void describeMismatchSafely(Path item, Description mismatchDescription) {
         mismatchDescription.appendText("doesn't exist");
+      }
+    };
+  }
+
+  public static Matcher<Path> fileContains(String content) {
+    return new TypeSafeMatcher<Path>() {
+      private String actualContents;
+
+      @Override
+      protected boolean matchesSafely(Path item) {
+        try {
+          actualContents = new String(Files.readAllBytes(item), UTF_8);
+          return actualContents.contains(content);
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("a file containing ").appendValue(content);
+      }
+
+      @Override
+      protected void describeMismatchSafely(Path item, Description mismatchDescription) {
+        mismatchDescription.appendText("was a file containing ").appendValue(actualContents);
       }
     };
   }


### PR DESCRIPTION
Closes #637

It appears that GitHub has reordered some commits, which could be a little confusing for the reviewer of this PR. Sorry about that! ¯\\\_(ツ)\_/¯

#### What has been done to verify that this works as intended?
- Run the automated tests
- Manually exported [Audit 1](https://github.com/opendatakit/briefcase/files/2370724/audit-1.txt), and [Audit 2](https://github.com/opendatakit/briefcase/files/2370723/audit-2.txt) forms with some submissions.

#### Why is this the best possible solution? Were any other approaches considered?
This is the narrowest change I could think of. It ensures that previous behavior doesn't change by adding a new mapper instead of changing the current binary mapper.

There are some ways we could address a performance decrease (see last section):
- we could post-process of the submissions and writing once in the output audit file
- we could change the side-effect of the new field mapper (writing to a file) and make it aggregate the lines into some external/global stream of lines

Both options would force us to change the structure of the main export process and the second option would make us think about concurrency/contingency if we want the audit contents to be ordered.

Taking into account that we don't really know how many people is using & exporting audit data, it feels like a more conservative strategy to wait and intervene if there are performance complaints.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

- Users should expect a new output CSV file with merged audit data from all the submissions of each exported form.
- Users could miss the `audit-N.csv` files we were previously writing into the media output directory
- Now users will be able to export two forms with audit data at the same time without breaking Briefcase! :tada:
- The new filenames follow the pattern `{FORM NAME} - audit.csv`
- Exported audit contents follow the same behavior as the main and repeat CSV contents regarding overwriting/appending lines. They are affected by the "overwrite files" export conf param.
- Since we basically have to process all the audit lines of all submissions, big forms with many submissions will experience a decrease in performance while exporting them.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
We don't currently document audit data export. Should we?