### PR TITLE
Issue 671 export param to remove group names

### DIFF
--- a/src/org/opendatakit/briefcase/export/Csv.java
+++ b/src/org/opendatakit/briefcase/export/Csv.java
@@ -56,7 +56,7 @@ class Csv {
   private static Csv main(FormDefinition formDefinition, ExportConfiguration configuration) {
     return new Csv(
         formDefinition.getModel().fqn(),
-        getMainHeader(formDefinition.getModel(), formDefinition.isFileEncryptedForm(), configuration.resolveSplitSelectMultiples()),
+        getMainHeader(formDefinition.getModel(), formDefinition.isFileEncryptedForm(), configuration.resolveSplitSelectMultiples(), false),
         buildMainOutputPath(formDefinition, configuration),
         true,
         configuration.resolveOverwriteExistingFiles(),
@@ -67,7 +67,7 @@ class Csv {
   private static Csv repeat(FormDefinition formDefinition, Model groupModel, ExportConfiguration configuration, Path output) {
     return new Csv(
         groupModel.fqn(),
-        getRepeatHeader(groupModel, configuration.resolveSplitSelectMultiples()),
+        getRepeatHeader(groupModel, configuration.resolveSplitSelectMultiples(), false),
         output,
         false,
         configuration.resolveOverwriteExistingFiles(),

--- a/src/org/opendatakit/briefcase/export/Csv.java
+++ b/src/org/opendatakit/briefcase/export/Csv.java
@@ -56,7 +56,12 @@ class Csv {
   private static Csv main(FormDefinition formDefinition, ExportConfiguration configuration) {
     return new Csv(
         formDefinition.getModel().fqn(),
-        getMainHeader(formDefinition.getModel(), formDefinition.isFileEncryptedForm(), configuration.resolveSplitSelectMultiples(), configuration.resolveRemoveGroupNames()),
+        getMainHeader(
+            formDefinition.getModel(),
+            formDefinition.isFileEncryptedForm(),
+            configuration.resolveSplitSelectMultiples(),
+            configuration.resolveRemoveGroupNames()
+        ),
         buildMainOutputPath(formDefinition, configuration),
         true,
         configuration.resolveOverwriteExistingFiles(),
@@ -67,7 +72,11 @@ class Csv {
   private static Csv repeat(FormDefinition formDefinition, Model groupModel, ExportConfiguration configuration, Path output) {
     return new Csv(
         groupModel.fqn(),
-        getRepeatHeader(groupModel, configuration.resolveSplitSelectMultiples(), configuration.resolveRemoveGroupNames()),
+        getRepeatHeader(
+            groupModel,
+            configuration.resolveSplitSelectMultiples(),
+            configuration.resolveRemoveGroupNames()
+        ),
         output,
         false,
         configuration.resolveOverwriteExistingFiles(),

--- a/src/org/opendatakit/briefcase/export/Csv.java
+++ b/src/org/opendatakit/briefcase/export/Csv.java
@@ -56,7 +56,7 @@ class Csv {
   private static Csv main(FormDefinition formDefinition, ExportConfiguration configuration) {
     return new Csv(
         formDefinition.getModel().fqn(),
-        getMainHeader(formDefinition.getModel(), formDefinition.isFileEncryptedForm(), configuration.resolveSplitSelectMultiples(), false),
+        getMainHeader(formDefinition.getModel(), formDefinition.isFileEncryptedForm(), configuration.resolveSplitSelectMultiples(), configuration.resolveRemoveGroupNames()),
         buildMainOutputPath(formDefinition, configuration),
         true,
         configuration.resolveOverwriteExistingFiles(),
@@ -67,7 +67,7 @@ class Csv {
   private static Csv repeat(FormDefinition formDefinition, Model groupModel, ExportConfiguration configuration, Path output) {
     return new Csv(
         groupModel.fqn(),
-        getRepeatHeader(groupModel, configuration.resolveSplitSelectMultiples(), false),
+        getRepeatHeader(groupModel, configuration.resolveSplitSelectMultiples(), configuration.resolveRemoveGroupNames()),
         output,
         false,
         configuration.resolveOverwriteExistingFiles(),

--- a/src/org/opendatakit/briefcase/export/CsvSubmissionMappers.java
+++ b/src/org/opendatakit/briefcase/export/CsvSubmissionMappers.java
@@ -102,11 +102,12 @@ final class CsvSubmissionMappers {
   /**
    * Produce a CSV line with the main form's header column names.
    *
-   * @param model       {@link Model} of the form
-   * @param isEncrypted {@link Boolean} indicating if the form is encrypted
+   * @param model            {@link Model} of the form
+   * @param isEncrypted      {@link Boolean} indicating if the form is encrypted
+   * @param removeGroupNames
    * @return a {@link String} with the main form's header column names
    */
-  static String getMainHeader(Model model, boolean isEncrypted, boolean splitSelectMultiples) {
+  static String getMainHeader(Model model, boolean isEncrypted, boolean splitSelectMultiples, boolean removeGroupNames) {
     StringBuilder sb = new StringBuilder();
     sb.append("SubmissionDate");
     model.forEach(field -> {
@@ -127,10 +128,11 @@ final class CsvSubmissionMappers {
   /**
    * Produce a CSV line with a repeat group's header column names.
    *
-   * @param groupModel {@link Model} of the group
+   * @param groupModel       {@link Model} of the group
+   * @param removeGroupNames
    * @return a {@link String} with a repeat group's header column names
    */
-  static String getRepeatHeader(Model groupModel, boolean splitSelectMultiples) {
+  static String getRepeatHeader(Model groupModel, boolean splitSelectMultiples, boolean removeGroupNames) {
     int shift = groupModel.countAncestors();
     StringBuilder sb = new StringBuilder();
     groupModel.forEach(field -> {

--- a/src/org/opendatakit/briefcase/export/ExportConfiguration.java
+++ b/src/org/opendatakit/briefcase/export/ExportConfiguration.java
@@ -66,6 +66,7 @@ public class ExportConfiguration {
   private static final String SPLIT_SELECT_MULTIPLES = "splitSelectMultiples";
   private static final String SPLIT_SELECT_MULTIPLES_OVERRIDE = "splitSelectMultiplesOverride";
   private static final String INCLUDE_GEOJSON_EXPORT = "includeGeoJsonExport";
+  private static final String REMOVE_GROUP_NAMES = "removeGroupNames";
   private final Optional<String> exportFileName;
   private final Optional<Path> exportDir;
   private final Optional<Path> pemFile;
@@ -75,8 +76,9 @@ public class ExportConfiguration {
   private final OverridableBoolean exportMedia;
   private final OverridableBoolean splitSelectMultiples;
   private final OverridableBoolean includeGeoJsonExport;
+  private final OverridableBoolean removeGroupNames;
 
-  private ExportConfiguration(Optional<String> exportFileName, Optional<Path> exportDir, Optional<Path> pemFile, DateRange dateRange, OverridableBoolean pullBefore, OverridableBoolean overwriteFiles, OverridableBoolean exportMedia, OverridableBoolean splitSelectMultiples, OverridableBoolean includeGeoJsonExport) {
+  private ExportConfiguration(Optional<String> exportFileName, Optional<Path> exportDir, Optional<Path> pemFile, DateRange dateRange, OverridableBoolean pullBefore, OverridableBoolean overwriteFiles, OverridableBoolean exportMedia, OverridableBoolean splitSelectMultiples, OverridableBoolean includeGeoJsonExport, OverridableBoolean removeGroupNames) {
     this.exportFileName = exportFileName;
     this.exportDir = exportDir;
     this.pemFile = pemFile;
@@ -86,6 +88,7 @@ public class ExportConfiguration {
     this.exportMedia = exportMedia;
     this.splitSelectMultiples = splitSelectMultiples;
     this.includeGeoJsonExport = includeGeoJsonExport;
+    this.removeGroupNames = removeGroupNames;
   }
 
   public static List<String> keys() {
@@ -102,7 +105,8 @@ public class ExportConfiguration {
         keyPrefix + OVERWRITE_FILES,
         keyPrefix + EXPORT_MEDIA,
         keyPrefix + SPLIT_SELECT_MULTIPLES,
-        keyPrefix + INCLUDE_GEOJSON_EXPORT
+        keyPrefix + INCLUDE_GEOJSON_EXPORT,
+        keyPrefix + REMOVE_GROUP_NAMES
     );
   }
 
@@ -148,6 +152,7 @@ public class ExportConfiguration {
     map.put(keyPrefix + EXPORT_MEDIA, exportMedia.serialize());
     map.put(keyPrefix + SPLIT_SELECT_MULTIPLES, splitSelectMultiples.serialize());
     map.put(keyPrefix + INCLUDE_GEOJSON_EXPORT, includeGeoJsonExport.serialize());
+    map.put(keyPrefix + REMOVE_GROUP_NAMES, removeGroupNames.serialize());
     return map;
   }
 
@@ -181,6 +186,10 @@ public class ExportConfiguration {
 
   public boolean resolveIncludeGeoJsonExport() {
     return includeGeoJsonExport.resolve(false);
+  }
+
+  boolean resolveRemoveGroupNames() {
+    return removeGroupNames.resolve(false);
   }
 
   public OverridableBoolean getPullBefore() {
@@ -219,7 +228,8 @@ public class ExportConfiguration {
         && overwriteFiles.isEmpty()
         && exportMedia.isEmpty()
         && splitSelectMultiples.isEmpty()
-        && includeGeoJsonExport.isEmpty();
+        && includeGeoJsonExport.isEmpty()
+        && removeGroupNames.isEmpty();
   }
 
   public boolean isValid() {
@@ -237,6 +247,7 @@ public class ExportConfiguration {
         .setExportMedia(exportMedia.fallingBackTo(defaultConfiguration.exportMedia))
         .setSplitSelectMultiples(splitSelectMultiples.fallingBackTo(defaultConfiguration.splitSelectMultiples))
         .setIncludeGeoJsonExport(includeGeoJsonExport.fallingBackTo(defaultConfiguration.includeGeoJsonExport))
+        .setRemoveGroupNames(removeGroupNames.fallingBackTo(defaultConfiguration.removeGroupNames))
         .build();
   }
 
@@ -278,6 +289,7 @@ public class ExportConfiguration {
         ", exportMedia=" + exportMedia +
         ", splitSelectMultiples=" + splitSelectMultiples +
         ", includeGeoJsonExport=" + includeGeoJsonExport +
+        ", removeGroupNames=" + removeGroupNames +
         '}';
   }
 
@@ -295,12 +307,13 @@ public class ExportConfiguration {
         Objects.equals(overwriteFiles, that.overwriteFiles) &&
         Objects.equals(exportMedia, that.exportMedia) &&
         Objects.equals(splitSelectMultiples, that.splitSelectMultiples) &&
-        Objects.equals(includeGeoJsonExport, that.includeGeoJsonExport);
+        Objects.equals(includeGeoJsonExport, that.includeGeoJsonExport) &&
+        Objects.equals(removeGroupNames, that.removeGroupNames);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(exportDir, pemFile, dateRange, pullBefore, overwriteFiles, exportMedia, splitSelectMultiples, includeGeoJsonExport);
+    return Objects.hash(exportDir, pemFile, dateRange, pullBefore, overwriteFiles, exportMedia, splitSelectMultiples, includeGeoJsonExport, removeGroupNames);
   }
 
   public static class Builder {
@@ -314,6 +327,7 @@ public class ExportConfiguration {
     private OverridableBoolean exportMedia = OverridableBoolean.empty();
     private OverridableBoolean splitSelectMultiples = OverridableBoolean.empty();
     private OverridableBoolean includeGeoJsonExport = OverridableBoolean.empty();
+    private OverridableBoolean removeGroupNames = OverridableBoolean.empty();
 
     public static Builder empty() {
       return new Builder();
@@ -335,6 +349,7 @@ public class ExportConfiguration {
           .setExportMedia(readOverridableBoolean(prefs, keyPrefix + EXPORT_MEDIA, keyPrefix + EXPORT_MEDIA_OVERRIDE))
           .setSplitSelectMultiples(readOverridableBoolean(prefs, keyPrefix + SPLIT_SELECT_MULTIPLES, keyPrefix + SPLIT_SELECT_MULTIPLES_OVERRIDE))
           .setIncludeGeoJsonExport(readOverridableBoolean(prefs, keyPrefix + INCLUDE_GEOJSON_EXPORT))
+          .setRemoveGroupNames(readOverridableBoolean(prefs, keyPrefix + REMOVE_GROUP_NAMES))
           .build();
     }
 
@@ -358,7 +373,8 @@ public class ExportConfiguration {
           overwriteFiles,
           exportMedia,
           splitSelectMultiples,
-          includeGeoJsonExport
+          includeGeoJsonExport,
+          removeGroupNames
       );
     }
 
@@ -499,6 +515,16 @@ public class ExportConfiguration {
       return this;
     }
 
+    public Builder setRemoveGroupNames(OverridableBoolean removeGroupNames) {
+      this.removeGroupNames = removeGroupNames;
+      return this;
+    }
+
+    public Builder setRemoveGroupNames(boolean value) {
+      removeGroupNames = removeGroupNames.set(value);
+      return this;
+    }
+
     public Builder overridePullBefore(TriStateBoolean overrideValue) {
       pullBefore = pullBefore.overrideWith(overrideValue);
       return this;
@@ -521,6 +547,11 @@ public class ExportConfiguration {
 
     public Builder overrideIncludeGeoJsonExport(TriStateBoolean overrideValue) {
       includeGeoJsonExport = includeGeoJsonExport.overrideWith(overrideValue);
+      return this;
+    }
+
+    public Builder overrideRemoveGroupNames(TriStateBoolean overrideValue) {
+      removeGroupNames = removeGroupNames.overrideWith(overrideValue);
       return this;
     }
   }

--- a/src/org/opendatakit/briefcase/export/Model.java
+++ b/src/org/opendatakit/briefcase/export/Model.java
@@ -48,7 +48,7 @@ import org.opendatakit.briefcase.reused.BriefcaseException;
  * It can hold the root level model or any of its fields.
  */
 class Model {
-  private final TreeElement model;
+  final TreeElement model;
   private Map<String, QuestionDef> controls;
 
   /**
@@ -143,8 +143,8 @@ class Model {
    *
    * @return a {@link List} of {@link String} names of this {@link Model} instance
    */
-  List<String> getNames() {
-    return getNames(0);
+  List<String> getNames(boolean removeGroupNames) {
+    return getNames(0, removeGroupNames);
   }
 
   /**
@@ -153,9 +153,9 @@ class Model {
    *
    * @param shift an int with the number of names to shift from the FQN
    * @return a {@link List} of shifted {@link String} names of this {@link Model} instance
-   * @see Model#getNames()
+   * @see Model#getNames(boolean)
    */
-  List<String> getNames(int shift) {
+  List<String> getNames(int shift, boolean removeGroupNames) {
     if (getDataType() == GEOPOINT)
       return Arrays.asList(
           fqn(shift) + "-Latitude",
@@ -166,8 +166,8 @@ class Model {
     if (getDataType() == NULL && model.isRepeatable())
       return singletonList("SET-OF-" + fqn(shift));
     if (getDataType() == NULL && !model.isRepeatable() && size() > 0)
-      return children().stream().flatMap(e -> e.getNames(shift).stream()).collect(toList());
-    return singletonList(fqn(shift));
+      return children().stream().flatMap(e -> e.getNames(shift, removeGroupNames).stream()).collect(toList());
+    return singletonList(removeGroupNames ? getName() : fqn(shift));
   }
 
   /**
@@ -247,7 +247,7 @@ class Model {
     return model.getNumChildren();
   }
 
-  private List<Model> children() {
+  List<Model> children() {
     Set<String> fqns = new HashSet<>();
     List<Model> children = new ArrayList<>(model.getNumChildren());
     for (int i = 0, max = model.getNumChildren(); i < max; i++) {

--- a/src/org/opendatakit/briefcase/export/Model.java
+++ b/src/org/opendatakit/briefcase/export/Model.java
@@ -156,18 +156,19 @@ class Model {
    * @see Model#getNames(boolean)
    */
   List<String> getNames(int shift, boolean removeGroupNames) {
-    if (getDataType() == GEOPOINT)
-      return Arrays.asList(
-          fqn(shift) + "-Latitude",
-          fqn(shift) + "-Longitude",
-          fqn(shift) + "-Altitude",
-          fqn(shift) + "-Accuracy"
-      );
     if (getDataType() == NULL && model.isRepeatable())
       return singletonList("SET-OF-" + fqn(shift));
     if (getDataType() == NULL && !model.isRepeatable() && size() > 0)
       return children().stream().flatMap(e -> e.getNames(shift, removeGroupNames).stream()).collect(toList());
-    return singletonList(removeGroupNames ? getName() : fqn(shift));
+    String fieldName = removeGroupNames ? getName() : fqn(shift);
+    if (getDataType() == GEOPOINT)
+      return Arrays.asList(
+          fieldName + "-Latitude",
+          fieldName + "-Longitude",
+          fieldName + "-Altitude",
+          fieldName + "-Accuracy"
+      );
+    return singletonList(fieldName);
   }
 
   /**

--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -59,6 +59,7 @@ public class Export {
   private static final Param<Void> PULL_BEFORE = Param.flag("pb", "pull_before", "Pull before export");
   private static final Param<Void> SPLIT_SELECT_MULTIPLES = Param.flag("ssm", "split_select_multiples", "Split select multiple fields");
   private static final Param<Void> INCLUDE_GEOJSON_EXPORT = Param.flag("ig", "include_geojson", "Include a GeoJSON companion file with spatial data");
+  private static final Param<Void> REMOVE_GROUP_NAMES = Param.flag("rgn", "remove_group_names", "Remove group names from column names");
 
   public static Operation EXPORT_FORM = Operation.of(
       EXPORT,
@@ -74,13 +75,14 @@ public class Export {
           args.getOptional(END),
           args.getOptional(PEM_FILE),
           args.has(SPLIT_SELECT_MULTIPLES),
-          args.has(INCLUDE_GEOJSON_EXPORT)
+          args.has(INCLUDE_GEOJSON_EXPORT),
+          args.has(REMOVE_GROUP_NAMES)
       ),
       Arrays.asList(STORAGE_DIR, FORM_ID, FILE, EXPORT_DIR),
-      Arrays.asList(PEM_FILE, EXCLUDE_MEDIA, OVERWRITE, START, END, PULL_BEFORE, SPLIT_SELECT_MULTIPLES, INCLUDE_GEOJSON_EXPORT)
+      Arrays.asList(PEM_FILE, EXCLUDE_MEDIA, OVERWRITE, START, END, PULL_BEFORE, SPLIT_SELECT_MULTIPLES, INCLUDE_GEOJSON_EXPORT, REMOVE_GROUP_NAMES)
   );
 
-  public static void export(String storageDir, String formid, Path exportDir, String baseFilename, boolean exportMedia, boolean overwriteFiles, boolean pullBefore, Optional<LocalDate> startDate, Optional<LocalDate> endDate, Optional<Path> maybePemFile, boolean splitSelectMultiples, boolean includeGeoJsonExport) {
+  public static void export(String storageDir, String formid, Path exportDir, String baseFilename, boolean exportMedia, boolean overwriteFiles, boolean pullBefore, Optional<LocalDate> startDate, Optional<LocalDate> endDate, Optional<Path> maybePemFile, boolean splitSelectMultiples, boolean includeGeoJsonExport, boolean removeGroupNames) {
     CliEventsCompanion.attach(log);
     Path briefcaseDir = Common.getOrCreateBriefcaseDir(storageDir);
     FormCache formCache = FormCache.from(briefcaseDir);
@@ -102,6 +104,7 @@ public class Export {
         .setOverwriteFiles(overwriteFiles)
         .setExportMedia(exportMedia)
         .setSplitSelectMultiples(splitSelectMultiples)
+        .setRemoveGroupNames(removeGroupNames)
         .build();
 
     if (configuration.resolvePullBefore()) {

--- a/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
+++ b/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
@@ -26,7 +26,6 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.util.Optional;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -319,6 +318,7 @@ public class BriefcaseCLI {
             Optional.ofNullable(startDateString).map(s -> LocalDate.parse(s.replaceAll("/", "-"))),
             Optional.ofNullable(endDateString).map(s -> LocalDate.parse(s.replaceAll("/", "-"))),
             Optional.ofNullable(pemKeyFile).map(Paths::get),
+            false,
             false,
             false
         );

--- a/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersHeadersTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersHeadersTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.opendatakit.briefcase.export.CsvSubmissionMappers.getMainHeader;
 import static org.opendatakit.briefcase.export.CsvSubmissionMappers.getRepeatHeader;
+import static org.opendatakit.briefcase.export.ModelBuilder.geopoint;
 import static org.opendatakit.briefcase.export.ModelBuilder.group;
 import static org.opendatakit.briefcase.export.ModelBuilder.instance;
 import static org.opendatakit.briefcase.export.ModelBuilder.repeat;
@@ -55,5 +56,16 @@ public class CsvSubmissionMappersHeadersTest {
     assertThat(getMainHeader(model, true, false, false), is("SubmissionDate,group-1-field,group-2-field,KEY,isValidated"));
     assertThat(getMainHeader(model, false, false, true), is("SubmissionDate,field,field,KEY"));
     assertThat(getMainHeader(model, true, false, true), is("SubmissionDate,field,field,KEY,isValidated"));
+  }
+
+  @Test
+  public void supports_fields_that_generate_more_than_one_column() {
+    Model model = instance(
+        group("some-group", geopoint("some-point"))
+    ).build();
+    assertThat(getMainHeader(model, false, false, false), is("SubmissionDate,some-group-some-point-Latitude,some-group-some-point-Longitude,some-group-some-point-Altitude,some-group-some-point-Accuracy,KEY"));
+    assertThat(getMainHeader(model, true, false, false), is("SubmissionDate,some-group-some-point-Latitude,some-group-some-point-Longitude,some-group-some-point-Altitude,some-group-some-point-Accuracy,KEY,isValidated"));
+    assertThat(getMainHeader(model, false, false, true), is("SubmissionDate,some-point-Latitude,some-point-Longitude,some-point-Altitude,some-point-Accuracy,KEY"));
+    assertThat(getMainHeader(model, true, false, true), is("SubmissionDate,some-point-Latitude,some-point-Longitude,some-point-Altitude,some-point-Accuracy,KEY,isValidated"));
   }
 }

--- a/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersHeadersTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersHeadersTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.export;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.opendatakit.briefcase.export.CsvSubmissionMappers.getMainHeader;
+import static org.opendatakit.briefcase.export.CsvSubmissionMappers.getRepeatHeader;
+import static org.opendatakit.briefcase.export.ModelBuilder.group;
+import static org.opendatakit.briefcase.export.ModelBuilder.instance;
+import static org.opendatakit.briefcase.export.ModelBuilder.repeat;
+import static org.opendatakit.briefcase.export.ModelBuilder.text;
+
+import org.junit.Test;
+
+public class CsvSubmissionMappersHeadersTest {
+
+  @Test
+  public void produces_a_header_for_the_main_file() {
+    Model model = instance(group("group", text("field"))).build();
+    assertThat(getMainHeader(model, false, false), is("SubmissionDate,group-field,KEY"));
+    assertThat(getMainHeader(model, true, false), is("SubmissionDate,group-field,KEY,isValidated"));
+  }
+
+  @Test
+  public void produces_a_header_for_a_repeat_file() {
+    Model repeat = instance(repeat("repeat", group("group", text("field")))).build().getChildByName("repeat");
+    assertThat(getRepeatHeader(repeat, false), is("group-field,PARENT_KEY,KEY,SET-OF-repeat"));
+  }
+}

--- a/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersHeadersTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersHeadersTest.java
@@ -44,4 +44,16 @@ public class CsvSubmissionMappersHeadersTest {
     assertThat(getRepeatHeader(repeat, false, false), is("group-field,PARENT_KEY,KEY,SET-OF-repeat"));
     assertThat(getRepeatHeader(repeat, false, true), is("field,PARENT_KEY,KEY,SET-OF-repeat"));
   }
+
+  @Test
+  public void supports_dupe_field_names() {
+    Model model = instance(
+        group("group-1", text("field")),
+        group("group-2", text("field"))
+    ).build();
+    assertThat(getMainHeader(model, false, false, false), is("SubmissionDate,group-1-field,group-2-field,KEY"));
+    assertThat(getMainHeader(model, true, false, false), is("SubmissionDate,group-1-field,group-2-field,KEY,isValidated"));
+    assertThat(getMainHeader(model, false, false, true), is("SubmissionDate,field,field,KEY"));
+    assertThat(getMainHeader(model, true, false, true), is("SubmissionDate,field,field,KEY,isValidated"));
+  }
 }

--- a/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersHeadersTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersHeadersTest.java
@@ -32,13 +32,13 @@ public class CsvSubmissionMappersHeadersTest {
   @Test
   public void produces_a_header_for_the_main_file() {
     Model model = instance(group("group", text("field"))).build();
-    assertThat(getMainHeader(model, false, false), is("SubmissionDate,group-field,KEY"));
-    assertThat(getMainHeader(model, true, false), is("SubmissionDate,group-field,KEY,isValidated"));
+    assertThat(getMainHeader(model, false, false, false), is("SubmissionDate,group-field,KEY"));
+    assertThat(getMainHeader(model, true, false, false), is("SubmissionDate,group-field,KEY,isValidated"));
   }
 
   @Test
   public void produces_a_header_for_a_repeat_file() {
     Model repeat = instance(repeat("repeat", group("group", text("field")))).build().getChildByName("repeat");
-    assertThat(getRepeatHeader(repeat, false), is("group-field,PARENT_KEY,KEY,SET-OF-repeat"));
+    assertThat(getRepeatHeader(repeat, false, false), is("group-field,PARENT_KEY,KEY,SET-OF-repeat"));
   }
 }

--- a/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersHeadersTest.java
+++ b/test/java/org/opendatakit/briefcase/export/CsvSubmissionMappersHeadersTest.java
@@ -34,11 +34,14 @@ public class CsvSubmissionMappersHeadersTest {
     Model model = instance(group("group", text("field"))).build();
     assertThat(getMainHeader(model, false, false, false), is("SubmissionDate,group-field,KEY"));
     assertThat(getMainHeader(model, true, false, false), is("SubmissionDate,group-field,KEY,isValidated"));
+    assertThat(getMainHeader(model, false, false, true), is("SubmissionDate,field,KEY"));
+    assertThat(getMainHeader(model, true, false, true), is("SubmissionDate,field,KEY,isValidated"));
   }
 
   @Test
   public void produces_a_header_for_a_repeat_file() {
     Model repeat = instance(repeat("repeat", group("group", text("field")))).build().getChildByName("repeat");
     assertThat(getRepeatHeader(repeat, false, false), is("group-field,PARENT_KEY,KEY,SET-OF-repeat"));
+    assertThat(getRepeatHeader(repeat, false, true), is("field,PARENT_KEY,KEY,SET-OF-repeat"));
   }
 }

--- a/test/java/org/opendatakit/briefcase/export/ExportConfigurationTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportConfigurationTest.java
@@ -163,6 +163,7 @@ public class ExportConfigurationTest {
     assertThat(empty().setExportMedia(true).build(), not(isEmpty()));
     assertThat(empty().setSplitSelectMultiples(true).build(), not(isEmpty()));
     assertThat(empty().setIncludeGeoJsonExport(true).build(), not(isEmpty()));
+    assertThat(empty().setRemoveGroupNames(true).build(), not(isEmpty()));
   }
 
   @Test
@@ -182,6 +183,9 @@ public class ExportConfigurationTest {
     assertThat(empty().overrideIncludeGeoJsonExport(UNDETERMINED).build(), isEmpty());
     assertThat(empty().overrideIncludeGeoJsonExport(TRUE).build(), not(isEmpty()));
     assertThat(empty().overrideIncludeGeoJsonExport(FALSE).build(), not(isEmpty()));
+    assertThat(empty().overrideRemoveGroupNames(UNDETERMINED).build(), isEmpty());
+    assertThat(empty().overrideRemoveGroupNames(TRUE).build(), not(isEmpty()));
+    assertThat(empty().overrideRemoveGroupNames(FALSE).build(), not(isEmpty()));
   }
 
   @Test
@@ -212,6 +216,11 @@ public class ExportConfigurationTest {
   @Test
   public void include_geojson_export_defaults_to_false_on_empty_confs() {
     assertThat(EMPTY_CONF.resolveIncludeGeoJsonExport(), is(false));
+  }
+
+  @Test
+  public void remove_group_names_defaults_to_false_on_empty_confs() {
+    assertThat(EMPTY_CONF.resolveRemoveGroupNames(), is(false));
   }
 
   @Test


### PR DESCRIPTION
Closes #671

This PR is built on top #669 and the first commit is https://github.com/opendatakit/briefcase/pull/674/commits/d0aef21a97450287396ea9a41ebb0c8e1ff36cea

Try it with this Briefcase JAR: 
[briefcase-674-remove-group-names.jar.zip](https://github.com/opendatakit/briefcase/files/2561259/briefcase-674-remove-group-names.jar.zip)

#### What has been done to verify that this works as intended?
Added new automated tests
Run the export of All Widgets form

Also exported [field-in-group.zip](https://github.com/opendatakit/briefcase/files/2557123/field-in-group.zip), which that has a field in a non-repeat group.

- Without `-rgn` builds this header: `SubmissionDate,meta-instanceID,group-some-field,KEY`
- With `-rgn` builds this header: `SubmissionDate,instanceID,some-field,KEY`

#### Why is this the best possible solution? Were any other approaches considered?
No other approaches considered. The code that generates the headers is very localized and the changes from this PR felt like the minimum required to get the new behavior.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Users should expect a new CLI `-rgn` (`--remove_group_names`) param to enable using unqualified header column names, which don't include group names.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Yes, we should update the docs to add the new CLI param