### PR TITLE
Issue 665 use instance id for sequencing audit files

### DIFF
--- a/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
+++ b/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
@@ -66,7 +66,7 @@ final class CsvFieldMappers {
 
   private static CsvFieldMapper AUDIT_MAPPER = BINARY_MAPPER
       .andThen((formName, localId, workingDir, model, maybeElement, configuration) -> maybeElement
-          .map(e -> audit(formName, localId, workingDir, configuration, e))
+          .map(e -> aggregatedAuditFile(formName, localId, workingDir, configuration, e))
           .orElse(empty(model.fqn())))
       .map(output -> output.filter(pair -> !pair.getLeft().contains("-aggregated")));
 
@@ -227,7 +227,7 @@ final class CsvFieldMappers {
     return Stream.of(Pair.of(element.fqn(), Paths.get("media").resolve(sequentialDestinationFile.getFileName()).toString()));
   }
 
-  private static Stream<Pair<String, String>> audit(String formName, String localId, Path workingDir, ExportConfiguration configuration, XmlElement e) {
+  private static Stream<Pair<String, String>> aggregatedAuditFile(String formName, String localId, Path workingDir, ExportConfiguration configuration, XmlElement e) {
     if (!e.hasValue())
       return empty(e.fqn() + "-aggregated");
 

--- a/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
@@ -267,6 +267,20 @@ public class CsvFieldMappersTest {
   }
 
   @Test
+  public void individual_audit_filenames_include_the_instance_id() {
+    scenario = Scenario.nonGroup("some-form", DataType.BINARY, "audit", "meta");
+    write(scenario.getWorkDir().resolve("audit.csv"), "event, node, start, end\nform start,,1536663986578,\n");
+
+    List<Pair<String, String>> output = scenario.mapSimpleValue("audit.csv", true);
+    assertThat(output, contains(Pair.of("data-audit", "media/audit-" + scenario.getInstanceId() + ".csv")));
+
+    Path outputAudit = scenario.getOutputMediaDir().resolve("audit-" + scenario.getInstanceId() + ".csv");
+
+    assertThat(outputAudit, exists());
+    assertThat(outputAudit, fileContains("event, node, start, end\nform start,,1536663986578,\n"));
+  }
+
+  @Test
   public void audit_fields_append_the_submissions_content_to_the_output_audit_file() {
     scenario = Scenario.nonGroup("some-form", DataType.BINARY, "audit", "meta");
     write(scenario.getWorkDir().resolve("audit.csv"), "event, node, start, end\nform start,,1536663986578,\n");

--- a/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvFieldMappersTest.java
@@ -285,10 +285,7 @@ public class CsvFieldMappersTest {
     scenario = Scenario.nonGroup("some-form", DataType.BINARY, "audit", "meta");
     write(scenario.getWorkDir().resolve("audit.csv"), "event, node, start, end\nform start,,1536663986578,\n");
 
-    List<Pair<String, String>> output = scenario.mapSimpleValue("audit.csv", true);
-    assertThat(output, contains(
-        Pair.of("data-audit", "media/audit.csv")
-    ));
+    scenario.mapSimpleValue("audit.csv", true);
 
     Path outputAudit = scenario.getOutputDir().resolve(scenario.getFormName() + " - audit.csv");
 
@@ -301,10 +298,7 @@ public class CsvFieldMappersTest {
     scenario = Scenario.nonGroup("some-form", DataType.BINARY, "audit", "meta");
     write(scenario.getWorkDir().resolve("audit.csv"), "event, node, start, end\nform start,,1536663986578,\n");
 
-    List<Pair<String, String>> output = scenario.mapSimpleValue("audit.csv", true);
-    assertThat(output, contains(
-        Pair.of("data-audit", "media/audit.csv")
-    ));
+    scenario.mapSimpleValue("audit.csv", true);
 
     Path outputAudit = scenario.getOutputDir().resolve(scenario.getFormName() + " - audit.csv");
 


### PR DESCRIPTION
Closes #665

#### What has been done to verify that this works as intended?
Added automated tests that cover the changes
Also tested manually using the UI and this form: [უნივერსიტეტის გამოკითხვა.zip](https://github.com/opendatakit/briefcase/files/2501380/default.zip)

#### Why is this the best possible solution? Were any other approaches considered?
This PR uses the current binary field mapper as a base for the individual audit file mapper and adds the smallest possible changes to deal with the filename.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Users won't have individual audit files with sequence numbers in the output `media` folders. Now, all audit files include the instance ID, which prevents name collisions and makes the files more useful for users, since it's easier to link the files to their corresponding rows in the output CSV files.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No, but I could be convinced to cover the audit exports on the docs.