### PR TITLE
Issue 681 resume last pull

### DIFF
--- a/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
+++ b/src/org/opendatakit/briefcase/model/BriefcasePreferences.java
@@ -46,6 +46,7 @@ public class BriefcasePreferences {
   private static final String BRIEFCASE_PROXY_HOST_PROPERTY = "briefcaseProxyHost";
   private static final String BRIEFCASE_PROXY_PORT_PROPERTY = "briefcaseProxyPort";
   private static final String BRIEFCASE_PARALLEL_PULLS_PROPERTY = "briefcaseParallelPulls";
+  private static final String BRIEFCASE_RESUME_LAST_PULL_PROPERTY = "briefcaseResumeLastPull";
   public static final String BRIEFCASE_TRACKING_CONSENT_PROPERTY = "briefcaseTrackingConsent";
   private static final String BRIEFCASE_STORE_PASSWORDS_CONSENT_PROPERTY = "briefcaseStorePasswordsConsent";
   private static final String BRIEFCASE_UNIQUE_USER_ID_PROPERTY = "uniqueUserID";
@@ -199,8 +200,16 @@ public class BriefcasePreferences {
     put(BRIEFCASE_PARALLEL_PULLS_PROPERTY, enabled.toString());
   }
 
+  public Optional<Boolean> getResumeLastPull() {
+    return nullSafeGet(BRIEFCASE_RESUME_LAST_PULL_PROPERTY).map(Boolean::parseBoolean);
+  }
+
   public Optional<Boolean> getPullInParallel() {
     return nullSafeGet(BRIEFCASE_PARALLEL_PULLS_PROPERTY).map(Boolean::parseBoolean);
+  }
+
+  public void setResumeLastPull(Boolean enabled) {
+    put(BRIEFCASE_RESUME_LAST_PULL_PROPERTY, enabled.toString());
   }
 
   public void setRememberPasswords(Boolean enabled) {

--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -25,7 +25,6 @@ import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Optional;
 import org.opendatakit.briefcase.export.DateRange;
 import org.opendatakit.briefcase.export.ExportConfiguration;
@@ -38,6 +37,7 @@ import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.ServerConnectionInfo;
 import org.opendatakit.briefcase.model.TerminationFuture;
 import org.opendatakit.briefcase.transfer.NewTransferAction;
+import org.opendatakit.briefcase.transfer.TransferForms;
 import org.opendatakit.briefcase.ui.export.ExportPanel;
 import org.opendatakit.briefcase.util.FormCache;
 import org.opendatakit.common.cli.Operation;
@@ -127,7 +127,7 @@ public class Export {
         NewTransferAction.transferServerToBriefcase(
             transferSettings,
             new TerminationFuture(),
-            Collections.singletonList(formStatus),
+            TransferForms.of(formStatus),
             briefcaseDir,
             appPreferences.getPullInParallel().orElse(false),
             false

--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -130,6 +130,7 @@ public class Export {
             TransferForms.of(formStatus),
             briefcaseDir,
             appPreferences.getPullInParallel().orElse(false),
+            false,
             false
         );
       }

--- a/src/org/opendatakit/briefcase/operations/ImportFromODK.java
+++ b/src/org/opendatakit/briefcase/operations/ImportFromODK.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.opendatakit.briefcase.model.FormStatus;
+import org.opendatakit.briefcase.transfer.TransferForms;
 import org.opendatakit.briefcase.util.FileSystemUtils;
 import org.opendatakit.briefcase.util.FormCache;
 import org.opendatakit.briefcase.util.TransferFromODK;
@@ -60,6 +61,6 @@ public class ImportFromODK {
         .filter(form -> formId.map(id -> form.getFormDefinition().getFormId().equals(id)).orElse(true))
         .collect(toList());
 
-    TransferFromODK.pull(briefcaseDir, odkDir, forms);
+    TransferFromODK.pull(briefcaseDir, odkDir, TransferForms.from(forms));
   }
 }

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -99,7 +99,7 @@ public class PullFormFromAggregate {
 
       FormStatus form = maybeForm.get();
       EventBus.publish(new StartPullEvent(form));
-      TransferFromServer.pull(remoteServer.asServerConnectionInfo(), briefcaseDir, pullInParallel, includeIncomplete, TransferForms.of(form));
+      TransferFromServer.pull(remoteServer.asServerConnectionInfo(), briefcaseDir, pullInParallel, includeIncomplete, TransferForms.of(form), false);
     }
   }
 

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -33,6 +33,7 @@ import org.opendatakit.briefcase.reused.RemoteServer;
 import org.opendatakit.briefcase.reused.http.CommonsHttp;
 import org.opendatakit.briefcase.reused.http.Credentials;
 import org.opendatakit.briefcase.reused.http.Response;
+import org.opendatakit.briefcase.transfer.TransferForms;
 import org.opendatakit.briefcase.util.FormCache;
 import org.opendatakit.briefcase.util.RetrieveAvailableFormsFromServer;
 import org.opendatakit.briefcase.util.TransferFromServer;
@@ -98,7 +99,7 @@ public class PullFormFromAggregate {
 
       FormStatus form = maybeForm.get();
       EventBus.publish(new StartPullEvent(form));
-      TransferFromServer.pull(remoteServer.asServerConnectionInfo(), briefcaseDir, pullInParallel, includeIncomplete, form);
+      TransferFromServer.pull(remoteServer.asServerConnectionInfo(), briefcaseDir, pullInParallel, includeIncomplete, TransferForms.of(form));
     }
   }
 

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -47,6 +47,7 @@ public class PullFormFromAggregate {
   public static final Param<Void> DEPRECATED_PULL_AGGREGATE = Param.flag("pa", "pull_aggregate", "(Deprecated)");
   private static final Param<Void> PULL_AGGREGATE = Param.flag("plla", "pull_aggregate", "Pull form from an Aggregate instance");
   private static final Param<Void> PULL_IN_PARALLEL = Param.flag("pp", "parallel_pull", "Pull submissions in parallel");
+  private static final Param<Void> RESUME_LAST_PULL = Param.flag("rlp", "resume_last_pull", "Resume last pull");
   private static final Param<Void> INCLUDE_INCOMPLETE = Param.flag("ii", "include_incomplete", "Include incomplete submissions");
 
   public static Operation PULL_FORM_FROM_AGGREGATE = Operation.of(
@@ -58,13 +59,14 @@ public class PullFormFromAggregate {
           args.get(ODK_PASSWORD),
           args.get(AGGREGATE_SERVER),
           args.has(PULL_IN_PARALLEL),
+          args.has(RESUME_LAST_PULL),
           args.has(INCLUDE_INCOMPLETE)
       ),
       Arrays.asList(STORAGE_DIR, FORM_ID, ODK_USERNAME, ODK_PASSWORD, AGGREGATE_SERVER),
-      Arrays.asList(PULL_IN_PARALLEL, INCLUDE_INCOMPLETE)
+      Arrays.asList(PULL_IN_PARALLEL, RESUME_LAST_PULL, INCLUDE_INCOMPLETE)
   );
 
-  public static void pullFormFromAggregate(String storageDir, String formid, String username, String password, String server, boolean pullInParallel, boolean includeIncomplete) {
+  public static void pullFormFromAggregate(String storageDir, String formid, String username, String password, String server, boolean pullInParallel, boolean resumeLastPull, boolean includeIncomplete) {
     CliEventsCompanion.attach(log);
     Path briefcaseDir = Common.getOrCreateBriefcaseDir(storageDir);
     FormCache formCache = FormCache.from(briefcaseDir);
@@ -99,7 +101,7 @@ public class PullFormFromAggregate {
 
       FormStatus form = maybeForm.get();
       EventBus.publish(new StartPullEvent(form));
-      TransferFromServer.pull(remoteServer.asServerConnectionInfo(), briefcaseDir, pullInParallel, includeIncomplete, TransferForms.of(form), false);
+      TransferFromServer.pull(remoteServer.asServerConnectionInfo(), briefcaseDir, pullInParallel, includeIncomplete, TransferForms.of(form), resumeLastPull);
     }
   }
 

--- a/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
@@ -33,6 +33,7 @@ import org.opendatakit.briefcase.reused.RemoteServer;
 import org.opendatakit.briefcase.reused.http.CommonsHttp;
 import org.opendatakit.briefcase.reused.http.Credentials;
 import org.opendatakit.briefcase.reused.http.Response;
+import org.opendatakit.briefcase.transfer.TransferForms;
 import org.opendatakit.briefcase.util.FormCache;
 import org.opendatakit.briefcase.util.TransferToServer;
 import org.opendatakit.common.cli.Operation;
@@ -92,7 +93,7 @@ public class PushFormToAggregate {
 
       FormStatus form = maybeFormStatus.orElseThrow(() -> new FormNotFoundException(formid));
 
-      TransferToServer.push(remoteServer.asServerConnectionInfo(), http, remoteServer, forceSendBlank, form);
+      TransferToServer.push(remoteServer.asServerConnectionInfo(), http, remoteServer, forceSendBlank, TransferForms.of(form));
     }
   }
 

--- a/src/org/opendatakit/briefcase/pull/FormInstaller.java
+++ b/src/org/opendatakit/briefcase/pull/FormInstaller.java
@@ -25,12 +25,12 @@ import static org.opendatakit.briefcase.reused.UncheckedFiles.walk;
 import static org.opendatakit.briefcase.util.StringUtils.stripIllegalChars;
 
 import java.nio.file.Path;
-import java.util.Collections;
 import org.bushe.swing.event.EventBus;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.FormStatusEvent;
 import org.opendatakit.briefcase.model.OdkCollectFormDefinition;
 import org.opendatakit.briefcase.reused.BriefcaseException;
+import org.opendatakit.briefcase.transfer.TransferForms;
 
 /**
  * This class has UI/CLI independent methods to install forms into
@@ -51,7 +51,7 @@ public class FormInstaller {
   public static void install(Path briefcaseDir, FormStatus fs) {
     try {
       installForm(briefcaseDir, fs);
-      EventBus.publish(new PullEvent.Success(Collections.singletonList(fs)));
+      EventBus.publish(new PullEvent.Success(TransferForms.of(fs)));
     } catch (BriefcaseException e) {
       EventBus.publish(new PullEvent.Failure());
     }

--- a/src/org/opendatakit/briefcase/pull/PullEvent.java
+++ b/src/org/opendatakit/briefcase/pull/PullEvent.java
@@ -60,4 +60,7 @@ public class PullEvent {
       this.transferSettings = Optional.ofNullable(transferSettings);
     }
   }
+
+  public static class CleanAllResumePoints extends PullEvent {
+  }
 }

--- a/src/org/opendatakit/briefcase/pull/PullEvent.java
+++ b/src/org/opendatakit/briefcase/pull/PullEvent.java
@@ -16,10 +16,10 @@
 
 package org.opendatakit.briefcase.pull;
 
-import java.util.List;
 import java.util.Optional;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.ServerConnectionInfo;
+import org.opendatakit.briefcase.transfer.TransferForms;
 
 public class PullEvent {
 
@@ -29,15 +29,15 @@ public class PullEvent {
   }
 
   public static class Success extends PullEvent {
-    public final List<FormStatus> forms;
+    public final TransferForms forms;
     public final Optional<ServerConnectionInfo> transferSettings;
 
-    public Success(List<FormStatus> forms) {
+    public Success(TransferForms forms) {
       this.forms = forms;
       this.transferSettings = Optional.empty();
     }
 
-    public Success(List<FormStatus> forms, ServerConnectionInfo transferSettings) {
+    public Success(TransferForms forms, ServerConnectionInfo transferSettings) {
       this.forms = forms;
       this.transferSettings = Optional.ofNullable(transferSettings);
     }

--- a/src/org/opendatakit/briefcase/push/PushEvent.java
+++ b/src/org/opendatakit/briefcase/push/PushEvent.java
@@ -16,10 +16,9 @@
 
 package org.opendatakit.briefcase.push;
 
-import java.util.List;
 import java.util.Optional;
-import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.ServerConnectionInfo;
+import org.opendatakit.briefcase.transfer.TransferForms;
 
 public class PushEvent {
 
@@ -29,10 +28,10 @@ public class PushEvent {
   }
 
   public static class Success extends PushEvent {
-    public List<FormStatus> forms;
+    public TransferForms forms;
     public final Optional<ServerConnectionInfo> transferSettings;
 
-    public Success(List<FormStatus> forms, ServerConnectionInfo transferSettings) {
+    public Success(TransferForms forms, ServerConnectionInfo transferSettings) {
       this.forms = forms;
       this.transferSettings = Optional.ofNullable(transferSettings);
     }

--- a/src/org/opendatakit/briefcase/transfer/NewTransferAction.java
+++ b/src/org/opendatakit/briefcase/transfer/NewTransferAction.java
@@ -17,9 +17,7 @@
 package org.opendatakit.briefcase.transfer;
 
 import java.nio.file.Path;
-import java.util.List;
 import org.bushe.swing.event.EventBus;
-import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.ServerConnectionInfo;
 import org.opendatakit.briefcase.model.TerminationFuture;
 import org.opendatakit.briefcase.pull.PullEvent;
@@ -30,7 +28,7 @@ import org.slf4j.LoggerFactory;
 public class NewTransferAction {
   private static final Logger log = LoggerFactory.getLogger(NewTransferAction.class);
 
-  public static void transferServerToBriefcase(ServerConnectionInfo transferSettings, TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete) {
+  public static void transferServerToBriefcase(ServerConnectionInfo transferSettings, TerminationFuture terminationFuture, TransferForms formsToTransfer, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete) {
     TransferFromServer action = new TransferFromServer(
         transferSettings,
         terminationFuture,

--- a/src/org/opendatakit/briefcase/transfer/NewTransferAction.java
+++ b/src/org/opendatakit/briefcase/transfer/NewTransferAction.java
@@ -28,14 +28,15 @@ import org.slf4j.LoggerFactory;
 public class NewTransferAction {
   private static final Logger log = LoggerFactory.getLogger(NewTransferAction.class);
 
-  public static void transferServerToBriefcase(ServerConnectionInfo transferSettings, TerminationFuture terminationFuture, TransferForms formsToTransfer, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete) {
+  public static void transferServerToBriefcase(ServerConnectionInfo transferSettings, TerminationFuture terminationFuture, TransferForms formsToTransfer, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete, boolean resumeLastPull) {
     TransferFromServer action = new TransferFromServer(
         transferSettings,
         terminationFuture,
         formsToTransfer,
         briefcaseDir,
         pullInParallel,
-        includeIncomplete
+        includeIncomplete,
+        resumeLastPull
     );
     try {
       boolean allSuccessful = action.doAction();

--- a/src/org/opendatakit/briefcase/transfer/TransferForms.java
+++ b/src/org/opendatakit/briefcase/transfer/TransferForms.java
@@ -208,6 +208,11 @@ public class TransferForms implements Iterable<FormStatus> {
 
   public void setLastPullCursor(FormStatus fs, String cursor) {
     lastPullCursorsByFormId.put(fs.getFormId(), cursor);
+    triggerOnChange();
+  }
+
+  public Map<String, String> getLastPullCursorsByFormId() {
+    return lastPullCursorsByFormId;
   }
 
   @Override

--- a/src/org/opendatakit/briefcase/transfer/TransferForms.java
+++ b/src/org/opendatakit/briefcase/transfer/TransferForms.java
@@ -38,6 +38,7 @@ import org.opendatakit.briefcase.reused.Pair;
  * selection of those forms, as well as merging changes in the forms cache.
  */
 public class TransferForms implements Iterable<FormStatus> {
+  public static final String LAST_CURSOR_PREFERENCE_KEY_SUFFIX = "-last-cursor";
   private List<FormStatus> forms;
   private Map<String, FormStatus> formsIndex = new HashMap<>();
   private Map<String, String> lastPullCursorsByFormId;
@@ -79,7 +80,7 @@ public class TransferForms implements Iterable<FormStatus> {
   public void load(List<FormStatus> forms, BriefcasePreferences preferences) {
     this.forms = forms;
     this.lastPullCursorsByFormId = forms.stream()
-        .map(form -> Pair.of(form.getFormId(), preferences.nullSafeGet(form.getFormId() + "-last-cursor")))
+        .map(form -> Pair.of(form.getFormId(), preferences.nullSafeGet(form.getFormId() + LAST_CURSOR_PREFERENCE_KEY_SUFFIX)))
         .filter(pair -> pair.getRight().isPresent())
         .map(pair -> pair.map(identity(), Optional::get))
         .collect(toMap(Pair::getLeft, Pair::getRight));

--- a/src/org/opendatakit/briefcase/transfer/TransferForms.java
+++ b/src/org/opendatakit/briefcase/transfer/TransferForms.java
@@ -166,7 +166,7 @@ public class TransferForms implements Iterable<FormStatus> {
    * Empties the {@link FormStatus} list.
    */
   public void clear() {
-    forms = Collections.emptyList();
+    forms.clear();
     triggerOnChange();
   }
 

--- a/src/org/opendatakit/briefcase/transfer/TransferForms.java
+++ b/src/org/opendatakit/briefcase/transfer/TransferForms.java
@@ -36,10 +36,12 @@ import org.opendatakit.briefcase.model.FormStatus;
 public class TransferForms implements Iterable<FormStatus> {
   private List<FormStatus> forms;
   private Map<String, FormStatus> formsIndex = new HashMap<>();
+  private final Map<String, String> lastPullCursorsByFormId;
   private final List<Runnable> onChangeCallbacks = new ArrayList<>();
 
-  private TransferForms(List<FormStatus> forms) {
+  private TransferForms(List<FormStatus> forms, Map<String, String> lastPullCursorsByFormId) {
     this.forms = forms;
+    this.lastPullCursorsByFormId = lastPullCursorsByFormId;
     rebuildIndex();
   }
 
@@ -47,7 +49,7 @@ public class TransferForms implements Iterable<FormStatus> {
    * Factory of empty {@link TransferForms} instances
    */
   public static TransferForms empty() {
-    return new TransferForms(Collections.emptyList());
+    return new TransferForms(Collections.emptyList(), Collections.emptyMap());
   }
 
   /**
@@ -55,7 +57,7 @@ public class TransferForms implements Iterable<FormStatus> {
    * list of {@link FormStatus} instances
    */
   public static TransferForms from(List<FormStatus> forms) {
-    return new TransferForms(forms);
+    return new TransferForms(forms, Collections.emptyMap());
   }
 
   private static String getFormId(FormStatus form) {
@@ -63,7 +65,7 @@ public class TransferForms implements Iterable<FormStatus> {
   }
 
   public static TransferForms of(FormStatus... forms) {
-    return new TransferForms(Arrays.asList(forms));
+    return new TransferForms(Arrays.asList(forms), Collections.emptyMap());
   }
 
   /**

--- a/src/org/opendatakit/briefcase/transfer/TransferForms.java
+++ b/src/org/opendatakit/briefcase/transfer/TransferForms.java
@@ -191,6 +191,10 @@ public class TransferForms implements Iterable<FormStatus> {
     return forms.stream().map(mapper);
   }
 
+  public String getLastCursor(FormStatus fs) {
+    return "";
+  }
+
   @Override
   public Iterator<FormStatus> iterator() {
     return forms.iterator();

--- a/src/org/opendatakit/briefcase/transfer/TransferForms.java
+++ b/src/org/opendatakit/briefcase/transfer/TransferForms.java
@@ -220,4 +220,8 @@ public class TransferForms implements Iterable<FormStatus> {
   public Iterator<FormStatus> iterator() {
     return forms.iterator();
   }
+
+  public void cleanAllResumePoints() {
+    lastPullCursorsByFormId.clear();
+  }
 }

--- a/src/org/opendatakit/briefcase/transfer/TransferForms.java
+++ b/src/org/opendatakit/briefcase/transfer/TransferForms.java
@@ -54,7 +54,7 @@ public class TransferForms implements Iterable<FormStatus> {
    * Factory of empty {@link TransferForms} instances
    */
   public static TransferForms empty() {
-    return new TransferForms(Collections.emptyList(), Collections.emptyMap());
+    return new TransferForms(Collections.emptyList(), new HashMap<>());
   }
 
   /**
@@ -62,7 +62,7 @@ public class TransferForms implements Iterable<FormStatus> {
    * list of {@link FormStatus} instances
    */
   public static TransferForms from(List<FormStatus> forms) {
-    return new TransferForms(forms, Collections.emptyMap());
+    return new TransferForms(forms, new HashMap<>());
   }
 
   private static String getFormId(FormStatus form) {
@@ -70,7 +70,7 @@ public class TransferForms implements Iterable<FormStatus> {
   }
 
   public static TransferForms of(FormStatus... forms) {
-    return new TransferForms(Arrays.asList(forms), Collections.emptyMap());
+    return new TransferForms(Arrays.asList(forms), new HashMap<>());
   }
 
   /**

--- a/src/org/opendatakit/briefcase/transfer/TransferForms.java
+++ b/src/org/opendatakit/briefcase/transfer/TransferForms.java
@@ -19,18 +19,21 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import org.opendatakit.briefcase.model.FormStatus;
 
 /**
  * This class represents a set of forms to be pulled/pushed. It manages the
  * selection of those forms, as well as merging changes in the forms cache.
  */
-public class TransferForms {
+public class TransferForms implements Iterable<FormStatus> {
   private List<FormStatus> forms;
   private Map<String, FormStatus> formsIndex = new HashMap<>();
   private final List<Runnable> onChangeCallbacks = new ArrayList<>();
@@ -57,6 +60,10 @@ public class TransferForms {
 
   private static String getFormId(FormStatus form) {
     return form.getFormDefinition().getFormId();
+  }
+
+  public static TransferForms of(FormStatus... forms) {
+    return new TransferForms(Arrays.asList(forms));
   }
 
   /**
@@ -104,14 +111,6 @@ public class TransferForms {
   }
 
   /**
-   * Lets calling sites iterate over all {@link FormStatus} instances
-   * present.
-   */
-  public void forEach(Consumer<FormStatus> consumer) {
-    forms.forEach(consumer);
-  }
-
-  /**
    * Marks all present {@link FormStatus} instances as being selected.
    */
   // TODO extract the selection status to this class instead of mutating the FormStatus instances
@@ -131,8 +130,8 @@ public class TransferForms {
   /**
    * Returns a list of selected {@link FormStatus} instances.
    */
-  public List<FormStatus> getSelectedForms() {
-    return forms.stream().filter(FormStatus::isSelected).collect(toList());
+  public TransferForms getSelectedForms() {
+    return new TransferForms(forms.stream().filter(FormStatus::isSelected).collect(toList()));
   }
 
   /**
@@ -186,5 +185,14 @@ public class TransferForms {
    */
   public boolean isEmpty() {
     return forms.isEmpty();
+  }
+
+  public <T> Stream<T> map(Function<FormStatus, T> mapper) {
+    return forms.stream().map(mapper);
+  }
+
+  @Override
+  public Iterator<FormStatus> iterator() {
+    return forms.iterator();
   }
 }

--- a/src/org/opendatakit/briefcase/transfer/TransferForms.java
+++ b/src/org/opendatakit/briefcase/transfer/TransferForms.java
@@ -206,6 +206,10 @@ public class TransferForms implements Iterable<FormStatus> {
     return Optional.ofNullable(lastPullCursorsByFormId.get(fs.getFormId())).orElse("");
   }
 
+  public void setLastPullCursor(FormStatus fs, String cursor) {
+    lastPullCursorsByFormId.put(fs.getFormId(), cursor);
+  }
+
   @Override
   public Iterator<FormStatus> iterator() {
     return forms.iterator();

--- a/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
+++ b/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
@@ -304,7 +304,7 @@ public class BriefcaseCLI {
         importODK(storageDir, Paths.get(odkDir), Optional.empty());
 
       if (odkDir == null && server != null)
-        pullFormFromAggregate(storageDir, formid, username, password, server, false, false);
+        pullFormFromAggregate(storageDir, formid, username, password, server, false, false, false);
 
       if (exportPath != null)
         export(

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -190,6 +190,7 @@ public class ExportPanel {
                   TransferForms.of(form),
                   appPreferences.getBriefcaseDir().orElseThrow(BriefcaseException::new),
                   appPreferences.getPullInParallel().orElse(false),
+                  false,
                   false
               ));
             FormDefinition formDef = FormDefinition.from((BriefcaseFormDefinition) form.getFormDefinition());

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -24,7 +24,6 @@ import static org.opendatakit.briefcase.ui.reused.UI.errorMessage;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.bushe.swing.event.annotation.AnnotationProcessor;
 import org.bushe.swing.event.annotation.EventSubscriber;
@@ -44,6 +43,7 @@ import org.opendatakit.briefcase.pull.PullEvent;
 import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.reused.CacheUpdateEvent;
 import org.opendatakit.briefcase.transfer.NewTransferAction;
+import org.opendatakit.briefcase.transfer.TransferForms;
 import org.opendatakit.briefcase.ui.reused.Analytics;
 import org.opendatakit.briefcase.util.FormCache;
 import org.slf4j.Logger;
@@ -187,7 +187,7 @@ public class ExportPanel {
               forms.getTransferSettings(formId).ifPresent(sci -> NewTransferAction.transferServerToBriefcase(
                   sci,
                   new TerminationFuture(),
-                  Collections.singletonList(form),
+                  TransferForms.of(form),
                   appPreferences.getBriefcaseDir().orElseThrow(BriefcaseException::new),
                   appPreferences.getPullInParallel().orElse(false),
                   false

--- a/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
+++ b/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
@@ -96,7 +96,11 @@ public class PullPanel {
 
     view.onCancel(() -> terminationFuture.markAsCancelled(new PullEvent.Abort("Cancelled by the user")));
 
-    forms.onChange(() -> forms.getLastPullCursorsByFormId().forEach((key, value) -> tabPreferences.put(key + "-last-cursor", value)));
+    // TODO Preserve encapsulation of the suffix constant
+    forms.onChange(() -> forms.getLastPullCursorsByFormId().forEach((key, value) -> tabPreferences.put(
+        key + TransferForms.LAST_CURSOR_PREFERENCE_KEY_SUFFIX,
+        value
+    )));
   }
 
   public static PullPanel from(Http http, BriefcasePreferences appPreferences, TerminationFuture terminationFuture, Analytics analytics) {
@@ -196,7 +200,8 @@ public class PullPanel {
 
   @EventSubscriber(eventClass = PullEvent.CleanAllResumePoints.class)
   public void onCleanAllResumePoints(PullEvent.CleanAllResumePoints e) {
-    tabPreferences.keys().stream().filter(key -> key.endsWith("-last-cursor")).forEach(tabPreferences::remove);
+    // TODO Preserve encapsulation of the suffix constant
+    tabPreferences.keys().stream().filter(key -> key.endsWith(TransferForms.LAST_CURSOR_PREFERENCE_KEY_SUFFIX)).forEach(tabPreferences::remove);
     infoMessage("All pull resume points cleaned.");
   }
 }

--- a/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
+++ b/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
@@ -201,7 +201,8 @@ public class PullPanel {
   @EventSubscriber(eventClass = PullEvent.CleanAllResumePoints.class)
   public void onCleanAllResumePoints(PullEvent.CleanAllResumePoints e) {
     // TODO Preserve encapsulation of the suffix constant
-    tabPreferences.keys().stream().filter(key -> key.endsWith(TransferForms.LAST_CURSOR_PREFERENCE_KEY_SUFFIX)).forEach(tabPreferences::remove);
+    tabPreferences.keys().stream().filter(key -> key.endsWith(TransferForms.LAST_CURSOR_PREFERENCE_KEY_SUFFIX)).collect(toList()).forEach(tabPreferences::remove);
+    forms.cleanAllResumePoints();
     infoMessage("All pull resume points cleaned.");
   }
 }

--- a/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
+++ b/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
@@ -90,7 +90,7 @@ public class PullPanel {
     view.onAction(() -> {
       view.setWorking();
       forms.forEach(FormStatus::clearStatusHistory);
-      source.ifPresent(s -> s.pull(forms.getSelectedForms(), terminationFuture, appPreferences.getBriefcaseDir().orElseThrow(BriefcaseException::new), appPreferences.getPullInParallel().orElse(false), false));
+      source.ifPresent(s -> s.pull(forms.getSelectedForms(), terminationFuture, appPreferences.getBriefcaseDir().orElseThrow(BriefcaseException::new), appPreferences.getPullInParallel().orElse(false), false, false));
     });
 
     view.onCancel(() -> terminationFuture.markAsCancelled(new PullEvent.Abort("Cancelled by the user")));

--- a/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
+++ b/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
@@ -94,6 +94,8 @@ public class PullPanel {
     });
 
     view.onCancel(() -> terminationFuture.markAsCancelled(new PullEvent.Abort("Cancelled by the user")));
+
+    forms.onChange(() -> forms.getLastPullCursorsByFormId().forEach((key, value) -> tabPreferences.put(key + "-last-cursor", value)));
   }
 
   public static PullPanel from(Http http, BriefcasePreferences appPreferences, TerminationFuture terminationFuture, Analytics analytics) {

--- a/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
+++ b/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
@@ -90,7 +90,7 @@ public class PullPanel {
     view.onAction(() -> {
       view.setWorking();
       forms.forEach(FormStatus::clearStatusHistory);
-      source.ifPresent(s -> s.pull(forms.getSelectedForms(), terminationFuture, appPreferences.getBriefcaseDir().orElseThrow(BriefcaseException::new), appPreferences.getPullInParallel().orElse(false), false, false));
+      source.ifPresent(s -> s.pull(forms.getSelectedForms(), terminationFuture, appPreferences.getBriefcaseDir().orElseThrow(BriefcaseException::new), appPreferences.getPullInParallel().orElse(false), false, appPreferences.getResumeLastPull().orElse(false)));
     });
 
     view.onCancel(() -> terminationFuture.markAsCancelled(new PullEvent.Abort("Cancelled by the user")));

--- a/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
+++ b/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
@@ -22,6 +22,7 @@ import static org.opendatakit.briefcase.model.BriefcasePreferences.PASSWORD;
 import static org.opendatakit.briefcase.model.BriefcasePreferences.USERNAME;
 import static org.opendatakit.briefcase.model.BriefcasePreferences.getStorePasswordsConsentProperty;
 import static org.opendatakit.briefcase.ui.reused.UI.errorMessage;
+import static org.opendatakit.briefcase.ui.reused.UI.infoMessage;
 
 import java.util.Optional;
 import javax.swing.JPanel;
@@ -191,5 +192,11 @@ public class PullPanel {
       }
     }
     analytics.event("Pull", "Transfer", "Success", null);
+  }
+
+  @EventSubscriber(eventClass = PullEvent.CleanAllResumePoints.class)
+  public void onCleanAllResumePoints(PullEvent.CleanAllResumePoints e) {
+    tabPreferences.keys().stream().filter(key -> key.endsWith("-last-cursor")).forEach(tabPreferences::remove);
+    infoMessage("All pull resume points cleaned.");
   }
 }

--- a/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
+++ b/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
@@ -114,7 +114,7 @@ public class PullPanel {
 
   private void onSource(TransferPanelForm view, TransferForms forms, Source<?> source) {
     source.getFormList().thenAccept(formList -> {
-      forms.load(formList);
+      forms.load(formList, tabPreferences);
       view.refresh();
       updateActionButtons();
     }).onError(cause -> {

--- a/src/org/opendatakit/briefcase/ui/reused/source/Source.java
+++ b/src/org/opendatakit/briefcase/ui/reused/source/Source.java
@@ -47,6 +47,7 @@ import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.reused.DeferredValue;
 import org.opendatakit.briefcase.reused.RemoteServer;
 import org.opendatakit.briefcase.reused.http.Http;
+import org.opendatakit.briefcase.transfer.TransferForms;
 import org.opendatakit.briefcase.ui.reused.FileChooser;
 import org.opendatakit.briefcase.ui.reused.MouseAdapterBuilder;
 import org.opendatakit.briefcase.util.BadFormDefinition;
@@ -187,7 +188,7 @@ public interface Source<T> {
    * @param includeIncomplete when passed true, it enables requesting the incomplete
    *                          submissions. This needs to be supported by the selected source
    */
-  void pull(List<FormStatus> forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete);
+  void pull(TransferForms forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete);
 
   /**
    * Pushes forms to this configured {@link Source}.
@@ -195,7 +196,7 @@ public interface Source<T> {
    * @param forms             {@link List} of forms to be pulled
    * @param terminationFuture object that to make the operation cancellable
    */
-  void push(List<FormStatus> forms, TerminationFuture terminationFuture);
+  void push(TransferForms forms, TerminationFuture terminationFuture);
 
   /**
    * Returns whether or not this {@link Source} supports reloading.
@@ -260,12 +261,12 @@ public interface Source<T> {
     }
 
     @Override
-    public void pull(List<FormStatus> forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete) {
+    public void pull(TransferForms forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete) {
       TransferAction.transferServerToBriefcase(server.asServerConnectionInfo(), terminationFuture, forms, briefcaseDir, pullInParallel, includeIncomplete);
     }
 
     @Override
-    public void push(List<FormStatus> forms, TerminationFuture terminationFuture) {
+    public void push(TransferForms forms, TerminationFuture terminationFuture) {
       TransferAction.transferBriefcaseToServer(server.asServerConnectionInfo(), terminationFuture, forms, http, server);
     }
 
@@ -361,12 +362,12 @@ public interface Source<T> {
     }
 
     @Override
-    public void pull(List<FormStatus> forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete) {
+    public void pull(TransferForms forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete) {
       TransferAction.transferODKToBriefcase(briefcaseDir, path.toFile(), terminationFuture, forms);
     }
 
     @Override
-    public void push(List<FormStatus> forms, TerminationFuture terminationFuture) {
+    public void push(TransferForms forms, TerminationFuture terminationFuture) {
       throw new BriefcaseException("Can't push to a Collect directory");
     }
 
@@ -449,12 +450,12 @@ public interface Source<T> {
     }
 
     @Override
-    public void pull(List<FormStatus> forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete) {
+    public void pull(TransferForms forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete) {
       invokeLater(() -> FormInstaller.install(briefcaseDir, form));
     }
 
     @Override
-    public void push(List<FormStatus> forms, TerminationFuture terminationFuture) {
+    public void push(TransferForms forms, TerminationFuture terminationFuture) {
       throw new BriefcaseException("Can't push to this source");
     }
 

--- a/src/org/opendatakit/briefcase/ui/reused/source/Source.java
+++ b/src/org/opendatakit/briefcase/ui/reused/source/Source.java
@@ -187,8 +187,9 @@ public interface Source<T> {
    * @param terminationFuture object that to make the operation cancellable
    * @param includeIncomplete when passed true, it enables requesting the incomplete
    *                          submissions. This needs to be supported by the selected source
+   * @param resumeLastPull
    */
-  void pull(TransferForms forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete);
+  void pull(TransferForms forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete, boolean resumeLastPull);
 
   /**
    * Pushes forms to this configured {@link Source}.
@@ -261,8 +262,8 @@ public interface Source<T> {
     }
 
     @Override
-    public void pull(TransferForms forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete) {
-      TransferAction.transferServerToBriefcase(server.asServerConnectionInfo(), terminationFuture, forms, briefcaseDir, pullInParallel, includeIncomplete);
+    public void pull(TransferForms forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete, boolean resumeLastPull) {
+      TransferAction.transferServerToBriefcase(server.asServerConnectionInfo(), terminationFuture, forms, briefcaseDir, pullInParallel, includeIncomplete, resumeLastPull);
     }
 
     @Override
@@ -362,7 +363,7 @@ public interface Source<T> {
     }
 
     @Override
-    public void pull(TransferForms forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete) {
+    public void pull(TransferForms forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete, boolean resumeLastPull) {
       TransferAction.transferODKToBriefcase(briefcaseDir, path.toFile(), terminationFuture, forms);
     }
 
@@ -450,7 +451,7 @@ public interface Source<T> {
     }
 
     @Override
-    public void pull(TransferForms forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete) {
+    public void pull(TransferForms forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete, boolean resumeLastPull) {
       invokeLater(() -> FormInstaller.install(briefcaseDir, form));
     }
 

--- a/src/org/opendatakit/briefcase/ui/settings/SettingsPanel.java
+++ b/src/org/opendatakit/briefcase/ui/settings/SettingsPanel.java
@@ -20,7 +20,9 @@ import static org.opendatakit.briefcase.ui.reused.UI.infoMessage;
 
 import java.nio.file.Path;
 import javax.swing.JPanel;
+import org.bushe.swing.event.EventBus;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
+import org.opendatakit.briefcase.pull.PullEvent;
 import org.opendatakit.briefcase.reused.UncheckedFiles;
 import org.opendatakit.briefcase.ui.reused.Analytics;
 import org.opendatakit.briefcase.util.FormCache;
@@ -68,6 +70,7 @@ public class SettingsPanel {
       formCache.update();
       infoMessage("Forms successfully reloaded from storage location.");
     });
+    form.onCleanAllPullResumePoints(() -> EventBus.publish(new PullEvent.CleanAllResumePoints()));
   }
 
   public static SettingsPanel from(BriefcasePreferences appPreferences, Analytics analytics, FormCache formCache) {

--- a/src/org/opendatakit/briefcase/ui/settings/SettingsPanel.java
+++ b/src/org/opendatakit/briefcase/ui/settings/SettingsPanel.java
@@ -36,6 +36,7 @@ public class SettingsPanel {
 
     appPreferences.getBriefcaseDir().ifPresent(path -> form.setStorageLocation(path.getParent()));
     appPreferences.getPullInParallel().ifPresent(form::setPullInParallel);
+    appPreferences.getResumeLastPull().ifPresent(form::setResumeLastPull);
     appPreferences.getRememberPasswords().ifPresent(form::setRememberPasswords);
     appPreferences.getSendUsageData().ifPresent(form::setSendUsageData);
     appPreferences.getHttpProxy().ifPresent(httpProxy -> {
@@ -56,6 +57,7 @@ public class SettingsPanel {
       appPreferences.unsetStorageDir();
     });
     form.onPullInParallelChange(appPreferences::setPullInParallel);
+    form.onResumeLastPullChange(appPreferences::setResumeLastPull);
     form.onRememberPasswordsChange(appPreferences::setRememberPasswords);
     form.onSendUsageDataChange(enabled -> {
       appPreferences.setSendUsage(enabled);

--- a/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.form
+++ b/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.form
@@ -2,7 +2,7 @@
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.opendatakit.briefcase.ui.settings.SettingsPanelForm">
   <grid id="f6607" binding="container" layout-manager="GridBagLayout">
     <constraints>
-      <xy x="20" y="20" width="558" height="457"/>
+      <xy x="20" y="20" width="558" height="581"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -77,7 +77,7 @@
       </component>
       <component id="ebec7" class="javax.swing.JCheckBox" binding="rememberPasswordsField">
         <constraints>
-          <grid row="5" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties>
@@ -86,7 +86,7 @@
       </component>
       <component id="eee9e" class="javax.swing.JCheckBox" binding="sendUsageDataField">
         <constraints>
-          <grid row="7" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="9" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties>
@@ -95,7 +95,7 @@
       </component>
       <component id="1e663" class="javax.swing.JCheckBox" binding="useHttpProxyField">
         <constraints>
-          <grid row="9" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="11" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties>
@@ -104,13 +104,13 @@
       </component>
       <hspacer id="e2bba">
         <constraints>
-          <grid row="10" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="12" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
           <gridbag top="0" left="0" bottom="0" right="20" weightx="0.0" weighty="0.0"/>
         </constraints>
       </hspacer>
       <component id="4798c" class="javax.swing.JLabel" binding="httpProxyJostLabel">
         <constraints>
-          <grid row="10" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="12" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties>
@@ -119,7 +119,7 @@
       </component>
       <component id="ba219" class="javax.swing.JTextField" binding="httpProxyHostField">
         <constraints>
-          <grid row="10" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="12" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
           <gridbag weightx="0.0" weighty="0.0"/>
@@ -131,13 +131,13 @@
       </component>
       <hspacer id="ef4f9">
         <constraints>
-          <grid row="10" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="12" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
       </hspacer>
       <component id="24a4b" class="javax.swing.JLabel" binding="httpProxyPortLabel">
         <constraints>
-          <grid row="11" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="13" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties>
@@ -146,13 +146,13 @@
       </component>
       <hspacer id="abc2a">
         <constraints>
-          <grid row="10" column="5" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="12" column="5" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
           <gridbag weightx="1.0" weighty="0.0"/>
         </constraints>
       </hspacer>
       <component id="c39fc" class="javax.swing.JSpinner" binding="httpProxyPortField" custom-create="true">
         <constraints>
-          <grid row="11" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="13" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties>
@@ -161,19 +161,19 @@
       </component>
       <vspacer id="9de98">
         <constraints>
-          <grid row="8" column="1" row-span="1" col-span="5" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="10" column="1" row-span="1" col-span="5" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
       </vspacer>
       <hspacer id="d8601">
         <constraints>
-          <grid row="1" column="6" row-span="11" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="6" row-span="13" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
       </hspacer>
       <hspacer id="4a57b">
         <constraints>
-          <grid row="1" column="0" row-span="11" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="13" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
       </hspacer>
@@ -185,13 +185,13 @@
       </vspacer>
       <vspacer id="bf0d2">
         <constraints>
-          <grid row="12" column="1" row-span="1" col-span="5" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="14" column="1" row-span="1" col-span="5" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="1.0"/>
         </constraints>
       </vspacer>
       <vspacer id="6a393">
         <constraints>
-          <grid row="6" column="1" row-span="1" col-span="5" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="1" row-span="1" col-span="5" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
       </vspacer>
@@ -203,7 +203,7 @@
       </vspacer>
       <grid id="a9540" layout-manager="GridBagLayout">
         <constraints>
-          <grid row="13" column="1" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="15" column="1" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
         <properties/>
@@ -282,7 +282,22 @@
       </grid>
       <vspacer id="af488">
         <constraints>
-          <grid row="14" column="0" row-span="1" col-span="6" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="16" column="0" row-span="1" col-span="6" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <gridbag weightx="0.0" weighty="0.0"/>
+        </constraints>
+      </vspacer>
+      <component id="16789" class="javax.swing.JCheckBox" binding="resumeLasPullField">
+        <constraints>
+          <grid row="5" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <gridbag weightx="0.0" weighty="0.0"/>
+        </constraints>
+        <properties>
+          <text value="Always try to resume last pull"/>
+        </properties>
+      </component>
+      <vspacer id="52501">
+        <constraints>
+          <grid row="6" column="1" row-span="1" col-span="5" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
       </vspacer>

--- a/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.form
+++ b/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.form
@@ -2,7 +2,7 @@
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.opendatakit.briefcase.ui.settings.SettingsPanelForm">
   <grid id="f6607" binding="container" layout-manager="GridBagLayout">
     <constraints>
-      <xy x="20" y="20" width="558" height="581"/>
+      <xy x="20" y="20" width="650" height="581"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -211,7 +211,7 @@
         <children>
           <component id="bd391" class="javax.swing.JButton" binding="reloadCacheButton">
             <constraints>
-              <grid row="4" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="8" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
               <gridbag weightx="0.0" weighty="0.0"/>
             </constraints>
             <properties>
@@ -220,31 +220,31 @@
           </component>
           <vspacer id="624">
             <constraints>
-              <grid row="3" column="2" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+              <grid row="7" column="2" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
               <gridbag weightx="0.0" weighty="0.0"/>
             </constraints>
           </vspacer>
           <vspacer id="e1029">
             <constraints>
-              <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+              <grid row="9" column="2" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
               <gridbag weightx="0.0" weighty="0.0"/>
             </constraints>
           </vspacer>
           <hspacer id="d66e1">
             <constraints>
-              <grid row="4" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="8" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
               <gridbag weightx="0.5" weighty="0.0"/>
             </constraints>
           </hspacer>
           <hspacer id="bd1f0">
             <constraints>
-              <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="8" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
               <gridbag weightx="0.5" weighty="0.0"/>
             </constraints>
           </hspacer>
           <component id="3d58f" class="javax.swing.JLabel">
             <constraints>
-              <grid row="1" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="5" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
               <gridbag weightx="0.0" weighty="0.0"/>
             </constraints>
             <properties>
@@ -253,7 +253,7 @@
           </component>
           <component id="29f57" class="javax.swing.JLabel">
             <constraints>
-              <grid row="2" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="6" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
               <gridbag weightx="0.0" weighty="0.0"/>
             </constraints>
             <properties>
@@ -262,7 +262,7 @@
           </component>
           <hspacer id="131d4">
             <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
               <gridbag weightx="0.0" weighty="0.0"/>
             </constraints>
           </hspacer>
@@ -274,10 +274,40 @@
           </vspacer>
           <hspacer id="b5209">
             <constraints>
-              <grid row="1" column="4" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="5" column="4" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
               <gridbag weightx="0.0" weighty="0.0"/>
             </constraints>
           </hspacer>
+          <vspacer id="ffb1b">
+            <constraints>
+              <grid row="4" column="2" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+              <gridbag weightx="0.0" weighty="0.0"/>
+            </constraints>
+          </vspacer>
+          <component id="60ae7" class="javax.swing.JButton" binding="cleanAllPullResumePointsButton">
+            <constraints>
+              <grid row="3" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <gridbag weightx="0.0" weighty="0.0"/>
+            </constraints>
+            <properties>
+              <text value="Clean all pull resume points"/>
+            </properties>
+          </component>
+          <component id="d4c34" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="1" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <gridbag weightx="0.0" weighty="0.0"/>
+            </constraints>
+            <properties>
+              <text value="You can clean all resume points if you need to restart pulling your forms."/>
+            </properties>
+          </component>
+          <vspacer id="b27e7">
+            <constraints>
+              <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+              <gridbag weightx="0.0" weighty="0.0"/>
+            </constraints>
+          </vspacer>
         </children>
       </grid>
       <vspacer id="af488">

--- a/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.form
+++ b/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.form
@@ -316,7 +316,7 @@
           <gridbag weightx="0.0" weighty="0.0"/>
         </constraints>
       </vspacer>
-      <component id="16789" class="javax.swing.JCheckBox" binding="resumeLasPullField">
+      <component id="16789" class="javax.swing.JCheckBox" binding="resumeLastPullField">
         <constraints>
           <grid row="5" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
           <gridbag weightx="0.0" weighty="0.0"/>

--- a/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.form
+++ b/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.form
@@ -215,6 +215,7 @@
               <gridbag weightx="0.0" weighty="0.0"/>
             </constraints>
             <properties>
+              <enabled value="false"/>
               <text value="Reload forms from storage location"/>
             </properties>
           </component>
@@ -290,6 +291,7 @@
               <gridbag weightx="0.0" weighty="0.0"/>
             </constraints>
             <properties>
+              <enabled value="false"/>
               <text value="Clean all pull resume points"/>
             </properties>
           </component>

--- a/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.java
@@ -83,8 +83,6 @@ public class SettingsPanelForm {
 
     httpProxyPortField.addChangeListener(__ -> processHttpProxyFields());
 
-    reloadCacheButton.setEnabled(false);
-
     updateProxyFields(useHttpProxyField.isSelected());
   }
 
@@ -404,6 +402,7 @@ public class SettingsPanelForm {
     container.add(panel1, gbc);
     panel1.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), "Troubleshooting"));
     reloadCacheButton = new JButton();
+    reloadCacheButton.setEnabled(false);
     reloadCacheButton.setText("Reload forms from storage location");
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
@@ -477,6 +476,7 @@ public class SettingsPanelForm {
     gbc.fill = GridBagConstraints.VERTICAL;
     panel1.add(spacer19, gbc);
     cleanAllPullResumePointsButton = new JButton();
+    cleanAllPullResumePointsButton.setEnabled(false);
     cleanAllPullResumePointsButton.setText("Clean all pull resume points");
     gbc = new GridBagConstraints();
     gbc.gridx = 2;

--- a/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.java
@@ -61,6 +61,7 @@ public class SettingsPanelForm {
   private JLabel httpProxyPortLabel;
   private JLabel httpProxyJostLabel;
   private JButton reloadCacheButton;
+  private JButton cleanAllPullResumePointsButton;
   private final List<Consumer<Path>> onStorageLocationCallbacks = new ArrayList<>();
   private final List<Runnable> onClearStorageLocationCallbacks = new ArrayList<>();
   private final List<Consumer<HttpHost>> onHttpProxyCallbacks = new ArrayList<>();
@@ -192,6 +193,10 @@ public class SettingsPanelForm {
 
   void onReloadCache(Runnable callback) {
     reloadCacheButton.addActionListener(__ -> callback.run());
+  }
+
+  void onCleanAllPullResumePoints(Runnable callback) {
+    cleanAllPullResumePointsButton.addActionListener(__ -> callback.run());
   }
 
   private void createUIComponents() {
@@ -400,32 +405,32 @@ public class SettingsPanelForm {
     reloadCacheButton.setText("Reload forms from storage location");
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
-    gbc.gridy = 4;
+    gbc.gridy = 8;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     panel1.add(reloadCacheButton, gbc);
     final JPanel spacer12 = new JPanel();
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
-    gbc.gridy = 3;
+    gbc.gridy = 7;
     gbc.fill = GridBagConstraints.VERTICAL;
     panel1.add(spacer12, gbc);
     final JPanel spacer13 = new JPanel();
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
-    gbc.gridy = 5;
+    gbc.gridy = 9;
     gbc.fill = GridBagConstraints.VERTICAL;
     panel1.add(spacer13, gbc);
     final JPanel spacer14 = new JPanel();
     gbc = new GridBagConstraints();
     gbc.gridx = 3;
-    gbc.gridy = 4;
+    gbc.gridy = 8;
     gbc.weightx = 0.5;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     panel1.add(spacer14, gbc);
     final JPanel spacer15 = new JPanel();
     gbc = new GridBagConstraints();
     gbc.gridx = 1;
-    gbc.gridy = 4;
+    gbc.gridy = 8;
     gbc.weightx = 0.5;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     panel1.add(spacer15, gbc);
@@ -433,7 +438,7 @@ public class SettingsPanelForm {
     label1.setText("The form list in Briefcase can get out of date if files are moved manually.");
     gbc = new GridBagConstraints();
     gbc.gridx = 1;
-    gbc.gridy = 1;
+    gbc.gridy = 5;
     gbc.gridwidth = 3;
     gbc.anchor = GridBagConstraints.WEST;
     panel1.add(label1, gbc);
@@ -441,14 +446,14 @@ public class SettingsPanelForm {
     label2.setText("This reload is always safe.");
     gbc = new GridBagConstraints();
     gbc.gridx = 1;
-    gbc.gridy = 2;
+    gbc.gridy = 6;
     gbc.gridwidth = 3;
     gbc.anchor = GridBagConstraints.WEST;
     panel1.add(label2, gbc);
     final JPanel spacer16 = new JPanel();
     gbc = new GridBagConstraints();
     gbc.gridx = 0;
-    gbc.gridy = 1;
+    gbc.gridy = 5;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     panel1.add(spacer16, gbc);
     final JPanel spacer17 = new JPanel();
@@ -460,16 +465,43 @@ public class SettingsPanelForm {
     final JPanel spacer18 = new JPanel();
     gbc = new GridBagConstraints();
     gbc.gridx = 4;
-    gbc.gridy = 1;
+    gbc.gridy = 5;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     panel1.add(spacer18, gbc);
     final JPanel spacer19 = new JPanel();
+    gbc = new GridBagConstraints();
+    gbc.gridx = 2;
+    gbc.gridy = 4;
+    gbc.fill = GridBagConstraints.VERTICAL;
+    panel1.add(spacer19, gbc);
+    cleanAllPullResumePointsButton = new JButton();
+    cleanAllPullResumePointsButton.setText("Clean all pull resume points");
+    gbc = new GridBagConstraints();
+    gbc.gridx = 2;
+    gbc.gridy = 3;
+    gbc.fill = GridBagConstraints.HORIZONTAL;
+    panel1.add(cleanAllPullResumePointsButton, gbc);
+    final JLabel label3 = new JLabel();
+    label3.setText("You can clean all resume points if you need to restart pulling your forms.");
+    gbc = new GridBagConstraints();
+    gbc.gridx = 1;
+    gbc.gridy = 1;
+    gbc.gridwidth = 3;
+    gbc.anchor = GridBagConstraints.WEST;
+    panel1.add(label3, gbc);
+    final JPanel spacer20 = new JPanel();
+    gbc = new GridBagConstraints();
+    gbc.gridx = 2;
+    gbc.gridy = 2;
+    gbc.fill = GridBagConstraints.VERTICAL;
+    panel1.add(spacer20, gbc);
+    final JPanel spacer21 = new JPanel();
     gbc = new GridBagConstraints();
     gbc.gridx = 0;
     gbc.gridy = 16;
     gbc.gridwidth = 6;
     gbc.fill = GridBagConstraints.VERTICAL;
-    container.add(spacer19, gbc);
+    container.add(spacer21, gbc);
     resumeLasPullField = new JCheckBox();
     resumeLasPullField.setText("Always try to resume last pull");
     gbc = new GridBagConstraints();
@@ -478,13 +510,13 @@ public class SettingsPanelForm {
     gbc.gridwidth = 5;
     gbc.anchor = GridBagConstraints.WEST;
     container.add(resumeLasPullField, gbc);
-    final JPanel spacer20 = new JPanel();
+    final JPanel spacer22 = new JPanel();
     gbc = new GridBagConstraints();
     gbc.gridx = 1;
     gbc.gridy = 6;
     gbc.gridwidth = 5;
     gbc.fill = GridBagConstraints.VERTICAL;
-    container.add(spacer20, gbc);
+    container.add(spacer22, gbc);
   }
 
   /**

--- a/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.java
@@ -52,7 +52,7 @@ public class SettingsPanelForm {
   private JButton storageLocationClearButton;
   private JButton storageLocationChooseButton;
   private JCheckBox pullInParallelField;
-  private JCheckBox resumeLasPullField;
+  private JCheckBox resumeLastPullField;
   private JCheckBox rememberPasswordsField;
   private JCheckBox sendUsageDataField;
   private JCheckBox useHttpProxyField;
@@ -168,11 +168,11 @@ public class SettingsPanelForm {
   }
 
   void onResumeLastPullChange(Consumer<Boolean> callback) {
-    resumeLasPullField.addActionListener(__ -> callback.accept(resumeLasPullField.isSelected()));
+    resumeLastPullField.addActionListener(__ -> callback.accept(resumeLastPullField.isSelected()));
   }
 
   void setResumeLastPull(Boolean enabled) {
-    resumeLasPullField.setSelected(enabled);
+    resumeLastPullField.setSelected(enabled);
   }
 
   void onRememberPasswordsChange(Consumer<Boolean> callback) {
@@ -502,14 +502,14 @@ public class SettingsPanelForm {
     gbc.gridwidth = 6;
     gbc.fill = GridBagConstraints.VERTICAL;
     container.add(spacer21, gbc);
-    resumeLasPullField = new JCheckBox();
-    resumeLasPullField.setText("Always try to resume last pull");
+    resumeLastPullField = new JCheckBox();
+    resumeLastPullField.setText("Always try to resume last pull");
     gbc = new GridBagConstraints();
     gbc.gridx = 1;
     gbc.gridy = 5;
     gbc.gridwidth = 5;
     gbc.anchor = GridBagConstraints.WEST;
-    container.add(resumeLasPullField, gbc);
+    container.add(resumeLastPullField, gbc);
     final JPanel spacer22 = new JPanel();
     gbc = new GridBagConstraints();
     gbc.gridx = 1;

--- a/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.java
@@ -119,6 +119,7 @@ public class SettingsPanelForm {
     storageLocationClearButton.setVisible(true);
     onStorageLocationCallbacks.forEach(consumer -> consumer.accept(path));
     reloadCacheButton.setEnabled(true);
+    cleanAllPullResumePointsButton.setEnabled(true);
   }
 
   private void clearStorageLocation() {
@@ -127,6 +128,7 @@ public class SettingsPanelForm {
     storageLocationClearButton.setVisible(false);
     onClearStorageLocationCallbacks.forEach(Runnable::run);
     reloadCacheButton.setEnabled(false);
+    cleanAllPullResumePointsButton.setEnabled(false);
   }
 
   void onStorageLocation(Consumer<Path> onSet, Runnable onClear) {

--- a/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.java
@@ -52,6 +52,7 @@ public class SettingsPanelForm {
   private JButton storageLocationClearButton;
   private JButton storageLocationChooseButton;
   private JCheckBox pullInParallelField;
+  private JCheckBox resumeLasPullField;
   private JCheckBox rememberPasswordsField;
   private JCheckBox sendUsageDataField;
   private JCheckBox useHttpProxyField;
@@ -157,13 +158,20 @@ public class SettingsPanelForm {
     };
   }
 
-
   void onPullInParallelChange(Consumer<Boolean> callback) {
     pullInParallelField.addActionListener(__ -> callback.accept(pullInParallelField.isSelected()));
   }
 
   void setPullInParallel(Boolean enabled) {
     pullInParallelField.setSelected(enabled);
+  }
+
+  void onResumeLastPullChange(Consumer<Boolean> callback) {
+    resumeLasPullField.addActionListener(__ -> callback.accept(resumeLasPullField.isSelected()));
+  }
+
+  void setResumeLastPull(Boolean enabled) {
+    resumeLasPullField.setSelected(enabled);
   }
 
   void onRememberPasswordsChange(Consumer<Boolean> callback) {
@@ -259,7 +267,7 @@ public class SettingsPanelForm {
     rememberPasswordsField.setText("Remember passwords (unencrypted)");
     gbc = new GridBagConstraints();
     gbc.gridx = 1;
-    gbc.gridy = 5;
+    gbc.gridy = 7;
     gbc.gridwidth = 5;
     gbc.anchor = GridBagConstraints.WEST;
     container.add(rememberPasswordsField, gbc);
@@ -267,7 +275,7 @@ public class SettingsPanelForm {
     sendUsageDataField.setText("Send usage data and crash logs to core developers");
     gbc = new GridBagConstraints();
     gbc.gridx = 1;
-    gbc.gridy = 7;
+    gbc.gridy = 9;
     gbc.gridwidth = 5;
     gbc.anchor = GridBagConstraints.WEST;
     container.add(sendUsageDataField, gbc);
@@ -275,14 +283,14 @@ public class SettingsPanelForm {
     useHttpProxyField.setText("Use HTTP Proxy");
     gbc = new GridBagConstraints();
     gbc.gridx = 1;
-    gbc.gridy = 9;
+    gbc.gridy = 11;
     gbc.gridwidth = 5;
     gbc.anchor = GridBagConstraints.WEST;
     container.add(useHttpProxyField, gbc);
     final JPanel spacer2 = new JPanel();
     gbc = new GridBagConstraints();
     gbc.gridx = 1;
-    gbc.gridy = 10;
+    gbc.gridy = 12;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     gbc.insets = new Insets(0, 0, 0, 20);
     container.add(spacer2, gbc);
@@ -290,7 +298,7 @@ public class SettingsPanelForm {
     httpProxyJostLabel.setText("Host");
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
-    gbc.gridy = 10;
+    gbc.gridy = 12;
     gbc.anchor = GridBagConstraints.WEST;
     container.add(httpProxyJostLabel, gbc);
     httpProxyHostField = new JTextField();
@@ -298,41 +306,41 @@ public class SettingsPanelForm {
     httpProxyHostField.setText("127.0.0.1");
     gbc = new GridBagConstraints();
     gbc.gridx = 4;
-    gbc.gridy = 10;
+    gbc.gridy = 12;
     gbc.anchor = GridBagConstraints.WEST;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     container.add(httpProxyHostField, gbc);
     final JPanel spacer3 = new JPanel();
     gbc = new GridBagConstraints();
     gbc.gridx = 3;
-    gbc.gridy = 10;
+    gbc.gridy = 12;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     container.add(spacer3, gbc);
     httpProxyPortLabel = new JLabel();
     httpProxyPortLabel.setText("Port");
     gbc = new GridBagConstraints();
     gbc.gridx = 2;
-    gbc.gridy = 11;
+    gbc.gridy = 13;
     gbc.anchor = GridBagConstraints.WEST;
     container.add(httpProxyPortLabel, gbc);
     final JPanel spacer4 = new JPanel();
     gbc = new GridBagConstraints();
     gbc.gridx = 5;
-    gbc.gridy = 10;
+    gbc.gridy = 12;
     gbc.weightx = 1.0;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     container.add(spacer4, gbc);
     httpProxyPortField.setPreferredSize(new Dimension(150, 30));
     gbc = new GridBagConstraints();
     gbc.gridx = 4;
-    gbc.gridy = 11;
+    gbc.gridy = 13;
     gbc.anchor = GridBagConstraints.WEST;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     container.add(httpProxyPortField, gbc);
     final JPanel spacer5 = new JPanel();
     gbc = new GridBagConstraints();
     gbc.gridx = 1;
-    gbc.gridy = 8;
+    gbc.gridy = 10;
     gbc.gridwidth = 5;
     gbc.fill = GridBagConstraints.VERTICAL;
     container.add(spacer5, gbc);
@@ -340,14 +348,14 @@ public class SettingsPanelForm {
     gbc = new GridBagConstraints();
     gbc.gridx = 6;
     gbc.gridy = 1;
-    gbc.gridheight = 11;
+    gbc.gridheight = 13;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     container.add(spacer6, gbc);
     final JPanel spacer7 = new JPanel();
     gbc = new GridBagConstraints();
     gbc.gridx = 0;
     gbc.gridy = 1;
-    gbc.gridheight = 11;
+    gbc.gridheight = 13;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     container.add(spacer7, gbc);
     final JPanel spacer8 = new JPanel();
@@ -360,7 +368,7 @@ public class SettingsPanelForm {
     final JPanel spacer9 = new JPanel();
     gbc = new GridBagConstraints();
     gbc.gridx = 1;
-    gbc.gridy = 12;
+    gbc.gridy = 14;
     gbc.gridwidth = 5;
     gbc.weighty = 1.0;
     gbc.fill = GridBagConstraints.VERTICAL;
@@ -368,7 +376,7 @@ public class SettingsPanelForm {
     final JPanel spacer10 = new JPanel();
     gbc = new GridBagConstraints();
     gbc.gridx = 1;
-    gbc.gridy = 6;
+    gbc.gridy = 8;
     gbc.gridwidth = 5;
     gbc.fill = GridBagConstraints.VERTICAL;
     container.add(spacer10, gbc);
@@ -383,7 +391,7 @@ public class SettingsPanelForm {
     panel1.setLayout(new GridBagLayout());
     gbc = new GridBagConstraints();
     gbc.gridx = 1;
-    gbc.gridy = 13;
+    gbc.gridy = 15;
     gbc.gridwidth = 5;
     gbc.fill = GridBagConstraints.BOTH;
     container.add(panel1, gbc);
@@ -458,10 +466,25 @@ public class SettingsPanelForm {
     final JPanel spacer19 = new JPanel();
     gbc = new GridBagConstraints();
     gbc.gridx = 0;
-    gbc.gridy = 14;
+    gbc.gridy = 16;
     gbc.gridwidth = 6;
     gbc.fill = GridBagConstraints.VERTICAL;
     container.add(spacer19, gbc);
+    resumeLasPullField = new JCheckBox();
+    resumeLasPullField.setText("Always try to resume last pull");
+    gbc = new GridBagConstraints();
+    gbc.gridx = 1;
+    gbc.gridy = 5;
+    gbc.gridwidth = 5;
+    gbc.anchor = GridBagConstraints.WEST;
+    container.add(resumeLasPullField, gbc);
+    final JPanel spacer20 = new JPanel();
+    gbc = new GridBagConstraints();
+    gbc.gridx = 1;
+    gbc.gridy = 6;
+    gbc.gridwidth = 5;
+    gbc.fill = GridBagConstraints.VERTICAL;
+    container.add(spacer20, gbc);
   }
 
   /**
@@ -470,4 +493,5 @@ public class SettingsPanelForm {
   public JComponent $$$getRootComponent$$$() {
     return container;
   }
+
 }

--- a/src/org/opendatakit/briefcase/util/PullFromODKException.java
+++ b/src/org/opendatakit/briefcase/util/PullFromODKException.java
@@ -17,12 +17,11 @@ package org.opendatakit.briefcase.util;
 
 import static java.util.stream.Collectors.joining;
 
-import java.util.List;
-import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.reused.BriefcaseException;
+import org.opendatakit.briefcase.transfer.TransferForms;
 
 class PullFromODKException extends BriefcaseException {
-  PullFromODKException(List<FormStatus> forms) {
-    super("Failure pulling forms from ODK. FormIds: " + forms.stream().map(f -> f.getFormDefinition().getFormId()).collect(joining(", ")));
+  PullFromODKException(TransferForms forms) {
+    super("Failure pulling forms from ODK. FormIds: " + forms.map(f -> f.getFormDefinition().getFormId()).collect(joining(", ")));
   }
 }

--- a/src/org/opendatakit/briefcase/util/PullFromServerException.java
+++ b/src/org/opendatakit/briefcase/util/PullFromServerException.java
@@ -17,20 +17,19 @@ package org.opendatakit.briefcase.util;
 
 import static java.util.stream.Collectors.joining;
 
-import java.util.List;
-import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.reused.BriefcaseException;
+import org.opendatakit.briefcase.transfer.TransferForms;
 
 class PullFromServerException extends BriefcaseException {
-  PullFromServerException(List<FormStatus> forms, Throwable cause) {
+  PullFromServerException(TransferForms forms, Throwable cause) {
     super(buildMessage(forms), cause);
   }
 
-  PullFromServerException(List<FormStatus> forms) {
+  PullFromServerException(TransferForms forms) {
     super(buildMessage(forms));
   }
 
-  private static String buildMessage(List<FormStatus> forms) {
-    return "Failure pulling forms from server. FormIds: " + forms.stream().map(f -> f.getFormDefinition().getFormId()).collect(joining(", "));
+  private static String buildMessage(TransferForms forms) {
+    return "Failure pulling forms from server. FormIds: " + forms.map(f -> f.getFormDefinition().getFormId()).collect(joining(", "));
   }
 }

--- a/src/org/opendatakit/briefcase/util/PushFromServerException.java
+++ b/src/org/opendatakit/briefcase/util/PushFromServerException.java
@@ -17,12 +17,11 @@ package org.opendatakit.briefcase.util;
 
 import static java.util.stream.Collectors.joining;
 
-import java.util.List;
-import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.reused.BriefcaseException;
+import org.opendatakit.briefcase.transfer.TransferForms;
 
 class PushFromServerException extends BriefcaseException {
-  PushFromServerException(List<FormStatus> forms) {
-    super("Failure pushing forms to server. FormIds: " + forms.stream().map(f -> f.getFormDefinition().getFormId()).collect(joining(", ")));
+  PushFromServerException(TransferForms forms) {
+    super("Failure pushing forms to server. FormIds: " + forms.map(f -> f.getFormDefinition().getFormId()).collect(joining(", ")));
   }
 }

--- a/src/org/opendatakit/briefcase/util/ServerFetcher.java
+++ b/src/org/opendatakit/briefcase/util/ServerFetcher.java
@@ -55,6 +55,7 @@ import org.opendatakit.briefcase.model.TerminationFuture;
 import org.opendatakit.briefcase.model.TransmissionException;
 import org.opendatakit.briefcase.model.XmlDocumentFetchException;
 import org.opendatakit.briefcase.pull.PullEvent;
+import org.opendatakit.briefcase.transfer.TransferForms;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,7 +96,7 @@ public class ServerFetcher {
     return terminationFuture.isCancelled();
   }
 
-  boolean downloadFormAndSubmissionFiles(List<FormStatus> formsToTransfer) {
+  boolean downloadFormAndSubmissionFiles(TransferForms formsToTransfer) {
     boolean allSuccessful = true;
 
     for (FormStatus fs : formsToTransfer) {

--- a/src/org/opendatakit/briefcase/util/ServerFetcher.java
+++ b/src/org/opendatakit/briefcase/util/ServerFetcher.java
@@ -96,7 +96,7 @@ public class ServerFetcher {
     return terminationFuture.isCancelled();
   }
 
-  boolean downloadFormAndSubmissionFiles(TransferForms formsToTransfer) {
+  boolean downloadFormAndSubmissionFiles(TransferForms formsToTransfer, boolean resumeLastPull) {
     boolean allSuccessful = true;
 
     for (FormStatus fs : formsToTransfer) {
@@ -154,7 +154,7 @@ public class ServerFetcher {
           File formInstancesDir = FileSystemUtils.getFormInstancesDirectory(briefcaseLfd.getFormDirectory());
 
           // this will publish events
-          successful = downloadAllSubmissionsForForm(formInstancesDir, formDatabase, briefcaseLfd, fs);
+          successful = downloadAllSubmissionsForForm(formInstancesDir, formDatabase, briefcaseLfd, fs, resumeLastPull ? formsToTransfer.getLastCursor(fs) : "");
         } catch (SQLException | FileSystemException e) {
           allSuccessful = false;
           String msg = "unable to open form database";
@@ -262,7 +262,7 @@ public class ServerFetcher {
   }
 
   private boolean downloadAllSubmissionsForForm(File formInstancesDir, DatabaseUtils formDatabase, BriefcaseFormDefinition lfd,
-                                                FormStatus fs) {
+                                                FormStatus fs, String websafeCursorString) {
     int submissionCount = 1;
     int chunkCount = 1;
     boolean allSuccessful = true;
@@ -272,7 +272,6 @@ public class ServerFetcher {
     CompletionService<String> submissionCompleter = new ExecutorCompletionService<>(execSvc);
 
     String oldWebsafeCursorString;
-    String websafeCursorString = "";
 
     chunkCompleter.submit(new SubmissionChunkDownload(fs, fd.getFormId(), websafeCursorString));
 

--- a/src/org/opendatakit/briefcase/util/ServerUploader.java
+++ b/src/org/opendatakit/briefcase/util/ServerUploader.java
@@ -42,6 +42,7 @@ import org.opendatakit.briefcase.model.TransmissionException;
 import org.opendatakit.briefcase.model.XmlDocumentFetchException;
 import org.opendatakit.briefcase.reused.RemoteServer;
 import org.opendatakit.briefcase.reused.http.Http;
+import org.opendatakit.briefcase.transfer.TransferForms;
 import org.opendatakit.briefcase.util.AggregateUtils.DocumentFetchResult;
 import org.opendatakit.briefcase.util.ServerFetcher.SubmissionChunk;
 import org.slf4j.Logger;
@@ -182,7 +183,7 @@ class ServerUploader {
     }
   }
 
-  boolean uploadFormAndSubmissionFiles(List<FormStatus> formsToTransfer) {
+  boolean uploadFormAndSubmissionFiles(TransferForms formsToTransfer) {
 
     boolean allSuccessful = true;
 

--- a/src/org/opendatakit/briefcase/util/TransferAction.java
+++ b/src/org/opendatakit/briefcase/util/TransferAction.java
@@ -18,17 +18,16 @@ package org.opendatakit.briefcase.util;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.bushe.swing.event.EventBus;
-import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.ServerConnectionInfo;
 import org.opendatakit.briefcase.model.TerminationFuture;
 import org.opendatakit.briefcase.pull.PullEvent;
 import org.opendatakit.briefcase.push.PushEvent;
 import org.opendatakit.briefcase.reused.RemoteServer;
 import org.opendatakit.briefcase.reused.http.Http;
+import org.opendatakit.briefcase.transfer.TransferForms;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,11 +37,42 @@ public class TransferAction {
 
   private static ExecutorService backgroundExecutorService = Executors.newCachedThreadPool();
 
+  private static void backgroundRun(ITransferToDestAction src, TransferForms formsToTransfer) {
+    backgroundExecutorService.execute(new UploadTransferRunnable(src, formsToTransfer));
+  }
+
+  private static void backgroundRun(ITransferFromSourceAction src, TransferForms formsToTransfer) {
+    backgroundExecutorService.execute(new GatherTransferRunnable(src, formsToTransfer));
+  }
+
+  public static void transferServerToBriefcase(ServerConnectionInfo originServerInfo, TerminationFuture terminationFuture, TransferForms formsToTransfer, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete) {
+    TransferFromServer source = new TransferFromServer(originServerInfo, terminationFuture, formsToTransfer, briefcaseDir, pullInParallel, includeIncomplete);
+    backgroundRun(source, formsToTransfer);
+  }
+
+  public static void transferODKToBriefcase(Path briefcaseDir, File odkSrcDir, TerminationFuture terminationFuture, TransferForms formsToTransfer) {
+    TransferFromODK source = new TransferFromODK(briefcaseDir, odkSrcDir, terminationFuture, formsToTransfer);
+    backgroundRun(source, formsToTransfer);
+  }
+
+  public static void transferBriefcaseToServer(ServerConnectionInfo destinationServerInfo, TerminationFuture terminationFuture, TransferForms formsToTransfer, Http http, RemoteServer server) {
+    TransferToServer dest = new TransferToServer(
+        destinationServerInfo,
+        terminationFuture,
+        formsToTransfer,
+        http,
+        server,
+        // Since this is only used by the GUI, always force sending the blank form
+        true
+    );
+    backgroundRun(dest, formsToTransfer);
+  }
+
   private static class UploadTransferRunnable implements Runnable {
     ITransferToDestAction dest;
-    private List<FormStatus> formsToTransfer;
+    private TransferForms formsToTransfer;
 
-    UploadTransferRunnable(ITransferToDestAction dest, List<FormStatus> formsToTransfer) {
+    UploadTransferRunnable(ITransferToDestAction dest, TransferForms formsToTransfer) {
       this.dest = dest;
       this.formsToTransfer = formsToTransfer;
     }
@@ -63,15 +93,11 @@ public class TransferAction {
     }
   }
 
-  private static void backgroundRun(ITransferToDestAction src, List<FormStatus> formsToTransfer) {
-    backgroundExecutorService.execute(new UploadTransferRunnable(src, formsToTransfer));
-  }
-
   private static class GatherTransferRunnable implements Runnable {
     ITransferFromSourceAction src;
-    private List<FormStatus> formsToTransfer;
+    private TransferForms formsToTransfer;
 
-    GatherTransferRunnable(ITransferFromSourceAction src, List<FormStatus> formsToTransfer) {
+    GatherTransferRunnable(ITransferFromSourceAction src, TransferForms formsToTransfer) {
       this.src = src;
       this.formsToTransfer = formsToTransfer;
     }
@@ -91,32 +117,5 @@ public class TransferAction {
       }
     }
 
-  }
-
-  private static void backgroundRun(ITransferFromSourceAction src, List<FormStatus> formsToTransfer) {
-    backgroundExecutorService.execute(new GatherTransferRunnable(src, formsToTransfer));
-  }
-
-  public static void transferServerToBriefcase(ServerConnectionInfo originServerInfo, TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete) {
-    TransferFromServer source = new TransferFromServer(originServerInfo, terminationFuture, formsToTransfer, briefcaseDir, pullInParallel, includeIncomplete);
-    backgroundRun(source, formsToTransfer);
-  }
-
-  public static void transferODKToBriefcase(Path briefcaseDir, File odkSrcDir, TerminationFuture terminationFuture, List<FormStatus> formsToTransfer) {
-    TransferFromODK source = new TransferFromODK(briefcaseDir, odkSrcDir, terminationFuture, formsToTransfer);
-    backgroundRun(source, formsToTransfer);
-  }
-
-  public static void transferBriefcaseToServer(ServerConnectionInfo destinationServerInfo, TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Http http, RemoteServer server) {
-    TransferToServer dest = new TransferToServer(
-        destinationServerInfo,
-        terminationFuture,
-        formsToTransfer,
-        http,
-        server,
-        // Since this is only used by the GUI, always force sending the blank form
-        true
-    );
-    backgroundRun(dest, formsToTransfer);
   }
 }

--- a/src/org/opendatakit/briefcase/util/TransferAction.java
+++ b/src/org/opendatakit/briefcase/util/TransferAction.java
@@ -45,8 +45,8 @@ public class TransferAction {
     backgroundExecutorService.execute(new GatherTransferRunnable(src, formsToTransfer));
   }
 
-  public static void transferServerToBriefcase(ServerConnectionInfo originServerInfo, TerminationFuture terminationFuture, TransferForms formsToTransfer, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete) {
-    TransferFromServer source = new TransferFromServer(originServerInfo, terminationFuture, formsToTransfer, briefcaseDir, pullInParallel, includeIncomplete);
+  public static void transferServerToBriefcase(ServerConnectionInfo originServerInfo, TerminationFuture terminationFuture, TransferForms formsToTransfer, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete, boolean resumeLastPull) {
+    TransferFromServer source = new TransferFromServer(originServerInfo, terminationFuture, formsToTransfer, briefcaseDir, pullInParallel, includeIncomplete, resumeLastPull);
     backgroundRun(source, formsToTransfer);
   }
 

--- a/src/org/opendatakit/briefcase/util/TransferFromServer.java
+++ b/src/org/opendatakit/briefcase/util/TransferFromServer.java
@@ -32,26 +32,20 @@ public class TransferFromServer implements ITransferFromSourceAction {
   private final Boolean pullInParallel;
   private final Boolean includeIncomplete;
   private final Path briefcaseDir;
+  private final boolean resumeLastPull;
 
-  public TransferFromServer(ServerConnectionInfo originServerInfo, TerminationFuture terminationFuture, TransferForms formsToTransfer, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete) {
+  public TransferFromServer(ServerConnectionInfo originServerInfo, TerminationFuture terminationFuture, TransferForms formsToTransfer, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete, boolean resumeLastPull) {
     this.originServerInfo = originServerInfo;
     this.terminationFuture = terminationFuture;
     this.formsToTransfer = formsToTransfer;
     this.briefcaseDir = briefcaseDir;
     this.pullInParallel = pullInParallel;
     this.includeIncomplete = includeIncomplete;
+    this.resumeLastPull = resumeLastPull;
   }
 
-  @Override
-  public boolean doAction() {
-
-    ServerFetcher fetcher = new ServerFetcher(originServerInfo, terminationFuture, briefcaseDir, pullInParallel, includeIncomplete);
-
-    return fetcher.downloadFormAndSubmissionFiles(formsToTransfer);
-  }
-
-  public static void pull(ServerConnectionInfo transferSettings, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete, TransferForms forms) {
-    TransferFromServer action = new TransferFromServer(transferSettings, new TerminationFuture(), forms, briefcaseDir, pullInParallel, includeIncomplete);
+  public static void pull(ServerConnectionInfo transferSettings, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete, TransferForms forms, boolean resumeLastPull) {
+    TransferFromServer action = new TransferFromServer(transferSettings, new TerminationFuture(), forms, briefcaseDir, pullInParallel, includeIncomplete, resumeLastPull);
 
     try {
       boolean allSuccessful = action.doAction();
@@ -64,6 +58,14 @@ public class TransferFromServer implements ITransferFromSourceAction {
       EventBus.publish(new PullEvent.Failure());
       throw new PullFromServerException(forms, e);
     }
+  }
+
+  @Override
+  public boolean doAction() {
+
+    ServerFetcher fetcher = new ServerFetcher(originServerInfo, terminationFuture, briefcaseDir, pullInParallel, includeIncomplete);
+
+    return fetcher.downloadFormAndSubmissionFiles(formsToTransfer, resumeLastPull);
   }
 
   @Override

--- a/src/org/opendatakit/briefcase/util/TransferFromServer.java
+++ b/src/org/opendatakit/briefcase/util/TransferFromServer.java
@@ -17,25 +17,23 @@
 package org.opendatakit.briefcase.util;
 
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 import org.bushe.swing.event.EventBus;
-import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.ServerConnectionInfo;
 import org.opendatakit.briefcase.model.TerminationFuture;
 import org.opendatakit.briefcase.pull.PullEvent;
+import org.opendatakit.briefcase.transfer.TransferForms;
 
 public class TransferFromServer implements ITransferFromSourceAction {
 
   private final ServerConnectionInfo originServerInfo;
   private final TerminationFuture terminationFuture;
-  private final List<FormStatus> formsToTransfer;
+  private final TransferForms formsToTransfer;
   private final Boolean pullInParallel;
   private final Boolean includeIncomplete;
-  private Path briefcaseDir;
+  private final Path briefcaseDir;
 
-  public TransferFromServer(ServerConnectionInfo originServerInfo, TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete) {
+  public TransferFromServer(ServerConnectionInfo originServerInfo, TerminationFuture terminationFuture, TransferForms formsToTransfer, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete) {
     this.originServerInfo = originServerInfo;
     this.terminationFuture = terminationFuture;
     this.formsToTransfer = formsToTransfer;
@@ -52,20 +50,19 @@ public class TransferFromServer implements ITransferFromSourceAction {
     return fetcher.downloadFormAndSubmissionFiles(formsToTransfer);
   }
 
-  public static void pull(ServerConnectionInfo transferSettings, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete, FormStatus... forms) {
-    List<FormStatus> formList = Arrays.asList(forms);
-    TransferFromServer action = new TransferFromServer(transferSettings, new TerminationFuture(), formList, briefcaseDir, pullInParallel, includeIncomplete);
+  public static void pull(ServerConnectionInfo transferSettings, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete, TransferForms forms) {
+    TransferFromServer action = new TransferFromServer(transferSettings, new TerminationFuture(), forms, briefcaseDir, pullInParallel, includeIncomplete);
 
     try {
       boolean allSuccessful = action.doAction();
       if (allSuccessful)
-        EventBus.publish(new PullEvent.Success(formList, transferSettings));
+        EventBus.publish(new PullEvent.Success(forms, transferSettings));
 
       if (!allSuccessful)
-        throw new PullFromServerException(formList);
+        throw new PullFromServerException(forms);
     } catch (Exception e) {
       EventBus.publish(new PullEvent.Failure());
-      throw new PullFromServerException(formList, e);
+      throw new PullFromServerException(forms, e);
     }
   }
 

--- a/src/org/opendatakit/briefcase/util/TransferToServer.java
+++ b/src/org/opendatakit/briefcase/util/TransferToServer.java
@@ -16,16 +16,14 @@
 
 package org.opendatakit.briefcase.util;
 
-import java.util.Arrays;
-import java.util.List;
 import org.bushe.swing.event.EventBus;
-import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.ServerConnectionInfo;
 import org.opendatakit.briefcase.model.TerminationFuture;
 import org.opendatakit.briefcase.push.PushEvent;
 import org.opendatakit.briefcase.reused.RemoteServer;
 import org.opendatakit.briefcase.reused.http.CommonsHttp;
 import org.opendatakit.briefcase.reused.http.Http;
+import org.opendatakit.briefcase.transfer.TransferForms;
 
 public class TransferToServer implements ITransferToDestAction {
   private final Http http;
@@ -33,9 +31,9 @@ public class TransferToServer implements ITransferToDestAction {
   private final boolean forceSendBlank;
   private ServerConnectionInfo destServerInfo;
   private TerminationFuture terminationFuture;
-  private List<FormStatus> formsToTransfer;
+  private TransferForms formsToTransfer;
 
-  TransferToServer(ServerConnectionInfo destServerInfo, TerminationFuture terminationFuture, List<FormStatus> formsToTransfer, Http http, RemoteServer server, boolean forceSendBlank) {
+  TransferToServer(ServerConnectionInfo destServerInfo, TerminationFuture terminationFuture, TransferForms formsToTransfer, Http http, RemoteServer server, boolean forceSendBlank) {
     this.destServerInfo = destServerInfo;
     this.terminationFuture = terminationFuture;
     this.formsToTransfer = formsToTransfer;
@@ -51,8 +49,7 @@ public class TransferToServer implements ITransferToDestAction {
     return uploader.uploadFormAndSubmissionFiles(formsToTransfer);
   }
 
-  public static void push(ServerConnectionInfo transferSettings, CommonsHttp http, RemoteServer server, boolean forceSendBlank, FormStatus... forms) {
-    List<FormStatus> formList = Arrays.asList(forms);
+  public static void push(ServerConnectionInfo transferSettings, CommonsHttp http, RemoteServer server, boolean forceSendBlank, TransferForms formList) {
     TransferToServer action = new TransferToServer(transferSettings, new TerminationFuture(), formList, http, server, forceSendBlank);
 
     try {


### PR DESCRIPTION
Closes #681

#### What has been done to verify that this works as intended?
Tested manually on Linux(Ubuntu) using an Aggregate v2.0 local server

#### Why is this the best possible solution? Were any other approaches considered?
This PR tries to store a byproduct of the pre-existing pull process that was being discarded (the cursor uses during interaction with the Aggregate API). 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There are new user facing options:
- There's a new global setting to enable resuming pulls in the Settings tab
- There's a new button in the settings tab that clears any saved resume cursors
- There's a new CLI flag `-rlp` or `--resume_last_pull` to enable the feature from the command line

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Yes, https://github.com/opendatakit/docs/issues/967