### PR TITLE
Issue 759 fix parsing times with unsupported offsets

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -70,16 +70,6 @@
             <property name="option" value="alone"/>
             <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
         </module>
-        <module name="WhitespaceAround">
-            <property name="allowEmptyConstructors" value="true"/>
-            <property name="allowEmptyMethods" value="true"/>
-            <property name="allowEmptyTypes" value="true"/>
-            <property name="allowEmptyLoops" value="true"/>
-            <message key="ws.notFollowed"
-             value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
-             <message key="ws.notPreceded"
-             value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
-        </module>
         <module name="OneStatementPerLine"/>
         <module name="MultipleVariableDeclarations"/>
         <!-- <module name="ArrayTypeStyle"/> -->

--- a/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
+++ b/src/org/opendatakit/briefcase/export/CsvFieldMappers.java
@@ -24,6 +24,8 @@ import static org.javarosa.core.model.DataType.DATE_TIME;
 import static org.javarosa.core.model.DataType.GEOPOINT;
 import static org.javarosa.core.model.DataType.NULL;
 import static org.javarosa.core.model.DataType.TIME;
+import static org.opendatakit.briefcase.reused.Iso8601Helpers.parseDateTime;
+import static org.opendatakit.briefcase.reused.Iso8601Helpers.parseTime;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.copy;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.createDirectories;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.exists;
@@ -39,7 +41,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
-import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -54,7 +55,6 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.javarosa.core.model.DataType;
-import org.opendatakit.briefcase.reused.Iso8601Helpers;
 import org.opendatakit.briefcase.reused.OptionalProduct;
 import org.opendatakit.briefcase.reused.Pair;
 
@@ -181,7 +181,7 @@ final class CsvFieldMappers {
         .appendText(ChronoField.AMPM_OF_DAY, TextStyle.FULL)
         .toFormatter();
     return Stream.of(Pair.of(element.fqn(), element.maybeValue()
-        .map(value -> OffsetTime.parse(value).format(formatter))
+        .map(value -> parseTime(value).format(formatter))
         .orElse("")));
   }
 
