### PR TITLE
Issue 695 Support empty manifest URLs when pulling forms

### DIFF
--- a/test/java/org/opendatakit/briefcase/util/ServerFetcherTest.java
+++ b/test/java/org/opendatakit/briefcase/util/ServerFetcherTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.util;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.opendatakit.briefcase.util.ServerFetcher.isUrl;
+
+import org.junit.Test;
+
+public class ServerFetcherTest {
+
+  @Test
+  public void knows_if_a_string_contains_a_valid_url() {
+    assertThat(isUrl(""), is(false));
+    assertThat(isUrl("foo.bar"), is(false));
+    assertThat(isUrl("some text"), is(false));
+    assertThat(isUrl("http://foo.bar"), is(true));
+    assertThat(isUrl("http://foo.bar:1234"), is(true));
+    assertThat(isUrl("http://foo.bar/baz"), is(true));
+    assertThat(isUrl("http://foo.bar/baz?query=string"), is(true));
+  }
+}


### PR DESCRIPTION
Closes #695

#### What has been done to verify that this works as intended?

**On Onadata**
- Create an account at https://odk.ona.io/
- Upload the form [pizza_questionnaire.xlsx](https://github.com/opendatakit/briefcase/files/2755542/pizza_questionnaire.xlsx)

**On Briefcase**
- Configure the aggregate server with `https://odk.ona.io/{username}` (and your Ona credentials)
- Pull form

#### Why is this the best possible solution? Were any other approaches considered?
This is a small change to check that whatever value coming on the manifestUrl is an url. This will prevent trying to get manifests when the server reports a `<manifest/>` tag when downloading a blank form (which is the default behavior in Ona).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
N/A

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No