### PR TITLE
Issue 688 Make pull and push urls clickable in the UI

### DIFF
--- a/src/org/opendatakit/briefcase/ui/reused/UI.java
+++ b/src/org/opendatakit/briefcase/ui/reused/UI.java
@@ -31,8 +31,10 @@ import java.awt.Font;
 import java.awt.Insets;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
+import java.awt.event.MouseListener;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -164,5 +166,10 @@ public class UI {
     scrollPane.setMinimumSize(dimension);
     scrollPane.setPreferredSize(dimension);
     return scrollPane;
+  }
+
+  public static void removeAllMouseListeners(JComponent component) {
+    for (MouseListener listener : component.getMouseListeners())
+      component.removeMouseListener(listener);
   }
 }

--- a/src/org/opendatakit/briefcase/ui/reused/source/ShowSourceForm.java
+++ b/src/org/opendatakit/briefcase/ui/reused/source/ShowSourceForm.java
@@ -78,7 +78,7 @@ public class ShowSourceForm extends JComponent {
 
   void showSource(Source source) {
     actionLabel.setText(action + ": " + source.toString());
-    sourceLabel.setText(source.getDescription());
+    source.decorate(sourceLabel);
     reloadButton.setVisible(source.canBeReloaded() && showReloadButton);
     markReloadOperationCompleted();
   }

--- a/src/org/opendatakit/briefcase/ui/reused/source/Source.java
+++ b/src/org/opendatakit/briefcase/ui/reused/source/Source.java
@@ -16,11 +16,20 @@
 
 package org.opendatakit.briefcase.ui.reused.source;
 
+import static java.awt.Cursor.HAND_CURSOR;
+import static java.awt.Cursor.getPredefinedCursor;
+import static java.awt.Desktop.getDesktop;
+import static javax.swing.SwingUtilities.invokeLater;
 import static org.opendatakit.briefcase.ui.reused.FileChooser.isUnderBriefcaseFolder;
 import static org.opendatakit.briefcase.ui.reused.UI.errorMessage;
 
 import java.awt.Container;
+import java.awt.Cursor;
+import java.awt.event.MouseListener;
 import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -28,7 +37,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import javax.swing.SwingUtilities;
+import javax.swing.JLabel;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.OdkCollectFormDefinition;
@@ -39,6 +48,7 @@ import org.opendatakit.briefcase.reused.DeferredValue;
 import org.opendatakit.briefcase.reused.RemoteServer;
 import org.opendatakit.briefcase.reused.http.Http;
 import org.opendatakit.briefcase.ui.reused.FileChooser;
+import org.opendatakit.briefcase.ui.reused.MouseAdapterBuilder;
 import org.opendatakit.briefcase.util.BadFormDefinition;
 import org.opendatakit.briefcase.util.FileSystemUtils;
 import org.opendatakit.briefcase.util.TransferAction;
@@ -199,6 +209,8 @@ public interface Source<T> {
    */
   String getDescription();
 
+  void decorate(JLabel label);
+
   class Aggregate implements Source<RemoteServer> {
     private final Http http;
     private RemoteServer.Test serverTester;
@@ -265,6 +277,25 @@ public interface Source<T> {
     @Override
     public String getDescription() {
       return server.getBaseUrl().toString();
+    }
+
+    private static void uncheckedBrowse(URL url) {
+      try {
+        getDesktop().browse(url.toURI());
+      } catch (URISyntaxException | IOException e) {
+        throw new BriefcaseException(e);
+      }
+    }
+
+    @Override
+    public void decorate(JLabel label) {
+      label.setText("<html><a href=\"" + server.getBaseUrl().toString() + "\">" + getDescription() + "</a></html>");
+      label.setCursor(getPredefinedCursor(HAND_CURSOR));
+      for (MouseListener ml : label.getMouseListeners())
+        label.removeMouseListener(ml);
+      label.addMouseListener(new MouseAdapterBuilder()
+          .onClick(__ -> invokeLater(() -> uncheckedBrowse(server.getBaseUrl())))
+          .build());
     }
 
     @Override
@@ -351,6 +382,14 @@ public interface Source<T> {
     }
 
     @Override
+    public void decorate(JLabel label) {
+      label.setText(getDescription());
+      label.setCursor(getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+      for (MouseListener listener : label.getMouseListeners())
+        label.removeMouseListener(listener);
+    }
+
+    @Override
     public String toString() {
       return "Collect directory";
     }
@@ -413,7 +452,7 @@ public interface Source<T> {
 
     @Override
     public void pull(List<FormStatus> forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete) {
-      SwingUtilities.invokeLater(() -> FormInstaller.install(briefcaseDir, form));
+      invokeLater(() -> FormInstaller.install(briefcaseDir, form));
     }
 
     @Override
@@ -429,6 +468,14 @@ public interface Source<T> {
     @Override
     public String getDescription() {
       return String.format("%s at %s", form.getFormName(), path.toString());
+    }
+
+    @Override
+    public void decorate(JLabel label) {
+      label.setText(getDescription());
+      label.setCursor(getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+      for (MouseListener listener : label.getMouseListeners())
+        label.removeMouseListener(listener);
     }
 
     @Override

--- a/src/org/opendatakit/briefcase/ui/reused/source/Source.java
+++ b/src/org/opendatakit/briefcase/ui/reused/source/Source.java
@@ -22,10 +22,10 @@ import static java.awt.Desktop.getDesktop;
 import static javax.swing.SwingUtilities.invokeLater;
 import static org.opendatakit.briefcase.ui.reused.FileChooser.isUnderBriefcaseFolder;
 import static org.opendatakit.briefcase.ui.reused.UI.errorMessage;
+import static org.opendatakit.briefcase.ui.reused.UI.removeAllMouseListeners;
 
 import java.awt.Container;
 import java.awt.Cursor;
-import java.awt.event.MouseListener;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -291,8 +291,7 @@ public interface Source<T> {
     public void decorate(JLabel label) {
       label.setText("<html><a href=\"" + server.getBaseUrl().toString() + "\">" + getDescription() + "</a></html>");
       label.setCursor(getPredefinedCursor(HAND_CURSOR));
-      for (MouseListener ml : label.getMouseListeners())
-        label.removeMouseListener(ml);
+      removeAllMouseListeners(label);
       label.addMouseListener(new MouseAdapterBuilder()
           .onClick(__ -> invokeLater(() -> uncheckedBrowse(server.getBaseUrl())))
           .build());
@@ -385,8 +384,7 @@ public interface Source<T> {
     public void decorate(JLabel label) {
       label.setText(getDescription());
       label.setCursor(getPredefinedCursor(Cursor.DEFAULT_CURSOR));
-      for (MouseListener listener : label.getMouseListeners())
-        label.removeMouseListener(listener);
+      removeAllMouseListeners(label);
     }
 
     @Override
@@ -474,8 +472,7 @@ public interface Source<T> {
     public void decorate(JLabel label) {
       label.setText(getDescription());
       label.setCursor(getPredefinedCursor(Cursor.DEFAULT_CURSOR));
-      for (MouseListener listener : label.getMouseListeners())
-        label.removeMouseListener(listener);
+      removeAllMouseListeners(label);
     }
 
     @Override


### PR DESCRIPTION
Closes #688

#### What has been done to verify that this works as intended?
Tested manually all possible sources on pull and push tabs.

#### Why is this the best possible solution? Were any other approaches considered?
I researched different options to make stuff clickable in Swing and I went for this one because it was the simplest way to get it done. Other alternatives involve more complex listeners and/or using custom-styled buttons instead of labels.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This PR makes clickable the URLs to the Aggregate sources/targets configured on the Pull and Push tabs. They will open the default browser.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.