### PR TITLE
Issue 687 export ui conf param remove group names

### DIFF
--- a/src/org/opendatakit/briefcase/export/ExportConfiguration.java
+++ b/src/org/opendatakit/briefcase/export/ExportConfiguration.java
@@ -212,6 +212,10 @@ public class ExportConfiguration {
     return includeGeoJsonExport;
   }
 
+  public OverridableBoolean getRemoveGroupNames() {
+    return removeGroupNames;
+  }
+
   public void ifExportDirPresent(Consumer<Path> consumer) {
     exportDir.ifPresent(consumer);
   }

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.form
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.form
@@ -2,7 +2,7 @@
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.opendatakit.briefcase.ui.export.components.ConfigurationPanelForm">
   <grid id="27dc6" binding="container" layout-manager="GridBagLayout">
     <constraints>
-      <xy x="20" y="20" width="545" height="425"/>
+      <xy x="20" y="20" width="545" height="454"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -106,7 +106,7 @@
       </hspacer>
       <component id="4d9bd" class="javax.swing.JCheckBox" binding="pullBeforeField">
         <constraints>
-          <grid row="9" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="10" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties>
@@ -115,7 +115,7 @@
       </component>
       <component id="6925f" class="javax.swing.JTextPane" binding="pullBeforeHintPanel">
         <constraints>
-          <grid row="15" column="2" row-span="1" col-span="2" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+          <grid row="17" column="2" row-span="1" col-span="2" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="50"/>
           </grid>
           <gridbag weightx="0.0" weighty="0.0"/>
@@ -137,7 +137,7 @@
       </vspacer>
       <component id="443be" class="javax.swing.JLabel" binding="pullBeforeOverrideLabel">
         <constraints>
-          <grid row="14" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="16" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties>
@@ -194,7 +194,7 @@
       </grid>
       <vspacer id="1c95d">
         <constraints>
-          <grid row="16" column="0" row-span="1" col-span="3" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="18" column="0" row-span="1" col-span="3" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
       </vspacer>
@@ -209,7 +209,7 @@
       </component>
       <component id="4aac8" class="javax.swing.JLabel" binding="exportMediaOverrideLabel">
         <constraints>
-          <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="11" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties>
@@ -227,7 +227,7 @@
       </component>
       <component id="46378" class="javax.swing.JLabel" binding="overwriteFilesOverrideLabel">
         <constraints>
-          <grid row="11" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties>
@@ -236,25 +236,25 @@
       </component>
       <nested-form id="fd598" form-file="org/opendatakit/briefcase/ui/export/components/CustomConfBooleanForm.form" binding="overwriteFilesOverrideField" custom-create="true">
         <constraints>
-          <grid row="11" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="12" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
       </nested-form>
       <nested-form id="d42b7" form-file="org/opendatakit/briefcase/ui/export/components/CustomConfBooleanForm.form" binding="exportMediaOverrideField" custom-create="true">
         <constraints>
-          <grid row="10" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="11" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
       </nested-form>
       <nested-form id="facf4" form-file="org/opendatakit/briefcase/ui/export/components/CustomConfBooleanForm.form" binding="pullBeforeOverrideField" custom-create="true">
         <constraints>
-          <grid row="14" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="16" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
       </nested-form>
       <component id="8729d" class="javax.swing.JLabel" binding="splitSelectMultiplesOverrideLabel">
         <constraints>
-          <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="13" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties>
@@ -263,7 +263,7 @@
       </component>
       <nested-form id="fa36a" form-file="org/opendatakit/briefcase/ui/export/components/CustomConfBooleanForm.form" binding="splitSelectMultiplesOverrideField" custom-create="true">
         <constraints>
-          <grid row="12" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="13" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
       </nested-form>
@@ -287,17 +287,41 @@
       </component>
       <nested-form id="3816a" form-file="org/opendatakit/briefcase/ui/export/components/CustomConfBooleanForm.form" binding="includeGeoJsonExportOverrideField" custom-create="true">
         <constraints>
-          <grid row="13" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="14" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
       </nested-form>
       <component id="f1724" class="javax.swing.JLabel" binding="includeGeoJsonExportOverrideLabel">
         <constraints>
-          <grid row="13" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="14" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties>
           <text value="Include GeoJSON export"/>
