### PR TITLE
Issue 657 Fix adding csv extension when given filename doesn't include it

### DIFF
--- a/src/org/opendatakit/briefcase/export/ExportConfiguration.java
+++ b/src/org/opendatakit/briefcase/export/ExportConfiguration.java
@@ -19,7 +19,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.exists;
 import static java.nio.file.Files.isDirectory;
 import static java.nio.file.Files.newInputStream;
-
 import static org.opendatakit.briefcase.ui.MessageStrings.DIR_INSIDE_BRIEFCASE_STORAGE;
 import static org.opendatakit.briefcase.ui.MessageStrings.DIR_INSIDE_ODK_DEVICE_DIRECTORY;
 import static org.opendatakit.briefcase.ui.MessageStrings.DIR_NOT_DIRECTORY;
@@ -48,7 +47,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
-
 import org.bouncycastle.openssl.PEMReader;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.reused.BriefcaseException;
@@ -449,7 +447,7 @@ public class ExportConfiguration {
   }
 
   public Optional<String> getExportFileName() {
-    return exportFileName;
+    return exportFileName.map(filename -> filename.endsWith(".csv") ? filename : filename + ".csv");
   }
 
   public Path getErrorsDir(String formName) {

--- a/src/org/opendatakit/briefcase/export/ExportConfiguration.java
+++ b/src/org/opendatakit/briefcase/export/ExportConfiguration.java
@@ -447,7 +447,7 @@ public class ExportConfiguration {
   }
 
   public Optional<String> getExportFileName() {
-    return exportFileName.map(filename -> filename.endsWith(".csv") ? filename : filename + ".csv");
+    return exportFileName.map(filename -> filename.toLowerCase().endsWith(".csv") ? filename : filename + ".csv");
   }
 
   public Path getErrorsDir(String formName) {

--- a/test/java/org/opendatakit/briefcase/export/ExportConfigurationTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportConfigurationTest.java
@@ -218,8 +218,15 @@ public class ExportConfigurationTest {
 
   @Test
   public void ensures_the_export_filename_has_csv_extension() {
-    ExportConfiguration conf = new ExportConfiguration(
-        Optional.of("some_filename"),
+    assertThat(buildConf("some_filename").getExportFileName(), OptionalMatchers.isPresentAnd(is("some_filename.csv")));
+    assertThat(buildConf("some_filename.csv").getExportFileName(), OptionalMatchers.isPresentAnd(is("some_filename.csv")));
+    assertThat(buildConf("some_filename.CSV").getExportFileName(), OptionalMatchers.isPresentAnd(is("some_filename.CSV")));
+    assertThat(buildConf("some_filename.cSv").getExportFileName(), OptionalMatchers.isPresentAnd(is("some_filename.cSv")));
+  }
+
+  public ExportConfiguration buildConf(String exportFileName) {
+    return new ExportConfiguration(
+        Optional.of(exportFileName),
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
@@ -229,6 +236,7 @@ public class ExportConfigurationTest {
         OverridableBoolean.empty(),
         Optional.of(false)
     );
-    assertThat(conf.getExportFileName(), OptionalMatchers.isPresentAnd(is("some_filename.csv")));
   }
+
+
 }

--- a/test/java/org/opendatakit/briefcase/export/ExportConfigurationTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportConfigurationTest.java
@@ -40,11 +40,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDate;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Before;
 import org.junit.Test;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.InMemoryPreferences;
+import org.opendatakit.briefcase.reused.OverridableBoolean;
 
 @SuppressWarnings("checkstyle:MethodName")
 public class ExportConfigurationTest {
@@ -212,5 +214,21 @@ public class ExportConfigurationTest {
     assertThat(validConfig.hashCode(), is(notNullValue()));
     assertThat(validConfig.equals(null), is(false));
     assertThat(validConfig, is(validConfig));
+  }
+
+  @Test
+  public void ensures_the_export_filename_has_csv_extension() {
+    ExportConfiguration conf = new ExportConfiguration(
+        Optional.of("some_filename"),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        OverridableBoolean.empty(),
+        OverridableBoolean.empty(),
+        OverridableBoolean.empty(),
+        Optional.of(false)
+    );
+    assertThat(conf.getExportFileName(), OptionalMatchers.isPresentAnd(is("some_filename.csv")));
   }
 }


### PR DESCRIPTION
Closes #657

#### What has been done to verify that this works as intended?
Add and run a new automated test that ensures the filename has the `csv` extension.
Manually run the JAR to verify it works.

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This PR fixes a regression introduced in v1.11

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.