### PR TITLE
Issue 651 fixed the busy cursor after error happens

### DIFF
--- a/src/org/opendatakit/briefcase/ui/reused/source/RemoteServerDialog.java
+++ b/src/org/opendatakit/briefcase/ui/reused/source/RemoteServerDialog.java
@@ -18,7 +18,6 @@ package org.opendatakit.briefcase.ui.reused.source;
 
 import static org.opendatakit.briefcase.ui.ODKOptionPane.showErrorDialog;
 
-import java.awt.Cursor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -38,11 +37,13 @@ public class RemoteServerDialog {
       form.setTestingConnection();
 
       new SwingWorker<Response<Boolean>, Void>() {
-        @Override protected Response<Boolean> doInBackground() {
+        @Override
+        protected Response<Boolean> doInBackground() {
           return serverTester.test(server);
         }
 
-        @Override protected void done() {
+        @Override
+        protected void done() {
           try {
             Response<Boolean> response = get();
             if (response.isSuccess()) {
@@ -61,7 +62,6 @@ public class RemoteServerDialog {
             }
           }
           form.unsetTestingConnection();
-          form.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
         }
       }.execute();
     });

--- a/src/org/opendatakit/briefcase/ui/reused/source/RemoteServerDialog.java
+++ b/src/org/opendatakit/briefcase/ui/reused/source/RemoteServerDialog.java
@@ -49,7 +49,6 @@ public class RemoteServerDialog {
               triggerConnect(server);
               form.hideDialog();
             } else
-              form.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
               showError(
                   response.isRedirection() ? "Redirection detected" : response.isUnauthorized() ? "Wrong credentials" : response.isNotFound() ? "Aggregate not found" : "",
                   response.isRedirection() ? "Unexpected error" : "Configuration error"
@@ -62,6 +61,7 @@ public class RemoteServerDialog {
             }
           }
           form.unsetTestingConnection();
+          form.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
         }
       }.execute();
     });

--- a/src/org/opendatakit/briefcase/ui/reused/source/RemoteServerDialog.java
+++ b/src/org/opendatakit/briefcase/ui/reused/source/RemoteServerDialog.java
@@ -18,6 +18,7 @@ package org.opendatakit.briefcase.ui.reused.source;
 
 import static org.opendatakit.briefcase.ui.ODKOptionPane.showErrorDialog;
 
+import java.awt.Cursor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -48,6 +49,7 @@ public class RemoteServerDialog {
               triggerConnect(server);
               form.hideDialog();
             } else
+              form.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
               showError(
                   response.isRedirection() ? "Redirection detected" : response.isUnauthorized() ? "Wrong credentials" : response.isNotFound() ? "Aggregate not found" : "",
                   response.isRedirection() ? "Unexpected error" : "Configuration error"

--- a/src/org/opendatakit/briefcase/ui/reused/source/RemoteServerDialogForm.java
+++ b/src/org/opendatakit/briefcase/ui/reused/source/RemoteServerDialogForm.java
@@ -75,16 +75,14 @@ public class RemoteServerDialogForm extends JDialog {
 
     cancelButton.addActionListener(e -> dispose());
 
-    connectButton.addActionListener(__ -> {
-      setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-      triggerConnect();
-    });
+    connectButton.addActionListener(__ -> triggerConnect());
 
     getRootPane().setDefaultButton(connectButton);
 
   }
 
   private void triggerConnect() {
+    setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
     try {
       Optional<Credentials> credentials = OptionalProduct.all(
           Optional.ofNullable(usernameField.getText()).map(String::trim).filter(s -> !s.isEmpty()),

--- a/src/org/opendatakit/briefcase/ui/reused/source/RemoteServerDialogForm.java
+++ b/src/org/opendatakit/briefcase/ui/reused/source/RemoteServerDialogForm.java
@@ -126,6 +126,7 @@ public class RemoteServerDialogForm extends JDialog {
     passwordField.setEditable(false);
     connectButton.setEnabled(false);
     progressBar.setVisible(true);
+    setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
   }
 
   void unsetTestingConnection() {
@@ -135,6 +136,7 @@ public class RemoteServerDialogForm extends JDialog {
     passwordField.setEditable(true);
     connectButton.setEnabled(true);
     progressBar.setVisible(false);
+    setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
   }
 
   /**

--- a/src/org/opendatakit/briefcase/ui/reused/source/RemoteServerDialogForm.java
+++ b/src/org/opendatakit/briefcase/ui/reused/source/RemoteServerDialogForm.java
@@ -99,8 +99,10 @@ public class RemoteServerDialogForm extends JDialog {
 
       onConnectCallbacks.forEach(callback -> callback.accept(server));
     } catch (BriefcaseException e) {
+      setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
       showErrorDialog(this, "Please, check data and try again.\n\nError: " + e.getCause().getMessage(), "Invalid Aggregate configuration");
     } catch (MalformedURLException e) {
+      setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
       showErrorDialog(this, "Malformed URL. Please, review data and try again.\n\nError: " + e.getMessage(), "Invalid Aggregate configuration");
     }
   }


### PR DESCRIPTION
Closes #651 

#### What has been done to verify that this works as intended?
We set the cursor to waiting after click the connection button but forget to set it back when an error happens, it's a small improvement but makes the user more comfortable when backing to the configuration dialog. 

#### Why is this the best possible solution? Were any other approaches considered?
It's the best solution, and it's really simple.

