### PR TITLE
Issue 714 fix selecting forms in cli ops

### DIFF
--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -19,6 +19,7 @@ import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 import static org.opendatakit.briefcase.export.ExportForms.buildExportDateTimePrefix;
 import static org.opendatakit.briefcase.operations.Common.FORM_ID;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
+import static org.opendatakit.briefcase.reused.UncheckedFiles.createDirectories;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -90,6 +91,8 @@ public class Export {
     Optional<BriefcaseFormDefinition> maybeFormDefinition = formCache.getForms().stream()
         .filter(form -> form.getFormId().equals(formid))
         .findFirst();
+
+    createDirectories(exportDir);
 
     BriefcaseFormDefinition formDefinition = maybeFormDefinition.orElseThrow(() -> new FormNotFoundException(formid));
 


### PR DESCRIPTION
Closes #714

#### What has been done to verify that this works as intended?
Run the export command, verify that Briefcase CLI creates the export dir.

#### Why is this the best possible solution? Were any other approaches considered?
Super narrow change to ensure that the export dir exists.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Users will be able to launch export CLI operations without having to previuosly create the export dir.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.