### PR TITLE
Issue #749 Improve layout of the show source panel to better acommodate info

### DIFF
--- a/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/ShowSourceOrTargetForm.form
+++ b/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/ShowSourceOrTargetForm.form
@@ -22,7 +22,7 @@
           <gridbag weightx="1.0" weighty="0.0"/>
         </constraints>
         <properties>
-          <text value="Pulling data from %s"/>
+          <text value="Action placeholder"/>
         </properties>
       </component>
       <component id="45a9d" class="javax.swing.JButton" binding="resetButton">

--- a/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/ShowSourceOrTargetForm.java
+++ b/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/ShowSourceOrTargetForm.java
@@ -135,7 +135,7 @@ public class ShowSourceOrTargetForm<T extends SourceOrTarget> extends JComponent
     gbc.anchor = GridBagConstraints.WEST;
     container.add(sourceLabel, gbc);
     actionLabel = new JLabel();
-    actionLabel.setText("Pulling data from %s");
+    actionLabel.setText("Action placeholder");
     gbc = new GridBagConstraints();
     gbc.gridx = 0;
     gbc.gridy = 0;

--- a/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/source/Aggregate.java
+++ b/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/source/Aggregate.java
@@ -125,7 +125,7 @@ public class Aggregate implements PullSource<AggregateServer> {
 
   @Override
   public void decorate(JLabel label) {
-    label.setText("<html><a href=\"" + server.getBaseUrl().toString() + "\">" + getDescription() + "</a></html>");
+    label.setText("<html>URL: <a href=\"" + server.getBaseUrl().toString() + "\">" + getDescription() + "</a></html>");
     label.setCursor(getPredefinedCursor(HAND_CURSOR));
     removeAllMouseListeners(label);
     label.addMouseListener(new MouseAdapterBuilder()

--- a/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/source/Central.java
+++ b/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/source/Central.java
@@ -85,7 +85,7 @@ public class Central implements PullSource<CentralServer> {
 
   @Override
   public void decorate(JLabel label) {
-    label.setText("<html><a href=\"" + server.getBaseUrl().toString() + "\">" + getDescription() + "</a> - Project " + server.getProjectId() + "</html>");
+    label.setText("<html>URL: <a href=\"" + server.getBaseUrl().toString() + "\">" + getDescription() + "</a><br/>Project ID: " + server.getProjectId() + "</html>");
     label.setCursor(getPredefinedCursor(HAND_CURSOR));
     removeAllMouseListeners(label);
     label.addMouseListener(new MouseAdapterBuilder()

--- a/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/target/Aggregate.java
+++ b/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/target/Aggregate.java
@@ -94,7 +94,7 @@ public class Aggregate implements PushTarget<AggregateServer> {
 
   @Override
   public void decorate(JLabel label) {
-    label.setText("<html><a href=\"" + server.getBaseUrl().toString() + "\">" + getDescription() + "</a></html>");
+    label.setText("<html>URL: <a href=\"" + server.getBaseUrl().toString() + "\">" + getDescription() + "</a></html>");
     label.setCursor(getPredefinedCursor(HAND_CURSOR));
     removeAllMouseListeners(label);
     label.addMouseListener(new MouseAdapterBuilder()

--- a/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/target/Central.java
+++ b/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/target/Central.java
@@ -87,7 +87,7 @@ public class Central implements PushTarget<CentralServer> {
 
   @Override
   public void decorate(JLabel label) {
-    label.setText("<html><a href=\"" + server.getBaseUrl().toString() + "\">" + getDescription() + "</a> - Project " + server.getProjectId() + "</html>");
+    label.setText("<html>URL: <a href=\"" + server.getBaseUrl().toString() + "\">" + getDescription() + "</a><br/>Project ID: " + server.getProjectId() + "</html>");
     label.setCursor(getPredefinedCursor(HAND_CURSOR));
     removeAllMouseListeners(label);
     label.addMouseListener(new MouseAdapterBuilder()


### PR DESCRIPTION
Closes #749

#### What has been done to verify that this works as intended?
Manually tested (Ubuntu) that Aggregate and Central servers show the new labels and rows accordingly.

Aggregate servers should say:
- (Pulling from|Pushing to): Aggregate server
- URL: http://foo.bar

Central servers should say:
- (Pulling from|Pushing to): Central server
- URL: http://foo.bar
- Project ID: 42

#### Why is this the best possible solution? Were any other approaches considered?
This is the narrowest solution I could come up with that doesn't require changing the Swing layout, which is always good.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The change is so small, and affects only to the presentation layer, that I don't think there's any regression risks.

Maybe Windows and Mac struggle with <br/> tags in html labels?

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.