### PR TITLE
Issue 663 unqualified group names csv export

### DIFF
--- a/docs/export-format.md
+++ b/docs/export-format.md
@@ -25,12 +25,31 @@ The main output file has values from any non-repeating group field found at the 
 
 ## Repeat output file
 
-Each repeat group will produce an output CSV file.
+Each repeat group will produce an output CSV file, and the filename will be the composition of the main csv filename and the repeat group's name.
 
-The file names of repeat groups depend on their position inside the model tree of the form. Some examples:
+- If form X has a repeat group Y, then the output file for the repeat group will be named `X-Y.csv`
+- Middle groups (including repeats) are ignored. If form X has a non-repeat group Y, which has a repeat group Z, then the output file for the repeat group will be named `X-Z.csv`
+- If form X has two repeat groups called Y (in any group arrangement), then a sequence number suffix is added for disambiguation and you will get output files `X-Y~1.csv`, and `X.Y~2.csv`
 
-- If form X contains a repeat group Y, then the output file for the repeat group will be named X-Y.csv.
-- If form X contains a non-repeat group Y, which contains a repeat group Z, then the output file for the repeat group will be named X-Y-Z.csv.
+  The sequence follows a depth-first ordering. In other words, files will have the same order as the repeat groups are defined in the instance's model.
+  
+  Some examples:
+
+    ```
+    outer-group
+      dupe-repeat     << gets the number 1
+        inner-group
+          dupe-repeat << gets the number 2
+    ```
+  
+    ```
+    group1
+      dupe-repeat << gets the number 1
+    group2
+      dupe-repeat << gets the number 2
+    ```
+  
+   
 
 ### Structure of the file:
 

--- a/src/org/opendatakit/briefcase/export/Csv.java
+++ b/src/org/opendatakit/briefcase/export/Csv.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
-import org.opendatakit.briefcase.reused.UncheckedFiles;
 
 /**
  * This class represents a CSV export output file. It knows how to write
@@ -58,7 +57,7 @@ class Csv {
     return new Csv(
         formDefinition.getModel().fqn(),
         getMainHeader(formDefinition.getModel(), formDefinition.isFileEncryptedForm(), configuration.resolveSplitSelectMultiples()),
-        configuration.getExportDir().resolve(configuration.getExportFileName().orElse(stripIllegalChars(formDefinition.getFormName()) + ".csv")),
+        buildMainOutputPath(formDefinition, configuration),
         true,
         configuration.resolveOverwriteExistingFiles(),
         CsvSubmissionMappers.main(formDefinition, configuration)
@@ -76,10 +75,17 @@ class Csv {
     );
   }
 
+  private static Path buildMainOutputPath(FormDefinition formDefinition, ExportConfiguration configuration) {
+    return configuration.getExportDir().resolve(String.format(
+        "%s.csv",
+        configuration.getFilenameBase(formDefinition.getFormName())
+    ));
+  }
+
   private static Path buildRepeatOutputPath(FormDefinition formDefinition, Model groupModel, ExportConfiguration configuration) {
     return configuration.getExportDir().resolve(String.format(
         "%s-%s.csv",
-        configuration.getExportFileName().map(UncheckedFiles::stripFileExtension).orElse(stripIllegalChars(formDefinition.getFormName())),
+        configuration.getFilenameBase(formDefinition.getFormName()),
         stripIllegalChars(groupModel.getName())
     ));
   }
@@ -87,7 +93,7 @@ class Csv {
   private static Path buildRepeatOutputPath(FormDefinition formDefinition, Model groupModel, ExportConfiguration configuration, int sequenceNumber) {
     return configuration.getExportDir().resolve(String.format(
         "%s-%s~%d.csv",
-        configuration.getExportFileName().map(UncheckedFiles::stripFileExtension).orElse(stripIllegalChars(formDefinition.getFormName())),
+        configuration.getFilenameBase(formDefinition.getFormName()),
         stripIllegalChars(groupModel.getName()),
         sequenceNumber
     ));

--- a/src/org/opendatakit/briefcase/export/Csv.java
+++ b/src/org/opendatakit/briefcase/export/Csv.java
@@ -58,7 +58,11 @@ class Csv {
     String repeatFileNameBase = configuration.getExportFileName()
         .map(UncheckedFiles::stripFileExtension)
         .orElse(stripIllegalChars(formDefinition.getFormName()));
-    Path output = configuration.getExportDir().resolve(repeatFileNameBase + "-" + stripIllegalChars(groupModel.getName()) + ".csv");
+    Path output = configuration.getExportDir().resolve(String.format(
+        "%s-%s.csv",
+        repeatFileNameBase,
+        stripIllegalChars(groupModel.getName())
+    ));
     return new Csv(
         groupModel.fqn(),
         getRepeatHeader(groupModel, configuration.resolveSplitSelectMultiples()),

--- a/src/org/opendatakit/briefcase/export/Csv.java
+++ b/src/org/opendatakit/briefcase/export/Csv.java
@@ -42,7 +42,7 @@ class Csv {
   /**
    * Factory for the main CSV export file of a form.
    */
