### PR TITLE
Ensure that CLI ops select the forms they need to transfer

### DIFF
--- a/src/org/opendatakit/briefcase/operations/ImportFromODK.java
+++ b/src/org/opendatakit/briefcase/operations/ImportFromODK.java
@@ -22,7 +22,6 @@ import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.transfer.TransferForms;
@@ -56,11 +55,12 @@ public class ImportFromODK {
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();
 
-    List<FormStatus> forms = FileSystemUtils.getODKFormList(odkDir.toFile()).stream()
+    TransferForms from = TransferForms.from(FileSystemUtils.getODKFormList(odkDir.toFile()).stream()
         .map(FormStatus::new)
         .filter(form -> formId.map(id -> form.getFormDefinition().getFormId().equals(id)).orElse(true))
-        .collect(toList());
+        .collect(toList()));
+    from.selectAll();
 
-    TransferFromODK.pull(briefcaseDir, odkDir, TransferForms.from(forms));
+    TransferFromODK.pull(briefcaseDir, odkDir, from);
   }
 }

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -100,8 +100,11 @@ public class PullFormFromAggregate {
         throw new FormNotFoundException(formid);
 
       FormStatus form = maybeForm.get();
+      TransferForms forms = TransferForms.of(form);
+      forms.selectAll();
+
       EventBus.publish(new StartPullEvent(form));
-      TransferFromServer.pull(remoteServer.asServerConnectionInfo(), briefcaseDir, pullInParallel, includeIncomplete, TransferForms.of(form), resumeLastPull);
+      TransferFromServer.pull(remoteServer.asServerConnectionInfo(), briefcaseDir, pullInParallel, includeIncomplete, forms, resumeLastPull);
     }
   }
 

--- a/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
@@ -92,8 +92,10 @@ public class PushFormToAggregate {
           .findFirst();
 
       FormStatus form = maybeFormStatus.orElseThrow(() -> new FormNotFoundException(formid));
+      TransferForms forms = TransferForms.of(form);
+      forms.selectAll();
 
-      TransferToServer.push(remoteServer.asServerConnectionInfo(), http, remoteServer, forceSendBlank, TransferForms.of(form));
+      TransferToServer.push(remoteServer.asServerConnectionInfo(), http, remoteServer, forceSendBlank, forms);
     }
   }
 


### PR DESCRIPTION
Closes #711 

**Context**
https://github.com/opendatakit/briefcase/pull/698/commits/7eccb568b4cba72f1da5ca3ecc42fe9b3841117f introduced a change that migrated the transfer(pull&push) code to use `TransferForms` instead of a generic `List<FormStatus>`. `TransferForms` has the notion of "selected forms" and downstream pull and push operation code does `forms.getSelectedForms()`.

The CLI wasn't adapted to this fact by accident, which introduced the bug that this PR solves.

#### What has been done to verify that this works as intended?
Run the pull from collect command to ensure that it works as expected:
- no form-id > pull all forms present
- form-id > pull just that form

#### Why is this the best possible solution? Were any other approaches considered?
This PR makes changes to have the CLI doing the same as the UI (select the forms)

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Users should be able to pull and push forms again using the CLI

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.