### PR TITLE
Issue 656 split selects with search appearance

### DIFF
--- a/src/org/opendatakit/briefcase/export/Model.java
+++ b/src/org/opendatakit/briefcase/export/Model.java
@@ -101,7 +101,7 @@ class Model {
 
   /**
    * Returns the Fully Qualified Name of this {@link Model} instance, having
-   * shifted a given amount of names.
+   * shifted a given number of names.
    */
   String fqn(int shift) {
     return fqn(model, shift);
@@ -109,7 +109,7 @@ class Model {
 
   /**
    * Returns the Fully Qualified Name of a given {@link TreeElement} model, having
-   * shifted a given amount of names.
+   * shifted a given number of names.
    */
   public static String fqn(TreeElement model, int shift) {
     List<String> names = new ArrayList<>();
@@ -147,9 +147,9 @@ class Model {
 
   /**
    * Returns the {@link List} of {@link String} names that this {@link Model} instance can be
-   * associated with, shifted a given amount of names.
+   * associated with, shifted a given number of names.
    *
-   * @param shift an int with the amount of names to shift from the FQN
+   * @param shift an int with the number of names to shift from the FQN
    * @return a {@link List} of shifted {@link String} names of this {@link Model} instance
    * @see Model#getNames()
    */

--- a/src/org/opendatakit/briefcase/export/Model.java
+++ b/src/org/opendatakit/briefcase/export/Model.java
@@ -267,7 +267,12 @@ class Model {
 
 
   public List<SelectChoice> getChoices() {
-    return Optional.ofNullable(controls.get(fqn()).getChoices()).orElse(emptyList());
+    Optional<QuestionDef> control = Optional.ofNullable(controls.get(fqn()));
+    if (!control.isPresent())
+      return emptyList();
+    if (control.map(QuestionDef::getAppearanceAttr).map(a -> a.contains("search(")).orElse(false))
+      return emptyList();
+    return control.get().getChoices();
   }
 
   public boolean isMetaAudit() {

--- a/src/org/opendatakit/briefcase/export/Model.java
+++ b/src/org/opendatakit/briefcase/export/Model.java
@@ -17,7 +17,6 @@ package org.opendatakit.briefcase.export;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static org.javarosa.core.model.Constants.DATATYPE_NULL;
 import static org.javarosa.core.model.DataType.GEOPOINT;
@@ -103,12 +102,16 @@ class Model {
   /**
    * Returns the Fully Qualified Name of this {@link Model} instance, having
    * shifted a given amount of names.
-   *
-   * @param shift an int with the amount of names to shift from the FQN
-   * @return a {@link String} with the shifted FQN of this {@link Model}
-   * @see Model#fqn()
    */
   String fqn(int shift) {
+    return fqn(model, shift);
+  }
+
+  /**
+   * Returns the Fully Qualified Name of a given {@link TreeElement} model, having
+   * shifted a given amount of names.
+   */
+  public static String fqn(TreeElement model, int shift) {
     List<String> names = new ArrayList<>();
     TreeElement current = model;
     while (current.getParent() != null && current.getParent().getName() != null) {
@@ -116,10 +119,7 @@ class Model {
       current = (TreeElement) current.getParent();
     }
     Collections.reverse(names);
-    return names
-        .subList(shift, names.size())
-        .stream()
-        .collect(joining("-"));
+    return String.join("-", names.subList(shift, names.size()));
   }
 
   /**
@@ -313,7 +313,7 @@ class Model {
     OSM_CAPTURE(14),
     FILE_CAPTURE(15);
 
-    private int value;
+    int value;
 
     ControlType(int value) {
       this.value = value;

--- a/test/java/org/opendatakit/briefcase/export/CsvTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvTest.java
@@ -47,7 +47,7 @@ public class CsvTest {
 
   @Test
   public void includes_non_repeat_groups_in_repeat_filenames() {
-    Model group = new XmlElementTest.ModelBuilder()
+    Model group = new ModelBuilder()
         .addGroup("data")
         .addGroup("g1")
         .addGroup("g2")
@@ -64,7 +64,7 @@ public class CsvTest {
 
   @Test
   public void includes_non_repeat_groups_in_repeat_filenames2() {
-    Model group = new XmlElementTest.ModelBuilder()
+    Model group = new ModelBuilder()
         .addGroup("data")
         .addGroup("g1")
         .addRepeatGroup("r1")

--- a/test/java/org/opendatakit/briefcase/export/ExportConfigurationTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportConfigurationTest.java
@@ -246,7 +246,7 @@ public class ExportConfigurationTest {
         OverridableBoolean.empty(),
         OverridableBoolean.empty(),
         OverridableBoolean.empty(),
-        OverridableBoolean.FALSE
+        OverridableBoolean.empty()
     );
   }
 }

--- a/test/java/org/opendatakit/briefcase/export/ModelBuilder.java
+++ b/test/java/org/opendatakit/briefcase/export/ModelBuilder.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.export;
+
+import static org.javarosa.core.model.instance.TreeReference.DEFAULT_MULTIPLICITY;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.javarosa.core.model.DataType;
+import org.javarosa.core.model.QuestionDef;
+import org.javarosa.core.model.instance.TreeElement;
+
+class ModelBuilder {
+  private TreeElement current = new TreeElement(null, DEFAULT_MULTIPLICITY);
+  private Map<String, QuestionDef> controls = new HashMap<>();
+
+  ModelBuilder addGroup(String name) {
+    TreeElement child = new TreeElement(name, DEFAULT_MULTIPLICITY);
+    child.setDataType(DataType.NULL.value);
+    child.setRepeatable(false);
+    child.setParent(current);
+    current.addChild(child);
+    current = child;
+    return this;
+  }
+
+  ModelBuilder addRepeatGroup(String name) {
+    TreeElement child = new TreeElement(name, DEFAULT_MULTIPLICITY);
+    child.setDataType(DataType.NULL.value);
+    child.setRepeatable(true);
+    child.setParent(current);
+    current.addChild(child);
+    current = child;
+    return this;
+  }
+
+  ModelBuilder addField(String name, DataType dataType) {
+    return addField(name, dataType, null);
+  }
+
+  ModelBuilder addField(String name, DataType dataType, QuestionDef control) {
+    TreeElement child = new TreeElement(name, DEFAULT_MULTIPLICITY);
+    child.setDataType(dataType.value);
+    child.setParent(current);
+    current.addChild(child);
+    current = child;
+    if (control != null)
+      controls.put(Model.fqn(current, 0), control);
+    return this;
+  }
+
+  Model build() {
+    return new Model(current, controls);
+  }
+}

--- a/test/java/org/opendatakit/briefcase/export/ModelTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ModelTest.java
@@ -18,6 +18,7 @@ package org.opendatakit.briefcase.export;
 
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.model.instance.TreeReference.DEFAULT_MULTIPLICITY;
 import static org.junit.Assert.assertThat;
@@ -48,6 +49,21 @@ public class ModelTest {
         .build();
 
     assertThat(model.getChoices(), contains(choice1, choice2));
+  }
+
+  @Test
+  public void gets_choices_of_a_related_select_control_with_search_appearance() {
+    QuestionDef control = new QuestionDef();
+    control.setControlType(Model.ControlType.SELECT_MULTI.value);
+    // This is the choice we will usually find in a select that uses appearance="search(...)"
+    control.addSelectChoice(new SelectChoice("name", "name_key", false));
+    control.setAppearanceAttr("search('some_external_instance')");
+
+    Model model = new ModelBuilder()
+        .addField("select", DataType.TEXT, control)
+        .build();
+
+    assertThat(model.getChoices(), empty());
   }
 
   static class ModelBuilder {

--- a/test/java/org/opendatakit/briefcase/export/ModelTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ModelTest.java
@@ -23,9 +23,7 @@ import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.model.instance.TreeReference.DEFAULT_MULTIPLICITY;
 import static org.junit.Assert.assertThat;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.javarosa.core.model.DataType;
@@ -64,50 +62,6 @@ public class ModelTest {
         .build();
 
     assertThat(model.getChoices(), empty());
-  }
-
-  static class ModelBuilder {
-    private TreeElement current = new TreeElement(null, DEFAULT_MULTIPLICITY);
-    private Map<String, QuestionDef> controls = new HashMap<>();
-
-    ModelBuilder addGroup(String name) {
-      TreeElement child = new TreeElement(name, DEFAULT_MULTIPLICITY);
-      child.setDataType(DataType.NULL.value);
-      child.setRepeatable(false);
-      child.setParent(current);
-      current.addChild(child);
-      current = child;
-      return this;
-    }
-
-    ModelBuilder addRepeatGroup(String name) {
-      TreeElement child = new TreeElement(name, DEFAULT_MULTIPLICITY);
-      child.setDataType(DataType.NULL.value);
-      child.setRepeatable(true);
-      child.setParent(current);
-      current.addChild(child);
-      current = child;
-      return this;
-    }
-
-    ModelBuilder addField(String name, DataType dataType) {
-      return addField(name, dataType, null);
-    }
-
-    ModelBuilder addField(String name, DataType dataType, QuestionDef control) {
-      TreeElement child = new TreeElement(name, DEFAULT_MULTIPLICITY);
-      child.setDataType(dataType.value);
-      child.setParent(current);
-      current.addChild(child);
-      current = child;
-      if (control != null)
-        controls.put(Model.fqn(current, 0), control);
-      return this;
-    }
-
-    Model build() {
-      return new Model(current, controls);
-    }
   }
 
   @Test
@@ -149,4 +103,5 @@ public class ModelTest {
       child = child.children().get(0);
     return child;
   }
+
 }

--- a/test/java/org/opendatakit/briefcase/export/XmlElementTest.java
+++ b/test/java/org/opendatakit/briefcase/export/XmlElementTest.java
@@ -16,15 +16,11 @@
 
 package org.opendatakit.briefcase.export;
 
-import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.is;
-import static org.javarosa.core.model.instance.TreeReference.DEFAULT_MULTIPLICITY;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.io.StringReader;
-import org.javarosa.core.model.DataType;
-import org.javarosa.core.model.instance.TreeElement;
 import org.junit.Test;
 import org.kxml2.io.KXmlParser;
 import org.kxml2.kdom.Document;
@@ -70,43 +66,6 @@ public class XmlElementTest {
     parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true);
     tempDoc.parse(parser);
     return tempDoc;
-  }
-
-  static class ModelBuilder {
-    private TreeElement current = new TreeElement(null, DEFAULT_MULTIPLICITY);
-
-    ModelBuilder addGroup(String name) {
-      TreeElement child = new TreeElement(name, DEFAULT_MULTIPLICITY);
-      child.setDataType(DataType.NULL.value);
-      child.setRepeatable(false);
-      child.setParent(current);
-      current.addChild(child);
-      current = child;
-      return this;
-    }
-
-    ModelBuilder addRepeatGroup(String name) {
-      TreeElement child = new TreeElement(name, DEFAULT_MULTIPLICITY);
-      child.setDataType(DataType.NULL.value);
-      child.setRepeatable(true);
-      child.setParent(current);
-      current.addChild(child);
-      current = child;
-      return this;
-    }
-
-    ModelBuilder addField(String name, DataType dataType) {
-      TreeElement child = new TreeElement(name, DEFAULT_MULTIPLICITY);
-      child.setDataType(dataType.value);
-      child.setParent(current);
-      current.addChild(child);
-      current = child;
-      return this;
-    }
-
-    Model build() {
-      return new Model(current, emptyMap());
-    }
   }
 
   private static XmlElement buildXmlElementFrom(Model field) throws IOException, XmlPullParserException {


### PR DESCRIPTION
Closes #656

#### What has been done to verify that this works as intended?
Run automated tests that verify that a multiple select with a `search()` appearance will give an empty list of fields.

#### Why is this the best possible solution? Were any other approaches considered?
This is the narrowest solution I can think of. Most of the code in this PR is for testing.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This will produce a more coherent behavior when using the split multiple selects option when exporting forms.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
https://github.com/opendatakit/docs/issues/879