-  static Csv main(FormDefinition formDefinition, ExportConfiguration configuration) {
+  private static Csv main(FormDefinition formDefinition, ExportConfiguration configuration) {
     Path output = configuration.getExportDir().resolve(
         configuration.getExportFileName().orElse(stripIllegalChars(formDefinition.getFormName()) + ".csv")
     );
@@ -59,7 +59,7 @@ class Csv {
   /**
    * Factory of any repeat CSV export file.
    */
-  static Csv repeat(FormDefinition formDefinition, Model groupModel, ExportConfiguration configuration) {
+  private static Csv repeat(FormDefinition formDefinition, Model groupModel, ExportConfiguration configuration) {
     String repeatFileNameBase = configuration.getExportFileName()
         .map(UncheckedFiles::stripFileExtension)
         .orElse(stripIllegalChars(formDefinition.getFormName()));
@@ -78,7 +78,7 @@ class Csv {
     );
   }
 
-  static Csv repeat(FormDefinition formDefinition, Model groupModel, ExportConfiguration configuration, int sequenceNumber) {
+  private static Csv repeat(FormDefinition formDefinition, Model groupModel, ExportConfiguration configuration, int sequenceNumber) {
     String repeatFileNameBase = configuration.getExportFileName()
         .map(UncheckedFiles::stripFileExtension)
         .orElse(stripIllegalChars(formDefinition.getFormName()));
@@ -96,34 +96,6 @@ class Csv {
         configuration.resolveOverwriteExistingFiles(),
         CsvSubmissionMappers.repeat(formDefinition, groupModel, configuration)
     );
-  }
-
-  /**
-   * Returns true if the grandparent node of the given Model is the model's root
-   * <p>
-   * Example 1:
-   * <p>
-   * <code><pre>
-   * &lt;data&gt;
-   * &nbsp;&nbsp;&lt;/some_field&gt;
-   * &lt;/data&gt;
-   * </pre></code>
-   * <p>
-   * In this example:
-   * <ul>
-   * <li>&lt;data&gt; has a parent with <code>null</code> name</li>
-   * <li>Returns true on &lt;some_field&gt;</li>
-   * </ul>
-   */
-  private static boolean grandParentIsRoot(Model current) {
-    return current.hasParent()
-        && current.getParent().hasParent() // Check if current has a grandparent
-        && current.getParent().getParent().getName() == null; // The root node has a null name
-  }
-
-  private static boolean parentIsRepeatGroup(Model current) {
-    return current.hasParent()
-        && current.getParent().isRepeatable();
   }
 
   static List<Csv> getCsvs(FormDefinition formDef, ExportConfiguration configuration) {

--- a/src/org/opendatakit/briefcase/export/Csv.java
+++ b/src/org/opendatakit/briefcase/export/Csv.java
@@ -3,6 +3,7 @@ package org.opendatakit.briefcase.export;
 import static java.nio.file.StandardOpenOption.APPEND;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static java.util.stream.Collectors.toList;
 import static org.opendatakit.briefcase.export.CsvSubmissionMappers.getMainHeader;
 import static org.opendatakit.briefcase.export.CsvSubmissionMappers.getRepeatHeader;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.write;
@@ -10,6 +11,8 @@ import static org.opendatakit.briefcase.util.StringUtils.stripIllegalChars;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 import org.opendatakit.briefcase.reused.UncheckedFiles;
 
@@ -99,6 +102,18 @@ class Csv {
   private static boolean parentIsRepeatGroup(Model current) {
     return current.hasParent()
         && current.getParent().isRepeatable();
+  }
+
+  static List<Csv> getCsvs(FormDefinition formDef, ExportConfiguration configuration) {
+    // Prepare the list of csv files we will export:
+    //  - one for the main instance
+    //  - one for each repeat group
+    List<Csv> csvs = new ArrayList<>();
+    csvs.add(main(formDef, configuration));
+    csvs.addAll(formDef.getRepeatableFields().stream()
+        .map(groupModel -> repeat(formDef, groupModel, configuration))
+        .collect(toList()));
+    return csvs;
   }
 
   /**

--- a/src/org/opendatakit/briefcase/export/Csv.java
+++ b/src/org/opendatakit/briefcase/export/Csv.java
@@ -58,15 +58,7 @@ class Csv {
     String repeatFileNameBase = configuration.getExportFileName()
         .map(UncheckedFiles::stripFileExtension)
         .orElse(stripIllegalChars(formDefinition.getFormName()));
-    String suffix = groupModel.getName();
-    Model current = groupModel;
-    while (!grandParentIsRoot(current) && !parentIsRepeatGroup(current)) {
-      current = current.getParent();
-      suffix = current.getName() + "-" + suffix;
-    }
-    Path output = configuration.getExportDir().resolve(
-        repeatFileNameBase + "-" + suffix + ".csv"
-    );
+    Path output = configuration.getExportDir().resolve(repeatFileNameBase + "-" + stripIllegalChars(groupModel.getName()) + ".csv");
     return new Csv(
         groupModel.fqn(),
         getRepeatHeader(groupModel, configuration.resolveSplitSelectMultiples()),

--- a/src/org/opendatakit/briefcase/export/ExportToCsv.java
+++ b/src/org/opendatakit/briefcase/export/ExportToCsv.java
@@ -21,7 +21,6 @@ import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
 import static java.nio.file.StandardOpenOption.WRITE;
 import static java.util.stream.Collectors.groupingByConcurrent;
 import static java.util.stream.Collectors.reducing;
-import static java.util.stream.Collectors.toList;
 import static org.opendatakit.briefcase.export.ExportOutcome.ALL_EXPORTED;
 import static org.opendatakit.briefcase.export.ExportOutcome.ALL_SKIPPED;
 import static org.opendatakit.briefcase.export.ExportOutcome.SOME_SKIPPED;
@@ -34,7 +33,6 @@ import static org.opendatakit.briefcase.reused.UncheckedFiles.exists;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.write;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -83,14 +81,7 @@ public class ExportToCsv {
 
     createDirectories(configuration.getExportDir());
 
-    // Prepare the list of csv files we will export:
-    //  - one for the main instance
-    //  - one for each repeat group
-    List<Csv> csvs = new ArrayList<>();
-    csvs.add(Csv.main(formDef, configuration));
-    csvs.addAll(formDef.getRepeatableFields().stream()
-        .map(groupModel -> Csv.repeat(formDef, groupModel, configuration))
-        .collect(toList()));
+    List<Csv> csvs = Csv.getCsvs(formDef, configuration);
 
     csvs.forEach(Csv::prepareOutputFiles);
 

--- a/src/org/opendatakit/briefcase/export/Model.java
+++ b/src/org/opendatakit/briefcase/export/Model.java
@@ -40,6 +40,7 @@ import org.javarosa.core.model.DataType;
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.instance.TreeElement;
+import org.opendatakit.briefcase.reused.BriefcaseException;
 
 /**
  * This class represents a particular level in the model of a Form.
@@ -297,6 +298,13 @@ class Model {
 
   private static Predicate<Model> modelWithName(String name) {
     return child -> child.getName().equals(name);
+  }
+
+  Model getChildByName(String name) {
+    return flatten()
+        .filter(child -> child.getName().equals(name))
+        .findFirst()
+        .orElseThrow(BriefcaseException::new);
   }
 
   // TODO This should be defined in JavaRosa, like the DataType enum

--- a/test/java/org/opendatakit/briefcase/export/CsvTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvTest.java
@@ -18,6 +18,7 @@ package org.opendatakit.briefcase.export;
 
 import static org.junit.Assert.assertThat;
 import static org.opendatakit.briefcase.matchers.PathMatchers.exists;
+import static org.opendatakit.briefcase.reused.UncheckedFiles.deleteRecursive;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -28,7 +29,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.opendatakit.briefcase.reused.OverridableBoolean;
-import org.opendatakit.briefcase.reused.UncheckedFiles;
 
 public class CsvTest {
   private Path exportDir;
@@ -42,7 +42,7 @@ public class CsvTest {
 
   @After
   public void tearDown() {
-    UncheckedFiles.deleteRecursive(exportDir);
+    deleteRecursive(exportDir);
   }
 
   @Test
@@ -57,7 +57,7 @@ public class CsvTest {
 
     FormDefinition formDef = buildFormDef("some_form", group, 4);
 
-    Csv.repeat(formDef, group, conf).prepareOutputFiles();
+    Csv.getCsvs(formDef, conf).forEach(Csv::prepareOutputFiles);
 
     assertThat(exportDir.resolve("some_form-r.csv"), exists());
   }
@@ -75,9 +75,7 @@ public class CsvTest {
 
     FormDefinition formDef = buildFormDef("some_form", group, 5);
 
-    Csv.repeat(formDef, group, conf).prepareOutputFiles();
-    Csv.repeat(formDef, group.getParent(), conf).prepareOutputFiles();
-    Csv.repeat(formDef, group.getParent().getParent().getParent(), conf).prepareOutputFiles();
+    Csv.getCsvs(formDef, conf).forEach(Csv::prepareOutputFiles);
 
     assertThat(exportDir.resolve("some_form-r1.csv"), exists());
     assertThat(exportDir.resolve("some_form-r2.csv"), exists());
@@ -94,8 +92,7 @@ public class CsvTest {
 
     FormDefinition formDef = buildFormDef("some.,form", group, 2);
 
-    Csv.main(formDef, conf).prepareOutputFiles();
-    Csv.repeat(formDef, group, conf).prepareOutputFiles();
+    Csv.getCsvs(formDef, conf).forEach(Csv::prepareOutputFiles);
 
     assertThat(exportDir.resolve("some__form.csv"), exists());
     assertThat(exportDir.resolve("some__form-re peat.csv"), exists());

--- a/test/java/org/opendatakit/briefcase/export/CsvTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvTest.java
@@ -114,7 +114,7 @@ public class CsvTest {
   }
 
   @Test
-  public void dupe_repeat_group_names_get_a_sequence_number_suffix() {
+  public void dupe_nested_repeat_group_names_get_a_sequence_number_suffix() {
     Model model = instance(
         repeat("outer-repeat",
             group("outer-group",
@@ -134,6 +134,22 @@ public class CsvTest {
     Csv.getCsvs(formDef, conf).forEach(Csv::prepareOutputFiles);
 
     assertThat(exportDir.resolve("some_form-outer_repeat.csv"), exists());
+    assertThat(exportDir.resolve("some_form-dupe_repeat~1.csv"), exists());
+    assertThat(exportDir.resolve("some_form-dupe_repeat~2.csv"), exists());
+  }
+
+  @Test
+  public void dupe_sibling_repeat_group_names_get_a_sequence_number_suffix() {
+    Model model = instance(
+        group("group1", repeat("dupe-repeat", text("some-field"))),
+        group("group2", repeat("dupe-repeat", text("some-field")))
+    ).build();
+
+    FormDefinition formDef = buildFormDef("some-form", model);
+
+    Csv.getCsvs(formDef, conf).forEach(Csv::prepareOutputFiles);
+
+    assertThat(exportDir.resolve("some_form.csv"), exists());
     assertThat(exportDir.resolve("some_form-dupe_repeat~1.csv"), exists());
     assertThat(exportDir.resolve("some_form-dupe_repeat~2.csv"), exists());
   }

--- a/test/java/org/opendatakit/briefcase/export/CsvTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvTest.java
@@ -101,6 +101,26 @@ public class CsvTest {
     assertThat(exportDir.resolve("some__form-re peat.csv"), exists());
   }
 
+  @Test
+  public void dupe_repeat_group_names_get_a_sequence_number_suffix() {
+    Model group = new ModelBuilder()
+        .addGroup("data")
+        .addRepeatGroup("outer-repeat")
+        .addGroup("outer-group")
+        .addRepeatGroup("dupe-repeat")
+        .addGroup("inner-group")
+        .addRepeatGroup("dupe-repeat")
+        .build();
+
+    FormDefinition formDef = buildFormDef("some-form", group, 5);
+
+    Csv.getCsvs(formDef, conf).forEach(Csv::prepareOutputFiles);
+
+    assertThat(exportDir.resolve("some_form-outer_repeat.csv"), exists());
+    assertThat(exportDir.resolve("some_form-dupe_repeat~1.csv"), exists());
+    assertThat(exportDir.resolve("some_form-dupe_repeat~2.csv"), exists());
+  }
+
   private ExportConfiguration buildConf(Path exportDir) {
     return new ExportConfiguration(
         Optional.empty(),

--- a/test/java/org/opendatakit/briefcase/export/CsvTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvTest.java
@@ -59,7 +59,7 @@ public class CsvTest {
 
     Csv.repeat(formDef, group, conf).prepareOutputFiles();
 
-    assertThat(exportDir.resolve("some_form-g1-g2-g3-r.csv"), exists());
+    assertThat(exportDir.resolve("some_form-r.csv"), exists());
   }
 
   @Test
@@ -79,12 +79,12 @@ public class CsvTest {
     Csv.repeat(formDef, group.getParent(), conf).prepareOutputFiles();
     Csv.repeat(formDef, group.getParent().getParent().getParent(), conf).prepareOutputFiles();
 
-    assertThat(exportDir.resolve("some_form-g1-r1.csv"), exists());
-    assertThat(exportDir.resolve("some_form-g2-r2.csv"), exists());
+    assertThat(exportDir.resolve("some_form-r1.csv"), exists());
+    assertThat(exportDir.resolve("some_form-r2.csv"), exists());
     assertThat(exportDir.resolve("some_form-r3.csv"), exists());
   }
 
-  public ExportConfiguration buildConf(Path exportDir) {
+  private ExportConfiguration buildConf(Path exportDir) {
     return new ExportConfiguration(
         Optional.of("some_form.csv"),
         Optional.of(exportDir),

--- a/test/java/org/opendatakit/briefcase/export/ExportConfigurationTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportConfigurationTest.java
@@ -17,11 +17,9 @@ package org.opendatakit.briefcase.export;
 
 import static java.nio.file.Files.createTempDirectory;
 import static java.nio.file.Files.write;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -34,7 +32,6 @@ import static org.opendatakit.briefcase.reused.TriStateBoolean.TRUE;
 import static org.opendatakit.briefcase.reused.TriStateBoolean.UNDETERMINED;
 
 import com.github.npathai.hamcrestopt.OptionalMatchers;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -207,17 +204,6 @@ public class ExportConfigurationTest {
   }
 
   @Test
-  public void toString_hashCode_and_equals_for_coverage() {
-    assertThat(validConfig.toString(), containsString("some" + File.separator + "dir"));
-    assertThat(validConfig.toString(), containsString("some_key.pem"));
-    assertThat(validConfig.toString(), containsString("2018"));
-    assertThat(validConfig.toString(), containsString("2020"));
-    assertThat(validConfig.hashCode(), is(notNullValue()));
-    assertThat(validConfig.equals(null), is(false));
-    assertThat(validConfig, is(validConfig));
-  }
-
-  @Test
   public void knows_the_path_to_the_output_audit_file() {
     assertThat(validConfig.getAuditPath("some-form").getFileName().toString(), is("some-form - audit.csv"));
     assertThat(validConfig.getAuditPath("some-form").getFileName().toString(), is("some-form - audit.csv"));
@@ -229,16 +215,16 @@ public class ExportConfigurationTest {
   }
 
   @Test
-  public void ensures_the_export_filename_has_csv_extension() {
-    assertThat(buildConf("some_filename").getExportFileName(), OptionalMatchers.isPresentAnd(is("some_filename.csv")));
-    assertThat(buildConf("some_filename.csv").getExportFileName(), OptionalMatchers.isPresentAnd(is("some_filename.csv")));
-    assertThat(buildConf("some_filename.CSV").getExportFileName(), OptionalMatchers.isPresentAnd(is("some_filename.CSV")));
-    assertThat(buildConf("some_filename.cSv").getExportFileName(), OptionalMatchers.isPresentAnd(is("some_filename.cSv")));
+  public void builds_the_sanitized_export_filename_base_with_the_form_name_and_an_optional_filename_param() {
+    assertThat(buildConf("some_filename.csv").getFilenameBase("Some Form"), is("some_filename"));
+    assertThat(buildConf(null).getFilenameBase("Some Form"), is("Some Form"));
+    assertThat(buildConf("some,.-filename.csv").getFilenameBase("Some Form"), is("some___filename"));
+    assertThat(buildConf(null).getFilenameBase("Some ,.- Form"), is("Some ___ Form"));
   }
 
-  public ExportConfiguration buildConf(String exportFileName) {
+  public ExportConfiguration buildConf(String filename) {
     return new ExportConfiguration(
-        Optional.of(exportFileName),
+        Optional.ofNullable(filename),
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),

--- a/test/java/org/opendatakit/briefcase/export/ModelBuilder.java
+++ b/test/java/org/opendatakit/briefcase/export/ModelBuilder.java
@@ -16,54 +16,165 @@
 
 package org.opendatakit.briefcase.export;
 
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.javarosa.core.model.DataType.TEXT;
 import static org.javarosa.core.model.instance.TreeReference.DEFAULT_MULTIPLICITY;
 
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.javarosa.core.model.DataType;
 import org.javarosa.core.model.QuestionDef;
+import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.instance.TreeElement;
+import org.kxml2.io.KXmlParser;
+import org.kxml2.kdom.Document;
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
 
 class ModelBuilder {
-  private TreeElement current = new TreeElement(null, DEFAULT_MULTIPLICITY);
-  private Map<String, QuestionDef> controls = new HashMap<>();
+  private final TreeElement current;
+  private final Map<String, QuestionDef> controls;
 
-  ModelBuilder addGroup(String name) {
-    TreeElement child = new TreeElement(name, DEFAULT_MULTIPLICITY);
-    child.setDataType(DataType.NULL.value);
-    child.setRepeatable(false);
-    child.setParent(current);
-    current.addChild(child);
-    current = child;
-    return this;
+  ModelBuilder(TreeElement current, Map<String, QuestionDef> controls) {
+    this.current = current;
+    this.controls = controls;
   }
 
-  ModelBuilder addRepeatGroup(String name) {
-    TreeElement child = new TreeElement(name, DEFAULT_MULTIPLICITY);
-    child.setDataType(DataType.NULL.value);
-    child.setRepeatable(true);
-    child.setParent(current);
-    current.addChild(child);
-    current = child;
-    return this;
+  public static ModelBuilder root(ModelBuilder... children) {
+    ModelBuilder root = new ModelBuilder(new TreeElement(null, DEFAULT_MULTIPLICITY), emptyMap());
+    root.add(children);
+    return root;
   }
 
-  ModelBuilder addField(String name, DataType dataType) {
-    return addField(name, dataType, null);
+  public static ModelBuilder instance(ModelBuilder... fields) {
+    return instance(Arrays.asList(fields));
   }
 
-  ModelBuilder addField(String name, DataType dataType, QuestionDef control) {
-    TreeElement child = new TreeElement(name, DEFAULT_MULTIPLICITY);
-    child.setDataType(dataType.value);
-    child.setParent(current);
-    current.addChild(child);
-    current = child;
-    if (control != null)
-      controls.put(Model.fqn(current, 0), control);
-    return this;
+  public static ModelBuilder instance(List<ModelBuilder> fields) {
+    ModelBuilder root = new ModelBuilder(new TreeElement(null, DEFAULT_MULTIPLICITY), emptyMap());
+    return root.add(group("data", fields));
+  }
+
+  public static ModelBuilder field(String name, DataType type) {
+    TreeElement element = new TreeElement(name, DEFAULT_MULTIPLICITY);
+    element.setDataType(type.value);
+    return new ModelBuilder(element, emptyMap());
+  }
+
+  public static ModelBuilder field(String name, DataType type, QuestionDef control) {
+    TreeElement element = new TreeElement(name, DEFAULT_MULTIPLICITY);
+    element.setDataType(type.value);
+    return new ModelBuilder(element, singletonMap(name, control));
+  }
+
+  public static ModelBuilder nul(String name) {
+    return field(name, DataType.NULL);
+  }
+
+  public static ModelBuilder text(String name) {
+    return field(name, DataType.TEXT);
+  }
+
+  public static ModelBuilder geopoint(String name) {
+    return field(name, DataType.GEOPOINT);
+  }
+
+  public static ModelBuilder geotrace(String name) {
+    return field(name, DataType.GEOTRACE);
+  }
+
+  public static ModelBuilder geoshape(String name) {
+    return field(name, DataType.GEOSHAPE);
+  }
+
+  public static ModelBuilder selectMultiple(String name, SelectChoice... choices) {
+    QuestionDef control = new QuestionDef();
+    control.setControlType(Model.ControlType.SELECT_MULTI.value);
+    for (SelectChoice choice : choices)
+      control.addSelectChoice(choice);
+    TreeElement element = new TreeElement(name, DEFAULT_MULTIPLICITY);
+    element.setDataType(TEXT.value);
+    return new ModelBuilder(element, singletonMap(name, control));
+  }
+
+
+  public static ModelBuilder group(String name, ModelBuilder... children) {
+    return group(name, Arrays.asList(children));
+  }
+
+  public static ModelBuilder group(String name, List<ModelBuilder> children) {
+    TreeElement element = new TreeElement(name, DEFAULT_MULTIPLICITY);
+    element.setDataType(DataType.NULL.value);
+    element.setRepeatable(false);
+    ModelBuilder group = new ModelBuilder(element, emptyMap());
+    return group.add(children);
+  }
+
+  public static ModelBuilder repeat(String name, ModelBuilder... children) {
+    TreeElement element = new TreeElement(name, DEFAULT_MULTIPLICITY);
+    element.setDataType(DataType.NULL.value);
+    element.setRepeatable(true);
+    ModelBuilder repeat = new ModelBuilder(element, emptyMap());
+    return repeat.add(children);
+  }
+
+  private static Document parse(String xml) throws XmlPullParserException, IOException {
+    Document tempDoc = new Document();
+    KXmlParser parser = new KXmlParser();
+    parser.setInput(new StringReader(xml));
+    parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true);
+    tempDoc.parse(parser);
+    return tempDoc;
+  }
+
+  static XmlElement parseXmlElement(String xml) throws XmlPullParserException, IOException {
+    return XmlElement.of(parse(xml));
+  }
+
+  static XmlElement buildXmlElementFrom(Model field) throws IOException, XmlPullParserException {
+    Model current = field;
+    String xml = "<" + current.getName() + "/>";
+    while (current.hasParent() && current.getParent().getName() != null) {
+      current = current.getParent();
+      xml = "<" + current.getName() + ">" + xml + "</" + current.getName() + ">";
+    }
+    return parseXmlElement(xml);
+  }
+
+  public ModelBuilder add(ModelBuilder... children) {
+    return add(Arrays.asList(children));
+  }
+
+  public ModelBuilder add(List<ModelBuilder> children) {
+    TreeElement newCurrent = copy(current);
+    Map<String, QuestionDef> newControls = new HashMap<>();
+    controls.forEach(newControls::put);
+    for (ModelBuilder child : children) {
+      TreeElement newChild = copy(child.current);
+      newCurrent.addChild(child.current);
+      newChild.setParent(newCurrent);
+      child.controls.forEach(newControls::put);
+    }
+    return new ModelBuilder(newCurrent, newControls);
+  }
+
+  private static TreeElement copy(TreeElement element) {
+    TreeElement newElement = new TreeElement(element.getName(), element.getMultiplicity());
+    newElement.setDataType(element.getDataType());
+    newElement.setRepeatable(element.isRepeatable());
+    return newElement;
   }
 
   Model build() {
     return new Model(current, controls);
+  }
+
+  public String getName() {
+    return current.getName();
   }
 }

--- a/test/java/org/opendatakit/briefcase/export/ModelTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ModelTest.java
@@ -20,13 +20,16 @@ import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.javarosa.core.model.DataType.TEXT;
 import static org.javarosa.core.model.instance.TreeReference.DEFAULT_MULTIPLICITY;
 import static org.junit.Assert.assertThat;
+import static org.opendatakit.briefcase.export.ModelBuilder.field;
+import static org.opendatakit.briefcase.export.ModelBuilder.instance;
+import static org.opendatakit.briefcase.export.ModelBuilder.selectMultiple;
 
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.javarosa.core.model.DataType;
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.instance.TreeElement;
@@ -37,14 +40,10 @@ public class ModelTest {
   public void gets_choices_of_a_related_select_control() {
     SelectChoice choice1 = new SelectChoice("some label 1", "some value 1", false);
     SelectChoice choice2 = new SelectChoice("some label 2", "some value 2", false);
-    QuestionDef control = new QuestionDef();
-    control.setControlType(Model.ControlType.SELECT_MULTI.value);
-    control.addSelectChoice(choice1);
-    control.addSelectChoice(choice2);
 
-    Model model = new ModelBuilder()
-        .addField("select", DataType.TEXT, control)
-        .build();
+    Model model = instance(selectMultiple("select", choice1, choice2))
+        .build()
+        .getChildByName("select");
 
     assertThat(model.getChoices(), contains(choice1, choice2));
   }
@@ -57,9 +56,10 @@ public class ModelTest {
     control.addSelectChoice(new SelectChoice("name", "name_key", false));
     control.setAppearanceAttr("search('some_external_instance')");
 
-    Model model = new ModelBuilder()
-        .addField("select", DataType.TEXT, control)
-        .build();
+    Model model = instance(field("select", TEXT, control))
+        .build()
+        .getChildByName("select");
+
 
     assertThat(model.getChoices(), empty());
   }

--- a/test/java/org/opendatakit/briefcase/export/XmlElementTest.java
+++ b/test/java/org/opendatakit/briefcase/export/XmlElementTest.java
@@ -18,6 +18,9 @@ package org.opendatakit.briefcase.export;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.opendatakit.briefcase.export.ModelBuilder.group;
+import static org.opendatakit.briefcase.export.ModelBuilder.repeat;
+import static org.opendatakit.briefcase.export.ModelBuilder.text;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -30,12 +33,17 @@ import org.xmlpull.v1.XmlPullParserException;
 public class XmlElementTest {
   @Test
   public void knows_how_to_generate_keys_of_a_repeat_nested_in_groups() throws IOException, XmlPullParserException {
-    Model field = new ModelBuilder()
-        .addGroup("g1")
-        .addGroup("g2")
-        .addGroup("g3")
-        .addRepeatGroup("r")
-        .build();
+    Model field = ModelBuilder.instance(
+        group("g1",
+            group("g2",
+                group("g3",
+                    repeat("r",
+                        text("field")
+                    )
+                )
+            )
+        )
+    ).build().getChildByName("r");
     XmlElement xmlElement = buildXmlElementFrom(field);
 
     assertThat(xmlElement.getCurrentLocalId(field, "uuid:SOMELONGUUID"), is("uuid:SOMELONGUUID/r[1]"));
@@ -45,13 +53,19 @@ public class XmlElementTest {
 
   @Test
   public void knows_how_to_generate_keys_of_nested_repeats() throws IOException, XmlPullParserException {
-    Model field = new ModelBuilder()
-        .addGroup("g1")
-        .addGroup("g2")
-        .addGroup("g3")
-        .addRepeatGroup("r1")
-        .addRepeatGroup("r2")
-        .build();
+    Model field = ModelBuilder.instance(
+        group("g1",
+            group("g2",
+                group("g3",
+                    repeat("r1",
+                        repeat("r2",
+                            text("field")
+                        )
+                    )
+                )
+            )
+        )
+    ).build().getChildByName("r2");
     XmlElement xmlElement = buildXmlElementFrom(field);
 
     assertThat(xmlElement.getCurrentLocalId(field, "uuid:SOMELONGUUID"), is("uuid:SOMELONGUUID/r1[1]/r2[1]"));


### PR DESCRIPTION
Closes #663 

#### What has been done to verify that this works as intended?

Add automated tests that cover the changes

#### Why is this the best possible solution? Were any other approaches considered?

These are narrow changes to support the change on filenames and the sequencing of files for deduplication.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This PR changes the filenames of output CSV files of repeat groups. Now, we use unqualified names and when more than one repeat group share the same name, we add a sequence number to the filenames for deduplication.

Sequence numbers start on 1 and assignation happens following a depth-first order.

I've tried this PR with two forms:
- [dupe-sibling-repeats.zip](https://github.com/opendatakit/briefcase/files/2556958/dupe-sibling-repeats.zip)

    ```
    group1
      dupe-repeat
    group2
      dupe-repeat
    ```
- [dupe-nested-repeats.zip](https://github.com/opendatakit/briefcase/files/2556960/dupe-nested-repeats.zip)


    ```
    outer-group
      dupe-repeat
        inner-group
          dupe-repeat
    ```

I'm getting these output files:
- `dupe_sibling_repeats.csv`
- `dupe_sibling_repeats-dupe_repeat~1.csv`
- `dupe_sibling_repeats-dupe_repeat~2.csv`
- `dupe_nested_repeats.csv`
- `dupe_nested_repeats-dupe_repeat~1.csv`
- `dupe_nested_repeats-dupe_repeat~2.csv`

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.

This PR adapts the [export format docs](https://github.com/opendatakit/briefcase/blob/6e8b3fba467b55c0eecb152d583b407549d0ee33/docs/export-format.md#repeat-output-file) to explain how the file naming works now.