### PR TITLE
Issue 709 Fix downloading form media attachments

### DIFF
--- a/src/org/opendatakit/briefcase/util/ServerFetcher.java
+++ b/src/org/opendatakit/briefcase/util/ServerFetcher.java
@@ -519,7 +519,7 @@ public class ServerFetcher {
 
   private String downloadManifestAndMediaFiles(File mediaDir, FormStatus fs) {
     RemoteFormDefinition fd = getRemoteFormDefinition(fs);
-    if (fd.getManifestUrl() == null || isUrl(fd.getManifestUrl()))
+    if (fd.getManifestUrl() == null || !isUrl(fd.getManifestUrl()))
       return null;
     fs.setStatusString("Fetching form manifest", true);
     EventBus.publish(new FormStatusEvent(fs));


### PR DESCRIPTION
Closes #709 

#### What has been done to verify that this works as intended?
Reproduce the error with the [Birds](https://github.com/opendatakit/sample-forms) form, fix the bug and check that now it pulls the attachments.

#### Why is this the best possible solution? Were any other approaches considered?
This fixes a silly mistake in an `if` condition.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
N/A

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.