### PR TITLE
Issue 729 cli pull start from date

### DIFF
--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -134,7 +134,8 @@ public class Export {
             briefcaseDir,
             appPreferences.getPullInParallel().orElse(false),
             false,
-            false
+            false,
+            Optional.empty()
         );
       }
 

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -103,7 +103,7 @@ public class PullFormFromAggregate {
 
       forms.selectAll();
 
-      TransferFromServer.pull(remoteServer.asServerConnectionInfo(), briefcaseDir, pullInParallel, includeIncomplete, forms, resumeLastPull);
+      TransferFromServer.pull(remoteServer.asServerConnectionInfo(), briefcaseDir, pullInParallel, includeIncomplete, forms, resumeLastPull, startFromDate);
     }
   }
 

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -24,6 +24,7 @@ import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -47,6 +48,7 @@ public class PullFormFromAggregate {
   private static final Param<Void> PULL_AGGREGATE = Param.flag("plla", "pull_aggregate", "Pull form from an Aggregate instance");
   private static final Param<Void> PULL_IN_PARALLEL = Param.flag("pp", "parallel_pull", "Pull submissions in parallel");
   private static final Param<Void> RESUME_LAST_PULL = Param.flag("sfl", "start_from_last", "Start pull from last submission pulled");
+  private static final Param<LocalDate> START_FROM_DATE = Param.arg("sfd", "start_from_date", "Start pull from date", LocalDate::parse);
   private static final Param<Void> INCLUDE_INCOMPLETE = Param.flag("ii", "include_incomplete", "Include incomplete submissions");
 
   public static Operation PULL_FORM_FROM_AGGREGATE = Operation.of(
@@ -59,13 +61,14 @@ public class PullFormFromAggregate {
           args.get(AGGREGATE_SERVER),
           args.has(PULL_IN_PARALLEL),
           args.has(RESUME_LAST_PULL),
+          args.getOptional(START_FROM_DATE),
           args.has(INCLUDE_INCOMPLETE)
       ),
       Arrays.asList(STORAGE_DIR, ODK_USERNAME, ODK_PASSWORD, AGGREGATE_SERVER),
-      Arrays.asList(PULL_IN_PARALLEL, RESUME_LAST_PULL, INCLUDE_INCOMPLETE, FORM_ID)
+      Arrays.asList(PULL_IN_PARALLEL, RESUME_LAST_PULL, INCLUDE_INCOMPLETE, FORM_ID, START_FROM_DATE)
   );
 
-  public static void pullFormFromAggregate(String storageDir, Optional<String> formId, String username, String password, String server, boolean pullInParallel, boolean resumeLastPull, boolean includeIncomplete) {
+  public static void pullFormFromAggregate(String storageDir, Optional<String> formId, String username, String password, String server, boolean pullInParallel, boolean resumeLastPull, Optional<LocalDate> startFromDate, boolean includeIncomplete) {
     CliEventsCompanion.attach(log);
     Path briefcaseDir = Common.getOrCreateBriefcaseDir(storageDir);
     FormCache formCache = FormCache.from(briefcaseDir);

--- a/src/org/opendatakit/briefcase/transfer/NewTransferAction.java
+++ b/src/org/opendatakit/briefcase/transfer/NewTransferAction.java
@@ -17,6 +17,8 @@
 package org.opendatakit.briefcase.transfer;
 
 import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.Optional;
 import org.bushe.swing.event.EventBus;
 import org.opendatakit.briefcase.model.ServerConnectionInfo;
 import org.opendatakit.briefcase.model.TerminationFuture;
@@ -28,7 +30,7 @@ import org.slf4j.LoggerFactory;
 public class NewTransferAction {
   private static final Logger log = LoggerFactory.getLogger(NewTransferAction.class);
 
-  public static void transferServerToBriefcase(ServerConnectionInfo transferSettings, TerminationFuture terminationFuture, TransferForms formsToTransfer, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete, boolean resumeLastPull) {
+  public static void transferServerToBriefcase(ServerConnectionInfo transferSettings, TerminationFuture terminationFuture, TransferForms formsToTransfer, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete, boolean resumeLastPull, Optional<LocalDate> startFromDate) {
     TransferFromServer action = new TransferFromServer(
         transferSettings,
         terminationFuture,
@@ -36,7 +38,8 @@ public class NewTransferAction {
         briefcaseDir,
         pullInParallel,
         includeIncomplete,
-        resumeLastPull
+        resumeLastPull,
+        startFromDate
     );
     try {
       boolean allSuccessful = action.doAction();

--- a/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
+++ b/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
@@ -307,7 +307,7 @@ public class BriefcaseCLI {
         throw new BriefcaseException("You need to provide a form ID (legacy CLI)");
 
       if (odkDir == null && server != null)
-        pullFormFromAggregate(storageDir, Optional.ofNullable(formid), username, password, server, false, false, false);
+        pullFormFromAggregate(storageDir, Optional.ofNullable(formid), username, password, server, false, false, Optional.empty(), false);
 
       if (exportPath != null)
         export(

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -25,6 +25,7 @@ import static org.opendatakit.briefcase.ui.reused.UI.errorMessage;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.bushe.swing.event.annotation.AnnotationProcessor;
 import org.bushe.swing.event.annotation.EventSubscriber;
 import org.opendatakit.briefcase.export.ExportConfiguration;
@@ -191,7 +192,8 @@ public class ExportPanel {
                   appPreferences.getBriefcaseDir().orElseThrow(BriefcaseException::new),
                   appPreferences.getPullInParallel().orElse(false),
                   false,
-                  false
+                  false,
+                  Optional.empty()
               ));
             FormDefinition formDef = FormDefinition.from((BriefcaseFormDefinition) form.getFormDefinition());
             ExportToCsv.export(formDef, configuration, analytics);

--- a/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
+++ b/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
@@ -91,7 +91,7 @@ public class PullPanel {
     view.onAction(() -> {
       view.setWorking();
       forms.forEach(FormStatus::clearStatusHistory);
-      source.ifPresent(s -> s.pull(forms.getSelectedForms(), terminationFuture, appPreferences.getBriefcaseDir().orElseThrow(BriefcaseException::new), appPreferences.getPullInParallel().orElse(false), false, appPreferences.getResumeLastPull().orElse(false)));
+      source.ifPresent(s -> s.pull(forms.getSelectedForms(), terminationFuture, appPreferences.getBriefcaseDir().orElseThrow(BriefcaseException::new), appPreferences.getPullInParallel().orElse(false), false, appPreferences.getResumeLastPull().orElse(false), Optional.empty()));
     });
 
     view.onCancel(() -> terminationFuture.markAsCancelled(new PullEvent.Abort("Cancelled by the user")));

--- a/src/org/opendatakit/briefcase/ui/reused/source/Source.java
+++ b/src/org/opendatakit/briefcase/ui/reused/source/Source.java
@@ -32,6 +32,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -189,7 +190,7 @@ public interface Source<T> {
    *                          submissions. This needs to be supported by the selected source
    * @param resumeLastPull
    */
-  void pull(TransferForms forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete, boolean resumeLastPull);
+  void pull(TransferForms forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete, boolean resumeLastPull, Optional<LocalDate> startFromDate);
 
   /**
    * Pushes forms to this configured {@link Source}.
@@ -262,8 +263,8 @@ public interface Source<T> {
     }
 
     @Override
-    public void pull(TransferForms forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete, boolean resumeLastPull) {
-      TransferAction.transferServerToBriefcase(server.asServerConnectionInfo(), terminationFuture, forms, briefcaseDir, pullInParallel, includeIncomplete, resumeLastPull);
+    public void pull(TransferForms forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete, boolean resumeLastPull, Optional<LocalDate> startFromDate) {
+      TransferAction.transferServerToBriefcase(server.asServerConnectionInfo(), terminationFuture, forms, briefcaseDir, pullInParallel, includeIncomplete, resumeLastPull, startFromDate);
     }
 
     @Override
@@ -363,7 +364,7 @@ public interface Source<T> {
     }
 
     @Override
-    public void pull(TransferForms forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete, boolean resumeLastPull) {
+    public void pull(TransferForms forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete, boolean resumeLastPull, Optional<LocalDate> startFromDate) {
       TransferAction.transferODKToBriefcase(briefcaseDir, path.toFile(), terminationFuture, forms);
     }
 
@@ -451,7 +452,7 @@ public interface Source<T> {
     }
 
     @Override
-    public void pull(TransferForms forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete, boolean resumeLastPull) {
+    public void pull(TransferForms forms, TerminationFuture terminationFuture, Path briefcaseDir, boolean pullInParallel, Boolean includeIncomplete, boolean resumeLastPull, Optional<LocalDate> startFromDate) {
       invokeLater(() -> FormInstaller.install(briefcaseDir, form));
     }
 

--- a/src/org/opendatakit/briefcase/util/ServerFetcher.java
+++ b/src/org/opendatakit/briefcase/util/ServerFetcher.java
@@ -29,10 +29,12 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
@@ -99,7 +101,7 @@ public class ServerFetcher {
     return terminationFuture.isCancelled();
   }
 
-  boolean downloadFormAndSubmissionFiles(TransferForms formsToTransfer, boolean resumeLastPull) {
+  boolean downloadFormAndSubmissionFiles(TransferForms formsToTransfer, boolean resumeLastPull, Optional<LocalDate> startFromDate) {
     boolean allSuccessful = true;
 
     for (FormStatus fs : formsToTransfer) {

--- a/src/org/opendatakit/briefcase/util/TransferAction.java
+++ b/src/org/opendatakit/briefcase/util/TransferAction.java
@@ -18,6 +18,8 @@ package org.opendatakit.briefcase.util;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.bushe.swing.event.EventBus;
@@ -45,8 +47,8 @@ public class TransferAction {
     backgroundExecutorService.execute(new GatherTransferRunnable(src, formsToTransfer));
   }
 
-  public static void transferServerToBriefcase(ServerConnectionInfo originServerInfo, TerminationFuture terminationFuture, TransferForms formsToTransfer, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete, boolean resumeLastPull) {
-    TransferFromServer source = new TransferFromServer(originServerInfo, terminationFuture, formsToTransfer, briefcaseDir, pullInParallel, includeIncomplete, resumeLastPull);
+  public static void transferServerToBriefcase(ServerConnectionInfo originServerInfo, TerminationFuture terminationFuture, TransferForms formsToTransfer, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete, boolean resumeLastPull, Optional<LocalDate> startFromDate) {
+    TransferFromServer source = new TransferFromServer(originServerInfo, terminationFuture, formsToTransfer, briefcaseDir, pullInParallel, includeIncomplete, resumeLastPull, startFromDate);
     backgroundRun(source, formsToTransfer);
   }
 

--- a/src/org/opendatakit/briefcase/util/TransferFromServer.java
+++ b/src/org/opendatakit/briefcase/util/TransferFromServer.java
@@ -17,6 +17,7 @@
 package org.opendatakit.briefcase.util;
 
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.util.Optional;
 import org.bushe.swing.event.EventBus;
 import org.opendatakit.briefcase.model.ServerConnectionInfo;
@@ -33,8 +34,9 @@ public class TransferFromServer implements ITransferFromSourceAction {
   private final Boolean includeIncomplete;
   private final Path briefcaseDir;
   private final boolean resumeLastPull;
+  private Optional<LocalDate> startFromDate;
 
-  public TransferFromServer(ServerConnectionInfo originServerInfo, TerminationFuture terminationFuture, TransferForms formsToTransfer, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete, boolean resumeLastPull) {
+  public TransferFromServer(ServerConnectionInfo originServerInfo, TerminationFuture terminationFuture, TransferForms formsToTransfer, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete, boolean resumeLastPull, Optional<LocalDate> startFromDate) {
     this.originServerInfo = originServerInfo;
     this.terminationFuture = terminationFuture;
     this.formsToTransfer = formsToTransfer;
@@ -42,10 +44,11 @@ public class TransferFromServer implements ITransferFromSourceAction {
     this.pullInParallel = pullInParallel;
     this.includeIncomplete = includeIncomplete;
     this.resumeLastPull = resumeLastPull;
+    this.startFromDate = startFromDate;
   }
 
-  public static void pull(ServerConnectionInfo transferSettings, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete, TransferForms forms, boolean resumeLastPull) {
-    TransferFromServer action = new TransferFromServer(transferSettings, new TerminationFuture(), forms, briefcaseDir, pullInParallel, includeIncomplete, resumeLastPull);
+  public static void pull(ServerConnectionInfo transferSettings, Path briefcaseDir, Boolean pullInParallel, Boolean includeIncomplete, TransferForms forms, boolean resumeLastPull, Optional<LocalDate> startFromDate) {
+    TransferFromServer action = new TransferFromServer(transferSettings, new TerminationFuture(), forms, briefcaseDir, pullInParallel, includeIncomplete, resumeLastPull, startFromDate);
 
     try {
       boolean allSuccessful = action.doAction();
@@ -65,7 +68,7 @@ public class TransferFromServer implements ITransferFromSourceAction {
 
     ServerFetcher fetcher = new ServerFetcher(originServerInfo, terminationFuture, briefcaseDir, pullInParallel, includeIncomplete);
 
-    return fetcher.downloadFormAndSubmissionFiles(formsToTransfer, resumeLastPull);
+    return fetcher.downloadFormAndSubmissionFiles(formsToTransfer, resumeLastPull, startFromDate);
   }
 
   @Override


### PR DESCRIPTION
Closes #729 

#### What has been done to verify that this works as intended?
Used a form in the sandbox with submissions to test this feature:
- Pull the form with `-sfd` and verify that the expected amount of submissions are pulled.
- Send some submissions and pull the form using the same `-sfd` date. Verify that only the new submissions get pulled.

#### Why is this the best possible solution? Were any other approaches considered?
This PR is a narrow change on top of the existing `-sfl` feature.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This PR should not have other effects other than the new added feature described in #729.

"start from date" will update the last cursor so that the next pull with "start from last" continues pulling from the next submission.

The CLI will ignore `-sfd` when combined with `-sfl`.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Yes! https://github.com/opendatakit/docs/issues/993