### PR TITLE
Issue 723 split select multiple with predicates on internal secondary instances

### DIFF
--- a/test/java/org/opendatakit/briefcase/export/ExportToCsvExplodeChoiceListWithPredicateTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportToCsvExplodeChoiceListWithPredicateTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.export;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ExportToCsvExplodeChoiceListWithPredicateTest {
+  private ExportToCsvScenario scenario;
+
+  @Before
+  public void setUp() {
+    scenario = ExportToCsvScenario.setUp("choice-lists-predicate");
+  }
+
+  @After
+  public void tearDown() {
+    scenario.tearDown();
+  }
+
+  @Test
+  public void exports_forms_with_all_data_types() {
+    scenario.runExportExplodedChoiceLists();
+    scenario.assertSameContent();
+  }
+
+}

--- a/test/resources/org/opendatakit/briefcase/export/choice-lists-predicate-submission.xml
+++ b/test/resources/org/opendatakit/briefcase/export/choice-lists-predicate-submission.xml
@@ -1,0 +1,7 @@
+<data id="choice-lists-predicate" instanceID="uuid:a21ca0ad-db7e-4ef5-b7ea-d73dd4a42bf0" submissionDate="2019-03-17T10:14:18.820Z" isComplete="true" markedAsCompleteDate="2019-03-17T10:14:18.820Z" xmlns="http://opendatakit.org/submissions">
+  <some-field-no-predicate>CHOICE_1 CHOICE_4</some-field-no-predicate>
+  <some-field>CHOICE_1</some-field>
+  <n0:meta xmlns:n0="http://openrosa.org/xforms">
+    <n0:instanceID>uuid:a21ca0ad-db7e-4ef5-b7ea-d73dd4a42bf0</n0:instanceID>
+  </n0:meta>
+</data>

--- a/test/resources/org/opendatakit/briefcase/export/choice-lists-predicate.csv.expected
+++ b/test/resources/org/opendatakit/briefcase/export/choice-lists-predicate.csv.expected
@@ -1,0 +1,2 @@
+SubmissionDate,some-field-no-predicate,some-field-no-predicate/CHOICE_1,some-field-no-predicate/CHOICE_2,some-field-no-predicate/CHOICE_3,some-field-no-predicate/CHOICE_4,some-field,some-field/CHOICE_1,some-field/CHOICE_2,meta-instanceID,KEY
+"Mar 17, 2019 10:14:18 AM",CHOICE_1 CHOICE_4,1,0,0,1,CHOICE_1,1,0,uuid:a21ca0ad-db7e-4ef5-b7ea-d73dd4a42bf0,uuid:a21ca0ad-db7e-4ef5-b7ea-d73dd4a42bf0

--- a/test/resources/org/opendatakit/briefcase/export/choice-lists-predicate.xml
+++ b/test/resources/org/opendatakit/briefcase/export/choice-lists-predicate.xml
@@ -1,0 +1,53 @@
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/2002/xforms">
+  <h:head>
+    <h:title>Static itemset predicate</h:title>
+    <model>
+      <instance>
+        <data id="choice-lists-predicate">
+          <some-field-no-predicate/>
+          <some-field/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </data>
+      </instance>
+      <instance id="choices">
+        <root>
+          <item>
+            <value>CHOICE_1</value>
+            <type>a</type>
+          </item>
+          <item>
+            <value>CHOICE_2</value>
+            <type>a</type>
+          </item>
+          <item>
+            <value>CHOICE_3</value>
+            <type>b</type>
+          </item>
+          <item>
+            <value>CHOICE_4</value>
+            <type>b</type>
+          </item>
+        </root>
+      </instance>
+      <bind nodeset="/data/some-field-no-predicate" type="string"/>
+      <bind nodeset="/data/some-field" type="string"/>
+      <bind calculate="concat('uuid:', uuid())" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <select ref="/data/some-field-no-predicate">
+      <itemset nodeset="instance('choices')/root/item">
+        <value ref="value"/>
+        <label ref="value"/>
+      </itemset>
+    </select>
+    <select ref="/data/some-field">
+      <itemset nodeset="instance('choices')/root/item[type='a']">
+        <value ref="value"/>
+        <label ref="value"/>
+      </itemset>
+    </select>
+  </h:body>
+</h:html>


### PR DESCRIPTION
Closes #723

#### What has been done to verify that this works as intended?
Add automated tests covering the new scenario
Run Briefcase manually to export this form: [choice-lists-predicate.txt](https://github.com/opendatakit/briefcase/files/2975020/choice-lists-predicate.txt)


#### Why is this the best possible solution? Were any other approaches considered?
This is a narrow fix to support the scenario described in #721

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Users now can expect to export forms and split any select multiple control if their itemsets use internal secondary instances, whether they have predicates or not.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.