### PR TITLE
721 pull all forms

### DIFF
--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -96,6 +96,10 @@ public class PullFormFromAggregate {
       TransferForms forms = TransferForms.from(RetrieveAvailableFormsFromServer.get(remoteServer.asServerConnectionInfo()).stream()
           .filter(f -> formId.map(id -> f.getFormDefinition().getFormId().equals(id)).orElse(true))
           .collect(Collectors.toList()));
+
+      if(formId.isPresent() && forms.isEmpty())
+        throw new FormNotFoundException(formId.get());
+
       forms.selectAll();
 
       TransferFromServer.pull(remoteServer.asServerConnectionInfo(), briefcaseDir, pullInParallel, includeIncomplete, forms, resumeLastPull);

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -27,8 +27,6 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.bushe.swing.event.EventBus;
-import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.reused.RemoteServer;
 import org.opendatakit.briefcase.reused.http.CommonsHttp;
@@ -97,7 +95,7 @@ public class PullFormFromAggregate {
           .filter(f -> formId.map(id -> f.getFormDefinition().getFormId().equals(id)).orElse(true))
           .collect(Collectors.toList()));
 
-      if(formId.isPresent() && forms.isEmpty())
+      if (formId.isPresent() && forms.isEmpty())
         throw new FormNotFoundException(formId.get());
 
       forms.selectAll();

--- a/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
+++ b/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
@@ -304,7 +304,7 @@ public class BriefcaseCLI {
         importODK(storageDir, Paths.get(odkDir), Optional.empty());
 
       if (odkDir == null && server != null)
-        pullFormFromAggregate(storageDir, formid, username, password, server, false, false, false);
+        pullFormFromAggregate(storageDir, Optional.empty(), username, password, server, false, false, false);
 
       if (exportPath != null)
         export(

--- a/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
+++ b/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
@@ -303,8 +303,11 @@ public class BriefcaseCLI {
       if (odkDir != null)
         importODK(storageDir, Paths.get(odkDir), Optional.empty());
 
+      if (formid == null)
+        throw new BriefcaseException("You need to provide a form ID (legacy CLI)");
+
       if (odkDir == null && server != null)
-        pullFormFromAggregate(storageDir, Optional.empty(), username, password, server, false, false, false);
+        pullFormFromAggregate(storageDir, Optional.ofNullable(formid), username, password, server, false, false, false);
 
       if (exportPath != null)
         export(


### PR DESCRIPTION
Closes #721 

#### What has been done to verify that this works as intended?
I checked the forms displayed in UI and compared with what was downloaded.
![Screenshot from 2019-03-23 01-34-44](https://user-images.githubusercontent.com/5601566/54862651-df6dba00-4d0b-11e9-8bea-c373e4ba0a68.png)
![Screenshot from 2019-03-23 01-29-08](https://user-images.githubusercontent.com/5601566/54862662-fd3b1f00-4d0b-11e9-9242-7b0fd74b6c52.png)
![Screenshot from 2019-03-23 01-29-23](https://user-images.githubusercontent.com/5601566/54862663-fd3b1f00-4d0b-11e9-857f-5d8184f1a09c.png)
![Screenshot from 2019-03-23 01-29-31](https://user-images.githubusercontent.com/5601566/54862664-fd3b1f00-4d0b-11e9-9e1a-202864593422.png)


#### Why is this the best possible solution? Were any other approaches considered?
Made the form_id argument optional.Similar to ```ImportFromODK```

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
If you run the command ```java -jar ODK-Briefcase-v1.14.0.jar -plla -sd /Users/yanokwa/Desktop -u admin -p admin -url https://example.com``` it should download all the forms from aggregate server. If you specify ```form_id``` argument then it just downloads the specified form.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.