@@ -196,7 +196,7 @@ final class CsvFieldMappers {
    * format users expect in their exported CSV files.
    */
   static String iso8601DateTimeToExportCsvFormat(String value) {
-    return iso8601DateTimeToExportCsvFormat(Iso8601Helpers.parseDateTime(value));
+    return iso8601DateTimeToExportCsvFormat(parseDateTime(value));
   }
 
   /**

--- a/src/org/opendatakit/briefcase/reused/Iso8601Helpers.java
+++ b/src/org/opendatakit/briefcase/reused/Iso8601Helpers.java
@@ -20,16 +20,7 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 
 public class Iso8601Helpers {
-  private static String normalizeDateTime(String value) {
-    char charAtMinus3 = value.charAt(value.length() - 3);
-    if (value.endsWith("Z") || charAtMinus3 == ':')
-      return value;
-    if (charAtMinus3 == '+' || charAtMinus3 == '-')
-      return value + ":00";
-    return String.format("%s:%s", value.substring(0, 26), value.substring(26));
-  }
-
-  private static String normalizeTime(String value) {
+  private static String normalizeOffset(String value) {
     char charAtMinus3 = value.charAt(value.length() - 3);
     if (value.endsWith("Z") || charAtMinus3 == ':')
       return value;
@@ -39,10 +30,10 @@ public class Iso8601Helpers {
   }
 
   public static OffsetDateTime parseDateTime(String value) {
-    return OffsetDateTime.parse(normalizeDateTime(value));
+    return OffsetDateTime.parse(normalizeOffset(value));
   }
 
   public static OffsetTime parseTime(String value) {
-    return OffsetTime.parse(normalizeTime(value));
+    return OffsetTime.parse(normalizeOffset(value));
   }
 }

--- a/src/org/opendatakit/briefcase/reused/Iso8601Helpers.java
+++ b/src/org/opendatakit/briefcase/reused/Iso8601Helpers.java
@@ -17,6 +17,7 @@
 package org.opendatakit.briefcase.reused;
 
 import java.time.OffsetDateTime;
+import java.time.OffsetTime;
 
 public class Iso8601Helpers {
   private static String normalizeDateTime(String value) {
@@ -28,7 +29,20 @@ public class Iso8601Helpers {
     return String.format("%s:%s", value.substring(0, 26), value.substring(26));
   }
 
+  private static String normalizeTime(String value) {
+    char charAtMinus3 = value.charAt(value.length() - 3);
+    if (value.endsWith("Z") || charAtMinus3 == ':')
+      return value;
+    if (charAtMinus3 == '+' || charAtMinus3 == '-')
+      return value + ":00";
+    return String.format("%s:%s", value.substring(0, 26), value.substring(26));
+  }
+
   public static OffsetDateTime parseDateTime(String value) {
     return OffsetDateTime.parse(normalizeDateTime(value));
+  }
+
+  public static OffsetTime parseTime(String value) {
+    return OffsetTime.parse(normalizeTime(value));
   }
 }

--- a/test/java/org/opendatakit/briefcase/reused/Iso8601HelpersTest.java
+++ b/test/java/org/opendatakit/briefcase/reused/Iso8601HelpersTest.java
@@ -19,8 +19,12 @@ package org.opendatakit.briefcase.reused;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.opendatakit.briefcase.reused.Iso8601Helpers.parseDateTime;
+import static org.opendatakit.briefcase.reused.Iso8601HelpersTest.TestType.DATETIME;
+import static org.opendatakit.briefcase.reused.Iso8601HelpersTest.TestType.TIME;
 
 import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.temporal.Temporal;
 import java.util.Arrays;
 import java.util.Collection;
 import org.junit.Test;
@@ -29,31 +33,37 @@ import org.junit.runners.Parameterized;
 
 @RunWith(value = Parameterized.class)
 public class Iso8601HelpersTest {
+  enum TestType {DATETIME, TIME}
+
   @Parameterized.Parameter(value = 0)
   public String testCase;
 
   @Parameterized.Parameter(value = 1)
-  public String input;
+  public TestType testType;
 
   @Parameterized.Parameter(value = 2)
-  public OffsetDateTime expectedOutput;
+  public String input;
+
+  @Parameterized.Parameter(value = 3)
+  public Temporal expectedOutput;
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][]{
-        {"Correct format - Offset Z", "2010-01-01T00:00:00.000Z", OffsetDateTime.parse("2010-01-01T00:00:00.000Z")},
-        {"Correct format - Offset +00:00", "2010-01-01T00:00:00.000+00:00", OffsetDateTime.parse("2010-01-01T00:00:00.000+00:00")},
-        {"Correct format - Offset -00:00", "2010-01-01T00:00:00.000-00:00", OffsetDateTime.parse("2010-01-01T00:00:00.000-00:00")},
-        {"Correct format - Offset +03:00", "2010-01-01T00:00:00.000+03:00", OffsetDateTime.parse("2010-01-01T00:00:00.000+03:00")},
-        {"Correct format - Offset -03:00", "2010-01-01T00:00:00.000-03:00", OffsetDateTime.parse("2010-01-01T00:00:00.000-03:00")},
-        {"Wrong format - Offset +0030", "2010-01-01T00:00:00.000+0030", OffsetDateTime.parse("2010-01-01T00:00:00.000+00:30")},
-        {"Wrong format - Offset -0030", "2010-01-01T00:00:00.000-0030", OffsetDateTime.parse("2010-01-01T00:00:00.000-00:30")},
-        {"Wrong format - Offset +01", "2010-01-01T00:00:00.000+01", OffsetDateTime.parse("2010-01-01T00:00:00.000+01:00")},
+        {"Correct datetime format - Offset Z", DATETIME, "2010-01-01T00:00:00.000Z", OffsetDateTime.parse("2010-01-01T00:00:00.000Z")},
+        {"Correct datetime format - Offset +00:00", DATETIME, "2010-01-01T00:00:00.000+00:00", OffsetDateTime.parse("2010-01-01T00:00:00.000+00:00")},
+        {"Correct datetime format - Offset -00:00", DATETIME, "2010-01-01T00:00:00.000-00:00", OffsetDateTime.parse("2010-01-01T00:00:00.000-00:00")},
+        {"Correct datetime format - Offset +03:00", DATETIME, "2010-01-01T00:00:00.000+03:00", OffsetDateTime.parse("2010-01-01T00:00:00.000+03:00")},
+        {"Correct datetime format - Offset -03:00", DATETIME, "2010-01-01T00:00:00.000-03:00", OffsetDateTime.parse("2010-01-01T00:00:00.000-03:00")},
+        {"Wrong datetime format - Offset +0030", DATETIME, "2010-01-01T00:00:00.000+0030", OffsetDateTime.parse("2010-01-01T00:00:00.000+00:30")},
+        {"Wrong datetime format - Offset -0030", DATETIME, "2010-01-01T00:00:00.000-0030", OffsetDateTime.parse("2010-01-01T00:00:00.000-00:30")},
+        {"Wrong datetime format - Offset +01", DATETIME, "2010-01-01T00:00:00.000+01", OffsetDateTime.parse("2010-01-01T00:00:00.000+01:00")},
+        {"Wrong time format - Offset +01", TIME, "08:08:00.000+01", OffsetTime.parse("08:08:00.000+01:00")}
     });
   }
 
   @Test
-  public void normalizes_and_parses_incoming_datetimes_with_minor_defects_in_their_offsets() {
-    assertThat(parseDateTime(input), is(expectedOutput));
+  public void normalizes_and_parses_incoming_datetimes_and_times_with_minor_defects_in_their_offsets() {
+    assertThat(testType == DATETIME ? parseDateTime(input) : Iso8601Helpers.parseTime(input), is(expectedOutput));
   }
 }


### PR DESCRIPTION
Closes #759

This PR has a stowaway change: removing the `WhitespaceAround` rule from the checkstyle config file:
- This rule is super noisy because every time that someone makes a change to a UI form using IntelliJ's GUI Designer, it generates code in their companion classes that offends the rule at least once. If the form has customized fonts it's even worse because there are multiple offending lines that you need to search and change *every time*.
- This rule can be annoying when dealing with no-op functions as `() -> {}`, forcing to write them with an empty space between the brackets, or simple enums such as `enum Type {A, B}`, forcing you to sandwich the enum values between whitespaces.
- I don't think this particular rule helps us to write particularly easier to read code, so I've removed it to spare us from wasting more time on it.

#### What has been done to verify that this works as intended?
- Added automated tests that verify that time values that would fail now work
- Manually exported the form attached to the issue using the UI

#### Why is this the best possible solution? Were any other approaches considered?
No other approaches were considered because there's already another precedent of the same normalization with datetime values in submissions.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It feels a pretty safe change. I can't foresee any regression risk on this one.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.