### PR TITLE
Issue 725 Avoid UnsupportedOperationException in TransferForms

### DIFF
--- a/src/org/opendatakit/briefcase/transfer/TransferForms.java
+++ b/src/org/opendatakit/briefcase/transfer/TransferForms.java
@@ -21,7 +21,6 @@ import static java.util.stream.Collectors.toMap;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -54,7 +53,7 @@ public class TransferForms implements Iterable<FormStatus> {
    * Factory of empty {@link TransferForms} instances
    */
   public static TransferForms empty() {
-    return new TransferForms(Collections.emptyList(), new HashMap<>());
+    return new TransferForms(new ArrayList<>(), new HashMap<>());
   }
 
   /**
@@ -70,7 +69,7 @@ public class TransferForms implements Iterable<FormStatus> {
   }
 
   public static TransferForms of(FormStatus... forms) {
-    return new TransferForms(Arrays.asList(forms), new HashMap<>());
+    return new TransferForms(new ArrayList<>(Arrays.asList(forms)), new HashMap<>());
   }
 
   /**

--- a/test/java/org/opendatakit/briefcase/transfer/TransferFormsTest.java
+++ b/test/java/org/opendatakit/briefcase/transfer/TransferFormsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.transfer;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.opendatakit.briefcase.model.FormStatusBuilder;
+
+public class TransferFormsTest {
+  @Test
+  public void empty_forms_can_merge_forms() {
+    // What we are really testing is that no UnsupportedOperationException
+    // is thrown when merging forms into an empty TransferForms object
+    TransferForms forms = TransferForms.empty();
+    forms.merge(singletonList(FormStatusBuilder.buildFormStatus(1)));
+    assertThat(forms.isEmpty(), is(false));
+  }
+
+  @Test
+  public void forms_from_varargs_factory_can_be_cleared() {
+    // What we are really testing is that no UnsupportedOperationException
+    // is thrown when clearing an TransferForms object obtained using
+    // the varargs factory method
+    TransferForms forms = TransferForms.of(FormStatusBuilder.buildFormStatus(1));
+    forms.clear();
+    assertThat(forms.isEmpty(), is(true));
+  }
+}


### PR DESCRIPTION
Closes #725

#### What has been done to verify that this works as intended?
Added automated tests

#### Why is this the best possible solution? Were any other approaches considered?
Avoid immutable lists to prevent UnsupportedOperationException
- The clear() and merge() methods will throw the exception on immutable subtypes
- By using the ArrayList<>() constructor instead of Collections.emptyList() or Arrays.asList() we prevent throwing the exception

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Users should expect no errors from this source when working with the pull and push tabs

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.