### PR TITLE
Issue #751 Change max HTTP conns language

### DIFF
--- a/src/org/opendatakit/briefcase/operations/Common.java
+++ b/src/org/opendatakit/briefcase/operations/Common.java
@@ -28,7 +28,7 @@ public class Common {
   static final Param<String> ODK_USERNAME = Param.arg("u", "odk_username", "ODK Username");
   static final Param<String> ODK_PASSWORD = Param.arg("p", "odk_password", "ODK Password");
   static final Param<String> AGGREGATE_SERVER = Param.arg("url", "aggregate_url", "Aggregate server URL");
-  public static final Param<Integer> MAX_HTTP_CONNECTIONS = Param.arg("mhc", "max_http_connections", "Maximum HTTP simultaneous connections (defaults to 8)", Integer::parseInt);
+  public static final Param<Integer> MAX_HTTP_CONNECTIONS = Param.arg("mhc", "max_http_connections", "Maximum simultaneous HTTP connections (defaults to 8)", Integer::parseInt);
 
   static Path getOrCreateBriefcaseDir(String storageDir) {
     Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));

--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -98,10 +98,10 @@ public class Export {
     BriefcasePreferences exportPrefs = BriefcasePreferences.forClass(ExportPanel.class);
     BriefcasePreferences pullPrefs = BriefcasePreferences.forClass(ExportPanel.class);
 
-    int maxConnections = appPreferences.getMaxHttpConnections().orElse(DEFAULT_HTTP_CONNECTIONS);
+    int maxHttpConnections = appPreferences.getMaxHttpConnections().orElse(DEFAULT_HTTP_CONNECTIONS);
     Http http = appPreferences.getHttpProxy()
-        .map(host -> CommonsHttp.of(maxConnections, host))
-        .orElseGet(() -> CommonsHttp.of(maxConnections));
+        .map(host -> CommonsHttp.of(maxHttpConnections, host))
+        .orElseGet(() -> CommonsHttp.of(maxHttpConnections));
 
     Optional<BriefcaseFormDefinition> maybeFormDefinition = formCache.getForms().stream()
         .filter(form -> form.getFormId().equals(formid))

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -78,7 +78,7 @@ public class PullFormFromAggregate {
       Arrays.asList(RESUME_LAST_PULL, INCLUDE_INCOMPLETE, FORM_ID, START_FROM_DATE, MAX_HTTP_CONNECTIONS)
   );
 
-  public static void pullFormFromAggregate(String storageDir, Optional<String> formId, String username, String password, String server, boolean resumeLastPull, Optional<LocalDate> startFromDate, boolean includeIncomplete, Optional<Integer> maybeMaxConnections) {
+  public static void pullFormFromAggregate(String storageDir, Optional<String> formId, String username, String password, String server, boolean resumeLastPull, Optional<LocalDate> startFromDate, boolean includeIncomplete, Optional<Integer> maybeMaxHttpConnections) {
     CliEventsCompanion.attach(log);
     Path briefcaseDir = Common.getOrCreateBriefcaseDir(storageDir);
     FormCache formCache = FormCache.from(briefcaseDir);
@@ -87,13 +87,13 @@ public class PullFormFromAggregate {
     appPreferences.setStorageDir(briefcaseDir);
     BriefcasePreferences tabPreferences = BriefcasePreferences.forClass(PullPanel.class);
 
-    int maxConnections = Optionals.race(
-        maybeMaxConnections,
+    int maxHttpConnections = Optionals.race(
+        maybeMaxHttpConnections,
         appPreferences.getMaxHttpConnections()
     ).orElse(DEFAULT_HTTP_CONNECTIONS);
     Http http = appPreferences.getHttpProxy()
-        .map(host -> CommonsHttp.of(maxConnections, host))
-        .orElseGet(() -> CommonsHttp.of(maxConnections));
+        .map(host -> CommonsHttp.of(maxHttpConnections, host))
+        .orElseGet(() -> CommonsHttp.of(maxHttpConnections));
 
     AggregateServer aggregateServer = AggregateServer.authenticated(RequestBuilder.url(server), new Credentials(username, password));
 

--- a/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
@@ -73,13 +73,13 @@ public class PushFormToAggregate {
     formCache.update();
     BriefcasePreferences appPreferences = BriefcasePreferences.appScoped();
 
-    int maxConnections = Optionals.race(
+    int maxHttpConnections = Optionals.race(
         maybeMaxConnections,
         appPreferences.getMaxHttpConnections()
     ).orElse(DEFAULT_HTTP_CONNECTIONS);
     Http http = appPreferences.getHttpProxy()
-        .map(host -> CommonsHttp.of(maxConnections, host))
-        .orElseGet(() -> CommonsHttp.of(maxConnections));
+        .map(host -> CommonsHttp.of(maxHttpConnections, host))
+        .orElseGet(() -> CommonsHttp.of(maxHttpConnections));
 
     AggregateServer aggregateServer = AggregateServer.authenticated(RequestBuilder.url(server), new Credentials(username, password));
 

--- a/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
+++ b/src/org/opendatakit/briefcase/ui/MainBriefcaseWindow.java
@@ -107,10 +107,10 @@ public class MainBriefcaseWindow extends WindowAdapter {
     analytics.enter("Briefcase");
     Runtime.getRuntime().addShutdownHook(new Thread(() -> analytics.leave("Briefcase")));
 
-    int maxConnections = appPreferences.getMaxHttpConnections().orElse(DEFAULT_HTTP_CONNECTIONS);
+    int maxHttpConnections = appPreferences.getMaxHttpConnections().orElse(DEFAULT_HTTP_CONNECTIONS);
     Http http = appPreferences.getHttpProxy()
-        .map(host -> CommonsHttp.of(maxConnections, host))
-        .orElseGet(() -> CommonsHttp.of(maxConnections));
+        .map(host -> CommonsHttp.of(maxHttpConnections, host))
+        .orElseGet(() -> CommonsHttp.of(maxHttpConnections));
 
     frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
 

--- a/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.form
+++ b/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.form
@@ -367,7 +367,7 @@
               <gridbag weightx="0.0" weighty="0.0"/>
             </constraints>
             <properties>
-              <text value="Maximum HTTP simultaneous connections"/>
+              <text value="Maximum simultaneous HTTP connections"/>
             </properties>
           </component>
           <hspacer id="b75ef">

--- a/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/settings/SettingsPanelForm.java
@@ -555,7 +555,7 @@ public class SettingsPanelForm {
     gbc.fill = GridBagConstraints.HORIZONTAL;
     maxHttpConnectionContainer.add(maxHttpConnectionsField, gbc);
     maxHttpConnectionsLabel = new JLabel();
-    maxHttpConnectionsLabel.setText("Maximum HTTP simultaneous connections");
+    maxHttpConnectionsLabel.setText("Maximum simultaneous HTTP connections");
     gbc = new GridBagConstraints();
     gbc.gridx = 0;
     gbc.gridy = 0;


### PR DESCRIPTION
Closes #751

Review language about max http connections conf setting
- Outside CommonsHttp, we use "max http connections"
- Inside CommonsHttp, we use "max connections"
- For user-facing texts, we use "maximum simultaneous HTTP connections"

#### What has been done to verify that this works as intended?
Run the CLI help and the UI to verify that user-facing texts are alright.
The rest of the changes can be verified by building the project since they're only safe name change refactors.

#### Why is this the best possible solution? Were any other approaches considered?
This is a small change to review code and text language use. 

We considered using "max connections" and "max HTTP connections", but ultimately decided that "max simultaneous HTTP connections" was the shortest form that gave all necessary context.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.