+        </properties>
+      </component>
+      <component id="61cc9" class="javax.swing.JCheckBox" binding="removeGroupNamesField">
+        <constraints>
+          <grid row="9" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <gridbag weightx="0.0" weighty="0.0"/>
+        </constraints>
+        <properties>
+          <text value="Remove group names"/>
+        </properties>
+      </component>
+      <nested-form id="ead5a" form-file="org/opendatakit/briefcase/ui/export/components/CustomConfBooleanForm.form" binding="removeGroupNamesOverrideField" custom-create="true">
+        <constraints>
+          <grid row="15" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <gridbag weightx="0.0" weighty="0.0"/>
+        </constraints>
+      </nested-form>
+      <component id="7f3a" class="javax.swing.JLabel" binding="removeGroupNamesOverrideLabel">
+        <constraints>
+          <grid row="15" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+          <gridbag weightx="0.0" weighty="0.0"/>
+        </constraints>
+        <properties>
+          <text value="Remove group names"/>
         </properties>
       </component>
     </children>

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
@@ -88,6 +88,9 @@ public class ConfigurationPanelForm extends JComponent {
   JCheckBox includeGeoJsonExportField;
   JLabel includeGeoJsonExportOverrideLabel;
   final CustomConfBooleanForm includeGeoJsonExportOverrideField;
+  JCheckBox removeGroupNamesField;
+  JLabel removeGroupNamesOverrideLabel;
+  final CustomConfBooleanForm removeGroupNamesOverrideField;
 
   // UI status and callbacks
   private final ConfigurationPanelMode mode;
@@ -115,6 +118,7 @@ public class ConfigurationPanelForm extends JComponent {
     overwriteFilesOverrideField = new CustomConfBooleanForm(Optional.empty());
     splitSelectMultiplesOverrideField = new CustomConfBooleanForm(Optional.empty());
     includeGeoJsonExportOverrideField = new CustomConfBooleanForm(Optional.empty());
+    removeGroupNamesOverrideField = new CustomConfBooleanForm(Optional.empty());
 
     $$$setupUI$$$();
 
@@ -204,6 +208,9 @@ public class ConfigurationPanelForm extends JComponent {
     includeGeoJsonExportField.setEnabled(enabled);
     includeGeoJsonExportOverrideField.setEnabled(enabled);
     includeGeoJsonExportOverrideLabel.setEnabled(enabled);
+    removeGroupNamesField.setEnabled(enabled);
+    removeGroupNamesOverrideField.setEnabled(enabled);
+    removeGroupNamesOverrideLabel.setEnabled(enabled);
   }
 
   void setExportDir(Path path) {
@@ -544,7 +551,7 @@ public class ConfigurationPanelForm extends JComponent {
     pullBeforeField.setText("Pull before export");
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
-    gbc.gridy = 9;
+    gbc.gridy = 10;
     gbc.gridwidth = 2;
     gbc.anchor = GridBagConstraints.WEST;
     container.add(pullBeforeField, gbc);
@@ -557,7 +564,7 @@ public class ConfigurationPanelForm extends JComponent {
     pullBeforeHintPanel.setText("Some hint will be shown here");
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
-    gbc.gridy = 15;
+    gbc.gridy = 17;
     gbc.gridwidth = 2;
     gbc.fill = GridBagConstraints.BOTH;
     container.add(pullBeforeHintPanel, gbc);
@@ -572,7 +579,7 @@ public class ConfigurationPanelForm extends JComponent {
     pullBeforeOverrideLabel.setText("Pull before export");
     gbc = new GridBagConstraints();
     gbc.gridx = 0;
-    gbc.gridy = 14;
+    gbc.gridy = 16;
     gbc.anchor = GridBagConstraints.EAST;
     container.add(pullBeforeOverrideLabel, gbc);
     exportDirButtons = new JPanel();
@@ -608,7 +615,7 @@ public class ConfigurationPanelForm extends JComponent {
     final JPanel spacer6 = new JPanel();
     gbc = new GridBagConstraints();
     gbc.gridx = 0;
-    gbc.gridy = 16;
+    gbc.gridy = 18;
     gbc.gridwidth = 3;
     gbc.fill = GridBagConstraints.VERTICAL;
     container.add(spacer6, gbc);
@@ -623,7 +630,7 @@ public class ConfigurationPanelForm extends JComponent {
     exportMediaOverrideLabel.setText("Export media files");
     gbc = new GridBagConstraints();
     gbc.gridx = 0;
-    gbc.gridy = 10;
+    gbc.gridy = 11;
     gbc.anchor = GridBagConstraints.EAST;
     container.add(exportMediaOverrideLabel, gbc);
     overwriteFilesField = new JCheckBox();
@@ -637,24 +644,24 @@ public class ConfigurationPanelForm extends JComponent {
     overwriteFilesOverrideLabel.setText("Overwrite existing files");
     gbc = new GridBagConstraints();
     gbc.gridx = 0;
-    gbc.gridy = 11;
+    gbc.gridy = 12;
     gbc.anchor = GridBagConstraints.EAST;
     container.add(overwriteFilesOverrideLabel, gbc);
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
-    gbc.gridy = 11;
+    gbc.gridy = 12;
     gbc.gridwidth = 2;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     container.add(overwriteFilesOverrideField.$$$getRootComponent$$$(), gbc);
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
-    gbc.gridy = 10;
+    gbc.gridy = 11;
     gbc.gridwidth = 2;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     container.add(exportMediaOverrideField.$$$getRootComponent$$$(), gbc);
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
-    gbc.gridy = 14;
+    gbc.gridy = 16;
     gbc.gridwidth = 2;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     container.add(pullBeforeOverrideField.$$$getRootComponent$$$(), gbc);
@@ -662,12 +669,12 @@ public class ConfigurationPanelForm extends JComponent {
     splitSelectMultiplesOverrideLabel.setText("Split select multiples");
     gbc = new GridBagConstraints();
     gbc.gridx = 0;
-    gbc.gridy = 12;
+    gbc.gridy = 13;
     gbc.anchor = GridBagConstraints.EAST;
     container.add(splitSelectMultiplesOverrideLabel, gbc);
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
-    gbc.gridy = 12;
+    gbc.gridy = 13;
     gbc.gridwidth = 2;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     container.add(splitSelectMultiplesOverrideField.$$$getRootComponent$$$(), gbc);
@@ -687,7 +694,7 @@ public class ConfigurationPanelForm extends JComponent {
     container.add(includeGeoJsonExportField, gbc);
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
-    gbc.gridy = 13;
+    gbc.gridy = 14;
     gbc.gridwidth = 2;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     container.add(includeGeoJsonExportOverrideField.$$$getRootComponent$$$(), gbc);
@@ -695,9 +702,29 @@ public class ConfigurationPanelForm extends JComponent {
     includeGeoJsonExportOverrideLabel.setText("Include GeoJSON export");
     gbc = new GridBagConstraints();
     gbc.gridx = 0;
-    gbc.gridy = 13;
+    gbc.gridy = 14;
     gbc.anchor = GridBagConstraints.EAST;
     container.add(includeGeoJsonExportOverrideLabel, gbc);
+    removeGroupNamesField = new JCheckBox();
+    removeGroupNamesField.setText("Remove group names");
+    gbc = new GridBagConstraints();
+    gbc.gridx = 2;
+    gbc.gridy = 9;
+    gbc.anchor = GridBagConstraints.WEST;
+    container.add(removeGroupNamesField, gbc);
+    gbc = new GridBagConstraints();
+    gbc.gridx = 2;
+    gbc.gridy = 15;
+    gbc.gridwidth = 2;
+    gbc.fill = GridBagConstraints.HORIZONTAL;
+    container.add(removeGroupNamesOverrideField.$$$getRootComponent$$$(), gbc);
+    removeGroupNamesOverrideLabel = new JLabel();
+    removeGroupNamesOverrideLabel.setText("Remove group names");
+    gbc = new GridBagConstraints();
+    gbc.gridx = 0;
+    gbc.gridy = 15;
+    gbc.anchor = GridBagConstraints.EAST;
+    container.add(removeGroupNamesOverrideLabel, gbc);
   }
 
   /**
@@ -706,4 +733,5 @@ public class ConfigurationPanelForm extends JComponent {
   public JComponent $$$getRootComponent$$$() {
     return container;
   }
+
 }

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelForm.java
@@ -106,6 +106,7 @@ public class ConfigurationPanelForm extends JComponent {
   private OverridableBoolean exportMedia = OverridableBoolean.TRUE;
   private OverridableBoolean splitSelectMultiples = OverridableBoolean.FALSE;
   private OverridableBoolean includeGeoJsonExport = OverridableBoolean.FALSE;
+  private OverridableBoolean removeGroupNames = OverridableBoolean.FALSE;
 
   ConfigurationPanelForm(ConfigurationPanelMode mode) {
     this.mode = mode;
@@ -161,6 +162,8 @@ public class ConfigurationPanelForm extends JComponent {
     splitSelectMultiplesOverrideField.onChange(this::setSplitSelectMultiples);
     includeGeoJsonExportField.addActionListener(__ -> setIncludeGeoJsonExport(includeGeoJsonExportField.isSelected()));
     includeGeoJsonExportOverrideField.onChange(this::setIncludeGeoJsonExport);
+    removeGroupNamesField.addActionListener(__ -> setRemoveGroupNames(removeGroupNamesField.isSelected()));
+    removeGroupNamesOverrideField.onChange(this::setRemoveGroupNames);
   }
 
   void initialize(ExportConfiguration configuration) {
@@ -172,6 +175,7 @@ public class ConfigurationPanelForm extends JComponent {
     setExportMedia(configuration.getExportMedia());
     setSplitSelectMultiples(configuration.getSplitSelectMultiples());
     setIncludeGeoJsonExport(configuration.getIncludeGeoJsonExport());
+    setRemoveGroupNames(configuration.getRemoveGroupNames());
   }
 
   @Override
@@ -370,6 +374,22 @@ public class ConfigurationPanelForm extends JComponent {
     includeGeoJsonExportOverrideField.set(value.getOverride());
   }
 
+  private void setRemoveGroupNames(boolean enabled) {
+    removeGroupNames = removeGroupNames.set(enabled);
+    triggerOnChange();
+  }
+
+  private void setRemoveGroupNames(TriStateBoolean overrideValue) {
+    removeGroupNames = removeGroupNames.overrideWith(overrideValue);
+    triggerOnChange();
+  }
+
+  private void setRemoveGroupNames(OverridableBoolean value) {
+    removeGroupNames = value;
+    removeGroupNamesField.setSelected(value.get(false));
+    removeGroupNamesOverrideField.set(value.getOverride());
+  }
+
   void onChange(Consumer<ExportConfiguration> callback) {
     onChangeCallbacks.add(callback);
   }
@@ -390,6 +410,7 @@ public class ConfigurationPanelForm extends JComponent {
         .setExportMedia(exportMedia)
         .setSplitSelectMultiples(splitSelectMultiples)
         .setIncludeGeoJsonExport(includeGeoJsonExport)
+        .setRemoveGroupNames(removeGroupNames)
         .build();
     onChangeCallbacks.forEach(callback -> callback.accept(conf));
   }

--- a/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelMode.java
+++ b/src/org/opendatakit/briefcase/ui/export/components/ConfigurationPanelMode.java
@@ -65,6 +65,10 @@ class ConfigurationPanelMode {
     form.includeGeoJsonExportField.setVisible(!isOverridePanel);
     form.includeGeoJsonExportOverrideLabel.setVisible(isOverridePanel);
     form.includeGeoJsonExportOverrideField.setVisible(isOverridePanel);
+
+    form.removeGroupNamesField.setVisible(!isOverridePanel);
+    form.removeGroupNamesOverrideLabel.setVisible(isOverridePanel);
+    form.removeGroupNamesOverrideField.setVisible(isOverridePanel);
   }
 
   boolean isOverridePanel() {


### PR DESCRIPTION
Closes #687

#### What has been done to verify that this works as intended?
Tested manually with [choice-lists.zip](https://github.com/opendatakit/briefcase/files/2648642/choice-lists.zip), which has a field in a group.
Tested all combinations of default conf and overridden conf.

#### Why is this the best possible solution? Were any other approaches considered?
This PR imitates what's being done with all the other overridable boolean export conf params.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Users should be able to enable removing the group names from the CSV header lines thanks to a new checkbox (default conf panel) and overridable boolean (custom conf panel)

![image](https://user-images.githubusercontent.com/205913/49511228-db1baf00-f88a-11e8-9fe4-4863b1b34027.png)

![image](https://user-images.githubusercontent.com/205913/49511244-e66eda80-f88a-11e8-99a0-43cd911f630e.png)

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Yes:
- [ ] https://github.com/opendatakit/docs/issues/927