### PR TITLE
Fix non Aggregate compatibility

### DIFF
--- a/src/org/opendatakit/briefcase/model/RemoteFormDefinition.java
+++ b/src/org/opendatakit/briefcase/model/RemoteFormDefinition.java
@@ -16,18 +16,24 @@
 
 package org.opendatakit.briefcase.model;
 
+import java.net.URL;
+import java.util.Optional;
+import org.opendatakit.briefcase.reused.http.RequestBuilder;
+
 public class RemoteFormDefinition implements IFormDefinition {
 
   private final String formName;
   private final String formId;
   private final String versionString;
   private final String manifestUrl;
+  private final String downloadUrl;
 
-  public RemoteFormDefinition(String formName, String formId, String versionString, String manifestUrl) {
+  public RemoteFormDefinition(String formName, String formId, String versionString, String manifestUrl, String downloadUrl) {
     this.formName = formName;
     this.formId = formId;
     this.versionString = versionString;
     this.manifestUrl = manifestUrl;
+    this.downloadUrl = downloadUrl;
   }
 
   @Override
@@ -46,5 +52,9 @@ public class RemoteFormDefinition implements IFormDefinition {
 
   public String getVersionString() {
     return versionString;
+  }
+
+  public Optional<URL> getDownloadUrl() {
+    return Optional.ofNullable(downloadUrl).map(RequestBuilder::url);
   }
 }

--- a/src/org/opendatakit/briefcase/pull/aggregate/AggregateCursor.java
+++ b/src/org/opendatakit/briefcase/pull/aggregate/AggregateCursor.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.pull.aggregate;
+
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Objects;
+import java.util.Optional;
+import org.opendatakit.briefcase.export.XmlElement;
+import org.opendatakit.briefcase.model.BriefcasePreferences;
+import org.opendatakit.briefcase.model.FormStatus;
+import org.opendatakit.briefcase.reused.Iso8601Helpers;
+
+/**
+ * This class stores information about a cursor to a list of remote submission
+ * instance IDs, or "resumptionCursor" as described in the <a href="https://docs.opendatakit.org/briefcase-api/#returned-document">Briefcase Aggregate API docs</a>
+ * <p>
+ * The contents of a Cursor are basically a date ({@link #lastUpdate} field) and
+ * a submission instanceID ({@link #lastReturnedValue} field), which are used by
+ * Aggregate to define the lower bound of a page of submission instanceIDs (also
+ * called batch or chunk in the documentation). The upper bound is a defined by
+ * another parameter that's not part of the cursor.
+ * <p>
+ * The date ({@link #lastUpdate} field) in a cursor is related to the last update
+ * date of a submission stored in Aggregate's database, not to be mistaken with
+ * the completion or submission dates, which can be different.
+ * <p>
+ * The submission instanceID of a Cursor ({@link #lastReturnedValue} field) is used
+ * to further filter the contents of a submission instanceID page when the existing
+ * submissions from the provided date don't fit in the same page.
+ */
+public class AggregateCursor implements Cursor<AggregateCursor> {
+  /**
+   * This date is used only to compare Cursors that might have an empty value in lastUpdate
+   */
+  private static final OffsetDateTime SOME_OLD_DATE = OffsetDateTime.parse("2010-01-01T00:00:00.000Z");
+  // TODO v2.0 Use a better name, like xml
+  private final String value;
+  private final Optional<OffsetDateTime> lastUpdate;
+  private final Optional<String> lastReturnedValue;
+
+  private AggregateCursor(String value, Optional<OffsetDateTime> lastUpdate, Optional<String> lastReturnedValue) {
+    this.value = value;
+    this.lastUpdate = lastUpdate;
+    this.lastReturnedValue = lastReturnedValue;
+  }
+
+  public static AggregateCursor empty() {
+    return new AggregateCursor("", Optional.empty(), Optional.empty());
+  }
+
+  /**
+   * Parses the provided cursor xml document and returns a new Cursor instance.
+   */
+  public static Cursor from(String cursorXml) {
+    if (cursorXml.isEmpty()
+        || cursorXml.equals("0") // Ona compatibility
+    )
+      return AggregateCursor.empty();
+
+    XmlElement root = XmlElement.from(cursorXml);
+
+    Optional<OffsetDateTime> lastUpdate = root
+        .findElement("attributeValue")
+        .flatMap(XmlElement::maybeValue)
+        .map(Iso8601Helpers::parseDateTime);
+
+    Optional<String> lastReturnedValue = root
+        .findElement("uriLastReturnedValue")
+        .flatMap(XmlElement::maybeValue);
+
+    return new AggregateCursor(cursorXml, lastUpdate, lastReturnedValue);
+  }
+
+  /**
+   * Returns a synthetic Cursor instance with the provided values.
+   */
+  public static AggregateCursor of(OffsetDateTime lastUpdate, String lastReturnedValue) {
+    String cursorXml = String.format("<cursor xmlns=\"http://www.opendatakit.org/cursor\">" +
+            "<attributeName>_LAST_UPDATE_DATE</attributeName>" +
+            "<attributeValue>%s</attributeValue>" +
+            "<uriLastReturnedValue>%s</uriLastReturnedValue>" +
+            "<isForwardCursor>true</isForwardCursor>" +
+            "</cursor>",
+        lastUpdate.format(ISO_OFFSET_DATE_TIME),
+        lastReturnedValue
+    );
+    return new AggregateCursor(cursorXml, Optional.of(lastUpdate), Optional.of(lastReturnedValue));
+  }
+
+  /**
+   * Returns a synthetic Cursor instance with the provided values.
+   */
+  public static AggregateCursor of(LocalDate date) {
+    OffsetDateTime lastUpdate = date.atStartOfDay().atOffset(ZoneOffset.UTC);
+    String cursorXml = String.format("<cursor xmlns=\"http://www.opendatakit.org/cursor\">" +
+            "<attributeName>_LAST_UPDATE_DATE</attributeName>" +
+            "<attributeValue>%s</attributeValue>" +
+            "<uriLastReturnedValue/>" +
+            "<isForwardCursor>true</isForwardCursor>" +
+            "</cursor>",
+        lastUpdate.format(ISO_OFFSET_DATE_TIME)
+    );
+    return new AggregateCursor(cursorXml, Optional.of(lastUpdate), Optional.empty());
+  }
+
+  /**
+   * Returns a synthetic Cursor instance with the provided values.
+   */
+  public static AggregateCursor of(LocalDate date, String lastReturnedValue) {
+    return of(date.atStartOfDay().atOffset(ZoneOffset.UTC), lastReturnedValue);
+  }
+
+  // TODO v2.0 Use a better name, like getXml();
+  @Override
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return value.isEmpty();
+  }
+
+  @Override
+  public int compareTo(AggregateCursor other) {
+    // Hacky way to adapt to values that might have empty lastUpdate
+    // members that provides valid comparison results for our purposes
+    return lastUpdate.orElse(SOME_OLD_DATE).compareTo(other.lastUpdate.orElse(SOME_OLD_DATE));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    AggregateCursor cursor = (AggregateCursor) o;
+    return lastUpdate.equals(cursor.lastUpdate) &&
+        lastReturnedValue.equals(cursor.lastReturnedValue);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(lastUpdate, lastReturnedValue);
+  }
+
+  @Override
+  public void storePrefs(FormStatus form, BriefcasePreferences prefs) {
+    prefs.put(form.getFormId() + LAST_CURSOR_PREFERENCE_KEY_SUFFIX, getValue());
+    prefs.put(form.getFormId() + LAST_CURSOR_TYPE_PREFERENCE_KEY_SUFFIX, Type.AGGREGATE.getName());
+  }
+}

--- a/src/org/opendatakit/briefcase/pull/aggregate/EmptyCursor.java
+++ b/src/org/opendatakit/briefcase/pull/aggregate/EmptyCursor.java
@@ -1,0 +1,26 @@
+package org.opendatakit.briefcase.pull.aggregate;
+
+import org.opendatakit.briefcase.model.BriefcasePreferences;
+import org.opendatakit.briefcase.model.FormStatus;
+
+public class EmptyCursor implements Cursor<Cursor> {
+  @Override
+  public String getValue() {
+    return "";
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return true;
+  }
+
+  @Override
+  public int compareTo(Cursor o) {
+    return -1;
+  }
+
+  @Override
+  public void storePrefs(FormStatus form, BriefcasePreferences prefs) {
+    // Do nothing
+  }
+}

--- a/src/org/opendatakit/briefcase/pull/aggregate/InstanceIdBatchGetter.java
+++ b/src/org/opendatakit/briefcase/pull/aggregate/InstanceIdBatchGetter.java
@@ -67,7 +67,7 @@ public class InstanceIdBatchGetter implements Iterator<InstanceIdBatch> {
     Cursor nextCursor = xmlElement.findElement("resumptionCursor")
         .flatMap(XmlElement::maybeValue)
         .map(Cursor::from)
-        .orElse(Cursor.empty());
+        .orElseGet(Cursor::empty);
     List<String> uids = xmlElement
         .findElement("idList")
         .map(e -> e.findElements("id"))

--- a/src/org/opendatakit/briefcase/pull/aggregate/OnaCursor.java
+++ b/src/org/opendatakit/briefcase/pull/aggregate/OnaCursor.java
@@ -1,0 +1,49 @@
+package org.opendatakit.briefcase.pull.aggregate;
+
+import java.util.Optional;
+import org.opendatakit.briefcase.model.BriefcasePreferences;
+import org.opendatakit.briefcase.model.FormStatus;
+
+/**
+ * This class represents Ona's implementation of a Cursor.
+ * <p>
+ * It's much simpler than the {@link AggregateCursor} because
+ * it only stores a numeric ID.
+ * <p>
+ * This makes it possible to support the "start from last" feature,
+ * but not the "start from date", since Ona cursors don't include
+ * any date.
+ */
+public class OnaCursor implements Cursor<OnaCursor> {
+  private final Optional<Long> value;
+
+  private OnaCursor(Optional<Long> value) {
+    this.value = value;
+  }
+
+  public static Cursor from(String rawValue) {
+    return new OnaCursor(Optional.ofNullable(rawValue).map(Long::parseLong));
+  }
+
+  @Override
+  public int compareTo(OnaCursor o) {
+    return Long.compare(value.orElse(-1L), o.value.orElse(-1L));
+  }
+
+  @Override
+  public String getValue() {
+    return value.map(Object::toString).orElse("");
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return !value.isPresent();
+  }
+
+  @Override
+  public void storePrefs(FormStatus form, BriefcasePreferences prefs) {
+    prefs.put(form.getFormId() + LAST_CURSOR_PREFERENCE_KEY_SUFFIX, getValue());
+    prefs.put(form.getFormId() + LAST_CURSOR_TYPE_PREFERENCE_KEY_SUFFIX, Type.ONA.getName());
+  }
+
+}

--- a/src/org/opendatakit/briefcase/pull/aggregate/PullFromAggregate.java
+++ b/src/org/opendatakit/briefcase/pull/aggregate/PullFromAggregate.java
@@ -40,6 +40,7 @@ import org.opendatakit.briefcase.export.XmlElement;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.FormStatusEvent;
+import org.opendatakit.briefcase.model.RemoteFormDefinition;
 import org.opendatakit.briefcase.pull.PullEvent;
 import org.opendatakit.briefcase.reused.OptionalProduct;
 import org.opendatakit.briefcase.reused.Pair;
@@ -163,7 +164,11 @@ public class PullFromAggregate {
     }
 
     tracker.trackStartDownloadingForm();
-    Response<String> response = http.execute(server.getDownloadFormRequest(form.getFormId()));
+    RemoteFormDefinition formDef = (RemoteFormDefinition) form.getFormDefinition();
+    Request<String> downloadFormRequest = formDef.getDownloadUrl()
+        .map(server::getDownloadFormRequest)
+        .orElse(server.getDownloadFormRequest(form.getFormId()));
+    Response<String> response = http.execute(downloadFormRequest);
     if (!response.isSuccess()) {
       tracker.trackErrorDownloadingForm(response);
       return null;

--- a/src/org/opendatakit/briefcase/pull/aggregate/PullFromAggregate.java
+++ b/src/org/opendatakit/briefcase/pull/aggregate/PullFromAggregate.java
@@ -164,11 +164,7 @@ public class PullFromAggregate {
     }
 
     tracker.trackStartDownloadingForm();
-    RemoteFormDefinition formDef = (RemoteFormDefinition) form.getFormDefinition();
-    Request<String> downloadFormRequest = formDef.getDownloadUrl()
-        .map(server::getDownloadFormRequest)
-        .orElse(server.getDownloadFormRequest(form.getFormId()));
-    Response<String> response = http.execute(downloadFormRequest);
+    Response<String> response = http.execute(getDownloadFormRequest(form, tracker));
     if (!response.isSuccess()) {
       tracker.trackErrorDownloadingForm(response);
       return null;
@@ -181,6 +177,32 @@ public class PullFromAggregate {
     write(formFile, formXml, CREATE, TRUNCATE_EXISTING);
     tracker.trackEndDownloadingForm();
     return formXml;
+  }
+
+  private Request<String> getDownloadFormRequest(FormStatus form, PullFromAggregateTracker tracker) {
+    Optional<RemoteFormDefinition> maybeRemoteForm;
+    if (form.getFormDefinition() instanceof RemoteFormDefinition) {
+      maybeRemoteForm = Optional.of((RemoteFormDefinition) form.getFormDefinition());
+    } else {
+      // This is a pull before export operation. We need to get the manifest
+      // to get the download URL of this blank form.
+      Response<List<RemoteFormDefinition>> remoteFormsResponse = http.execute(server.getFormListRequest());
+      if (remoteFormsResponse.isSuccess())
+        maybeRemoteForm = remoteFormsResponse.get().stream()
+            .filter(remoteForm -> remoteForm.getFormId().equals(form.getFormId()))
+            .findFirst();
+      else {
+        tracker.trackErrorGettingFormManifest(remoteFormsResponse);
+        maybeRemoteForm = Optional.empty();
+      }
+    }
+
+    // In case the downloadUrl is empty, we return an Aggregate
+    // compatible url and wish for the best.
+    return maybeRemoteForm
+        .flatMap(RemoteFormDefinition::getDownloadUrl)
+        .map(server::getDownloadFormRequest)
+        .orElse(server.getDownloadFormRequest(form.getFormId()));
   }
 
   List<AggregateAttachment> getFormAttachments(FormStatus form, RunnerStatus runnerStatus, PullFromAggregateTracker tracker) {
@@ -239,7 +261,8 @@ public class PullFromAggregate {
       tracker.trackErrorDownloadingFormAttachment(attachmentNumber, totalAttachments, response);
   }
 
-  DownloadedSubmission downloadSubmission(FormStatus form, String instanceId, SubmissionKeyGenerator subKeyGen, RunnerStatus runnerStatus, PullFromAggregateTracker tracker, int submissionNumber, int totalSubmissions) {
+  DownloadedSubmission downloadSubmission(FormStatus form, String instanceId, SubmissionKeyGenerator subKeyGen, RunnerStatus runnerStatus, PullFromAggregateTracker tracker, int submissionNumber,
+                                          int totalSubmissions) {
     if (runnerStatus.isCancelled()) {
       tracker.trackCancellation("Download submission " + submissionNumber + " of " + totalSubmissions);
       return null;
@@ -261,7 +284,8 @@ public class PullFromAggregate {
     return submission;
   }
 
-  void downloadSubmissionAttachment(FormStatus form, DownloadedSubmission submission, AggregateAttachment attachment, RunnerStatus runnerStatus, PullFromAggregateTracker tracker, int submissionNumber, int totalSubmissions, int attachmentNumber, int totalAttachments) {
+  void downloadSubmissionAttachment(FormStatus form, DownloadedSubmission submission, AggregateAttachment attachment, RunnerStatus runnerStatus, PullFromAggregateTracker tracker,
+                                    int submissionNumber, int totalSubmissions, int attachmentNumber, int totalAttachments) {
     if (runnerStatus.isCancelled()) {
       tracker.trackCancellation("Download attachment " + attachmentNumber + " of " + totalAttachments + " of submission " + submissionNumber + " of " + totalSubmissions);
       return;

--- a/src/org/opendatakit/briefcase/reused/http/CommonsHttp.java
+++ b/src/org/opendatakit/briefcase/reused/http/CommonsHttp.java
@@ -67,7 +67,7 @@ public class CommonsHttp implements Http {
         .create()
         .setMaxConnPerRoute(maxConnections)
         .setMaxConnTotal(maxConnections)
-        .disableAuthCaching()
+        //.disableAuthCaching()
         .setDefaultRequestConfig(custom()
             .setConnectionRequestTimeout(0)
             .setSocketTimeout(0)
@@ -78,7 +78,7 @@ public class CommonsHttp implements Http {
   @Override
   public <T> Response<T> execute(Request<T> request) {
     // Ensure that we will be using fresh credentials
-    executor.clearAuth();
+    //executor.clearAuth();
     // Apply auth settings if credentials are received
     request.ifCredentials((URL url, Credentials credentials) -> executor.auth(
         HttpHost.create(url.getHost()),

--- a/src/org/opendatakit/briefcase/reused/http/CommonsHttp.java
+++ b/src/org/opendatakit/briefcase/reused/http/CommonsHttp.java
@@ -67,7 +67,6 @@ public class CommonsHttp implements Http {
         .create()
         .setMaxConnPerRoute(maxConnections)
         .setMaxConnTotal(maxConnections)
-        //.disableAuthCaching()
         .setDefaultRequestConfig(custom()
             .setConnectionRequestTimeout(0)
             .setSocketTimeout(0)
@@ -77,8 +76,6 @@ public class CommonsHttp implements Http {
 
   @Override
   public <T> Response<T> execute(Request<T> request) {
-    // Ensure that we will be using fresh credentials
-    //executor.clearAuth();
     // Apply auth settings if credentials are received
     request.ifCredentials((URL url, Credentials credentials) -> executor.auth(
         HttpHost.create(url.getHost()),

--- a/src/org/opendatakit/briefcase/reused/http/RequestBuilder.java
+++ b/src/org/opendatakit/briefcase/reused/http/RequestBuilder.java
@@ -220,13 +220,9 @@ public class RequestBuilder<T> {
   }
 
   public RequestBuilder<T> withPath(String path) {
-    String cleanPath = path.startsWith("/") && path.endsWith("/")
-        ? path.substring(1, path.length() - 1)
-        : path.startsWith("/")
-        ? path.substring(1)
-        : path.endsWith("/")
-        ? path.substring(0, path.length() - 1)
-        : path;
+    int startOffset = path.startsWith("/") ? 1 : 0;
+    int endOffset = path.endsWith("/") ? 1 : 0;
+    String cleanPath = path.substring(startOffset, path.length() - endOffset);
     URL newBaseUrl = url(baseUrl + "/" + cleanPath);
     return new RequestBuilder<>(method, newBaseUrl, responseMapper, credentials, headers, body, multipartMessages);
   }

--- a/src/org/opendatakit/briefcase/reused/http/RequestBuilder.java
+++ b/src/org/opendatakit/briefcase/reused/http/RequestBuilder.java
@@ -220,9 +220,14 @@ public class RequestBuilder<T> {
   }
 
   public RequestBuilder<T> withPath(String path) {
-    if (!baseUrl.getPath().isEmpty())
-      throw new BriefcaseException("Can't apply withPath() twice");
-    URL newBaseUrl = url(baseUrl + (path.startsWith("/") ? path : "/" + path));
+    String cleanPath = path.startsWith("/") && path.endsWith("/")
+        ? path.substring(1, path.length() - 1)
+        : path.startsWith("/")
+        ? path.substring(1)
+        : path.endsWith("/")
+        ? path.substring(0, path.length() - 1)
+        : path;
+    URL newBaseUrl = url(baseUrl + "/" + cleanPath);
     return new RequestBuilder<>(method, newBaseUrl, responseMapper, credentials, headers, body, multipartMessages);
   }
 

--- a/src/org/opendatakit/briefcase/reused/transfer/AggregateServer.java
+++ b/src/org/opendatakit/briefcase/reused/transfer/AggregateServer.java
@@ -148,7 +148,7 @@ public class AggregateServer implements RemoteServer {
         .withPath("/view/submissionList")
         .withQuery(
             Pair.of("formId", formId),
-            Pair.of("cursor", cursor.get()),
+            Pair.of("cursor", cursor.getValue()),
             Pair.of("numEntries", String.valueOf(entriesPerBatch)),
             Pair.of("includeIncomplete", includeIncomplete ? "true" : "false")
         )

--- a/src/org/opendatakit/briefcase/reused/transfer/AggregateServer.java
+++ b/src/org/opendatakit/briefcase/reused/transfer/AggregateServer.java
@@ -89,6 +89,14 @@ public class AggregateServer implements RemoteServer {
         .asText()
         .withPath("/formXml")
         .withQuery(Pair.of("formId", formId))
+        .withCredentials(credentials)
+        .build();
+  }
+
+  public Request<String> getDownloadFormRequest(URL downloadUrl) {
+    return get(downloadUrl)
+        .asText()
+        .withCredentials(credentials)
         .build();
   }
 
@@ -97,6 +105,7 @@ public class AggregateServer implements RemoteServer {
         .asXmlElement()
         .withPath("/view/downloadSubmission")
         .withQuery(Pair.of("formId", submissionKey))
+        .withCredentials(credentials)
         .withResponseMapper(DownloadedSubmission::from)
         .build();
   }
@@ -114,7 +123,8 @@ public class AggregateServer implements RemoteServer {
                 e.findElement("name").flatMap(XmlElement::maybeValue).get(),
                 e.findElement("formID").flatMap(XmlElement::maybeValue).get(),
                 e.findElement("version").flatMap(XmlElement::maybeValue).orElse(null),
-                e.findElement("manifestUrl").flatMap(XmlElement::maybeValue).orElse(null)
+                e.findElement("manifestUrl").flatMap(XmlElement::maybeValue).orElse(null),
+                e.findElement("downloadUrl").flatMap(XmlElement::maybeValue).orElse(null)
             )).collect(toList())).build();
   }
 
@@ -142,6 +152,7 @@ public class AggregateServer implements RemoteServer {
             Pair.of("numEntries", String.valueOf(entriesPerBatch)),
             Pair.of("includeIncomplete", includeIncomplete ? "true" : "false")
         )
+        .withCredentials(credentials)
         .build();
   }
 
@@ -165,6 +176,7 @@ public class AggregateServer implements RemoteServer {
     return builder
         .withHeader("X-OpenRosa-Version", "1.0")
         .withHeader("Date", OffsetDateTime.now().format(RFC_1123_DATE_TIME))
+        .withCredentials(credentials)
         .build();
   }
 
@@ -189,6 +201,7 @@ public class AggregateServer implements RemoteServer {
     return builder
         .withHeader("X-OpenRosa-Version", "1.0")
         .withHeader("Date", OffsetDateTime.now().format(RFC_1123_DATE_TIME))
+        .withCredentials(credentials)
         .build();
   }
 

--- a/src/org/opendatakit/briefcase/reused/transfer/CentralServer.java
+++ b/src/org/opendatakit/briefcase/reused/transfer/CentralServer.java
@@ -206,7 +206,8 @@ public class CentralServer implements RemoteServer {
                 (String) json.get("name"),
                 (String) json.get("xmlFormId"),
                 (String) json.get("version"),
-                String.format("%s/v1/projects/%d/forms/%s/manifest", baseUrl.toString(), projectId, (String) json.get("xmlFormId"))
+                String.format("%s/v1/projects/%d/forms/%s/manifest", baseUrl.toString(), projectId, (String) json.get("xmlFormId")),
+                null
             ))
             .collect(toList()))
         .build();

--- a/test/java/org/opendatakit/briefcase/pull/aggregate/OpenRosaCursorTest.java
+++ b/test/java/org/opendatakit/briefcase/pull/aggregate/OpenRosaCursorTest.java
@@ -31,7 +31,7 @@ import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.InMemoryPreferences;
 
-public class CursorTest {
+public class OpenRosaCursorTest {
 
   public static String buildCursorXml(OffsetDateTime lastUpdate) {
     return buildCursorXml(lastUpdate, UUID.randomUUID().toString());
@@ -71,7 +71,7 @@ public class CursorTest {
     Cursor originalCursor = Cursor.from(buildCursorXml("2019-01-01T00:00:00.000Z", "1234"));
 
     originalCursor.storePrefs(form, testBriefcasePrefs);
-    assertThat(testBriefcasePrefs.keys(), hasSize(1));
+    assertThat(testBriefcasePrefs.keys(), hasSize(2));
 
     Optional<Cursor> actualCursor = Cursor.readPrefs(form, testBriefcasePrefs);
     assertThat(actualCursor, isPresentAndIs(originalCursor));
@@ -85,7 +85,7 @@ public class CursorTest {
     Cursor.from(buildCursorXml("2019-01-01T00:00:00.000Z", "1")).storePrefs(buildFormStatus(1), testBriefcasePrefs);
     Cursor.from(buildCursorXml("2019-01-01T00:00:00.000Z", "2")).storePrefs(buildFormStatus(2), testBriefcasePrefs);
     Cursor.from(buildCursorXml("2019-01-01T00:00:00.000Z", "3")).storePrefs(buildFormStatus(3), testBriefcasePrefs);
-    assertThat(testBriefcasePrefs.keys(), hasSize(4));
+    assertThat(testBriefcasePrefs.keys(), hasSize(7));
 
     Cursor.cleanAllPrefs(testBriefcasePrefs);
 

--- a/test/java/org/opendatakit/briefcase/reused/http/RequestBuilderTest.java
+++ b/test/java/org/opendatakit/briefcase/reused/http/RequestBuilderTest.java
@@ -20,16 +20,38 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.opendatakit.briefcase.reused.http.RequestBuilder.url;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.Test;
 import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.reused.Pair;
 
 public class RequestBuilderTest {
 
-  @Test(expected = BriefcaseException.class)
-  public void should_reject_calling_withPath_if_baseUrl_already_has_a_path() {
-    RequestBuilder.get("http://foo.bar/baz")
-        .withPath("/bing");
+  @Test
+  public void can_compose_multiple_path_parts() {
+    List<String> baseUrls = Arrays.asList("http://foo.com", "http://foo.com/");
+    List<Pair<String, String>> pathPairs = generatePathPairs(new String[]{"bar", "/bar", "bar/", "/bar/"}, new String[]{"baz", "/baz", "baz/", "/baz/"});
+    for (String baseUrl : baseUrls)
+      for (Pair<String, String> pathPair : pathPairs)
+        assertThat(
+            String.format("baseUrl: \"%s\", paths: \"%s\" and \"%s\"", baseUrl, pathPair.getLeft(), pathPair.getRight()),
+            RequestBuilder.get(baseUrl)
+                .withPath(pathPair.getLeft())
+                .withPath(pathPair.getRight())
+                .build()
+                .getUrl(),
+            is(url("http://foo.com/bar/baz"))
+        );
+  }
+
+  private static List<Pair<String, String>> generatePathPairs(String[] firsts, String[] seconds) {
+    List<Pair<String, String>> pairs = new ArrayList<>();
+    for (String first : firsts)
+      for (String second : seconds)
+        pairs.add(Pair.of(first, second));
+    return pairs;
   }
 
   @Test(expected = BriefcaseException.class)

--- a/test/java/org/opendatakit/briefcase/reused/transfer/AggregateServerTest.java
+++ b/test/java/org/opendatakit/briefcase/reused/transfer/AggregateServerTest.java
@@ -63,7 +63,7 @@ public class AggregateServerTest {
     Cursor cursor = Cursor.of(LocalDate.parse("2010-01-01"));
     assertThat(
         server.getInstanceIdBatchRequest("some-form", 100, cursor, false).getUrl().toString(),
-        is("https://some.server.com/view/submissionList?formId=some-form&cursor=" + encode(cursor.get(), UTF_8.toString()) + "&numEntries=100&includeIncomplete=false")
+        is("https://some.server.com/view/submissionList?formId=some-form&cursor=" + encode(cursor.getValue(), UTF_8.toString()) + "&numEntries=100&includeIncomplete=false")
     );
   }
 

--- a/test/java/org/opendatakit/briefcase/reused/transfer/TransferTestHelpers.java
+++ b/test/java/org/opendatakit/briefcase/reused/transfer/TransferTestHelpers.java
@@ -197,7 +197,7 @@ public class TransferTestHelpers {
       pages.add(Pair.of("" +
           "<idChunk xmlns=\"http://opendatakit.org/submissions\">" +
           "<idList>" + ids.stream().map(id -> "<id>" + id + "</id>").collect(joining("")) + "</idList>" +
-          "<resumptionCursor>" + escape(cursor.get()) + "</resumptionCursor>" +
+          "<resumptionCursor>" + escape(cursor.getValue()) + "</resumptionCursor>" +
           "</idChunk>" +
           "", cursor));
 
@@ -206,7 +206,7 @@ public class TransferTestHelpers {
     pages.add(Pair.of("" +
         "<idChunk xmlns=\"http://opendatakit.org/submissions\">" +
         "<idList></idList>" +
-        "<resumptionCursor>" + escape(lastCursor.get()) + "</resumptionCursor>" +
+        "<resumptionCursor>" + escape(lastCursor.getValue()) + "</resumptionCursor>" +
         "</idChunk>" +
         "", lastCursor));
 

--- a/test/java/org/opendatakit/briefcase/reused/transfer/TransferTestHelpers.java
+++ b/test/java/org/opendatakit/briefcase/reused/transfer/TransferTestHelpers.java
@@ -133,7 +133,8 @@ public class TransferTestHelpers {
         formName,
         formName,
         null,
-        manifestUrl
+        manifestUrl,
+        null
     ));
   }
 


### PR DESCRIPTION
This PR solves issues when dealing with Ona servers:
- Can't connect to list forms in the pull tab
- Can't use the "start from last" feature when pulling forms
- Can't use the "pull before export" feature when exporting forms.

#### What has been done to verify that this works as intended?
I've tested this manually using my Ona account at https://odk.ona.io/ggalmazor
- Pull forms under various "start from last" scenarios: first time pull, second time pull, send new submissions and pull again, etc.
- Export forms with the "pull before export" option:
  - Single form
  - Multiple form, from Ona and Aggregate servers

#### Why is this the best possible solution? Were any other approaches considered?
Subtyping Cursor felt like the simplest way to go. The alternative would have been to revert the changes to Cursor that made it parse its value, but that would have an impact on how we deal with the "start from date" feature.

The changes to Cursor are required to get the submissions list when pulling forms. This is because Ona uses a simple numeric id, instead of a complex XML document like Aggregate.

An alternative to the changes to support the pull before export feature with Ona would be to simply not support it, but it felt like we ought to make the effort this time.  

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Every time we change something related to the java prefs system we should be on the lookout for trouble.

This time, we need to save a new key with the cursor type (aggregate/ona) and when reading cursors from prefs, we base on that value to choose which factory to use (defaulting to aggregate)

If I did something wrong, users might have trouble with the "start from last" feature, and the "pull before export" feature, by extension.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.
