### PR TITLE
Issue 763 central cli ops

### DIFF
--- a/src/org/opendatakit/briefcase/Launcher.java
+++ b/src/org/opendatakit/briefcase/Launcher.java
@@ -21,7 +21,9 @@ import static org.opendatakit.briefcase.buildconfig.BuildConfig.SENTRY_ENABLED;
 import static org.opendatakit.briefcase.buildconfig.BuildConfig.VERSION;
 import static org.opendatakit.briefcase.model.BriefcasePreferences.BRIEFCASE_TRACKING_CONSENT_PROPERTY;
 import static org.opendatakit.briefcase.operations.ClearPreferences.CLEAR_PREFS;
+import static org.opendatakit.briefcase.operations.Common.DEPRECATED_AGGREGATE_SERVER;
 import static org.opendatakit.briefcase.operations.Common.MAX_HTTP_CONNECTIONS;
+import static org.opendatakit.briefcase.operations.Common.SERVER_URL;
 import static org.opendatakit.briefcase.operations.Export.EXPORT_FORM;
 import static org.opendatakit.briefcase.operations.ImportFromODK.IMPORT_FROM_ODK;
 import static org.opendatakit.briefcase.operations.PullFormFromAggregate.DEPRECATED_PULL_AGGREGATE;
@@ -62,6 +64,7 @@ public class Launcher {
     new Cli()
         .deprecate(DEPRECATED_PULL_AGGREGATE, PULL_AGGREGATE)
         .deprecate(DEPRECATED_PULL_IN_PARALLEL, MAX_HTTP_CONNECTIONS)
+        .deprecate(DEPRECATED_AGGREGATE_SERVER, SERVER_URL)
         .register(PULL_FORM_FROM_AGGREGATE)
         .register(PullFormFromCentral.OPERATION)
         .register(PUSH_FORM_TO_AGGREGATE)

--- a/src/org/opendatakit/briefcase/Launcher.java
+++ b/src/org/opendatakit/briefcase/Launcher.java
@@ -37,6 +37,7 @@ import io.sentry.Sentry;
 import io.sentry.SentryClient;
 import java.util.Optional;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
+import org.opendatakit.briefcase.operations.PullFormFromCentral;
 import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.common.cli.Cli;
 import org.slf4j.Logger;
@@ -62,6 +63,7 @@ public class Launcher {
         .deprecate(DEPRECATED_PULL_AGGREGATE, PULL_AGGREGATE)
         .deprecate(DEPRECATED_PULL_IN_PARALLEL, MAX_HTTP_CONNECTIONS)
         .register(PULL_FORM_FROM_AGGREGATE)
+        .register(PullFormFromCentral.OPERATION)
         .register(PUSH_FORM_TO_AGGREGATE)
         .register(IMPORT_FROM_ODK)
         .register(EXPORT_FORM)

--- a/src/org/opendatakit/briefcase/Launcher.java
+++ b/src/org/opendatakit/briefcase/Launcher.java
@@ -40,6 +40,7 @@ import io.sentry.SentryClient;
 import java.util.Optional;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.operations.PullFormFromCentral;
+import org.opendatakit.briefcase.operations.PushFormToCentral;
 import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.common.cli.Cli;
 import org.slf4j.Logger;
@@ -68,6 +69,7 @@ public class Launcher {
         .register(PULL_FORM_FROM_AGGREGATE)
         .register(PullFormFromCentral.OPERATION)
         .register(PUSH_FORM_TO_AGGREGATE)
+        .register(PushFormToCentral.OPERATION)
         .register(IMPORT_FROM_ODK)
         .register(EXPORT_FORM)
         .register(CLEAR_PREFS)

--- a/src/org/opendatakit/briefcase/operations/Common.java
+++ b/src/org/opendatakit/briefcase/operations/Common.java
@@ -15,19 +15,23 @@
  */
 package org.opendatakit.briefcase.operations;
 
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.reused.UncheckedFiles;
+import org.opendatakit.briefcase.reused.http.RequestBuilder;
 import org.opendatakit.common.cli.Param;
 
 public class Common {
   static final Param<String> STORAGE_DIR = Param.arg("sd", "storage_directory", "Briefcase storage directory");
   static final Param<String> FORM_ID = Param.arg("id", "form_id", "Form ID");
-  static final Param<String> ODK_USERNAME = Param.arg("u", "odk_username", "ODK Username");
-  static final Param<String> ODK_PASSWORD = Param.arg("p", "odk_password", "ODK Password");
-  static final Param<String> AGGREGATE_SERVER = Param.arg("url", "aggregate_url", "Aggregate server URL");
+  static final Param<String> CREDENTIALS_USERNAME = Param.arg("u", "odk_username", "ODK Username");
+  static final Param<String> CREDENTIALS_EMAIL = Param.arg("E", "odk_email", "ODK Email");
+  static final Param<String> CREDENTIALS_PASSWORD = Param.arg("p", "odk_password", "ODK Password");
+  public static final Param<String> DEPRECATED_AGGREGATE_SERVER = Param.arg("url", "aggregate_url", "Aggregate server URL");
+  public static final Param<URL> SERVER_URL = Param.arg("U", "odk_url", "ODK Server URL", RequestBuilder::url);
   public static final Param<Integer> MAX_HTTP_CONNECTIONS = Param.arg("mhc", "max_http_connections", "Maximum simultaneous HTTP connections (defaults to 8)", Integer::parseInt);
 
   static Path getOrCreateBriefcaseDir(String storageDir) {

--- a/src/org/opendatakit/briefcase/operations/Common.java
+++ b/src/org/opendatakit/briefcase/operations/Common.java
@@ -27,6 +27,7 @@ import org.opendatakit.common.cli.Param;
 public class Common {
   static final Param<String> STORAGE_DIR = Param.arg("sd", "storage_directory", "Briefcase storage directory");
   static final Param<String> FORM_ID = Param.arg("id", "form_id", "Form ID");
+  static final Param<Integer> PROJECT_ID = Param.arg("pid", "project_id", "ODK Project ID number", Integer::parseInt);
   static final Param<String> CREDENTIALS_USERNAME = Param.arg("u", "odk_username", "ODK Username");
   static final Param<String> CREDENTIALS_EMAIL = Param.arg("E", "odk_email", "ODK Email");
   static final Param<String> CREDENTIALS_PASSWORD = Param.arg("p", "odk_password", "ODK Password");

--- a/src/org/opendatakit/briefcase/operations/PullFormFromCentral.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromCentral.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.opendatakit.briefcase.operations;
+
+import static java.util.stream.Collectors.toList;
+import static org.opendatakit.briefcase.operations.Common.AGGREGATE_SERVER;
+import static org.opendatakit.briefcase.operations.Common.FORM_ID;
+import static org.opendatakit.briefcase.operations.Common.MAX_HTTP_CONNECTIONS;
+import static org.opendatakit.briefcase.operations.Common.ODK_PASSWORD;
+import static org.opendatakit.briefcase.operations.Common.ODK_USERNAME;
+import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
+import static org.opendatakit.briefcase.reused.http.Http.DEFAULT_HTTP_CONNECTIONS;
+
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.opendatakit.briefcase.model.BriefcasePreferences;
+import org.opendatakit.briefcase.model.FormStatus;
+import org.opendatakit.briefcase.model.FormStatusEvent;
+import org.opendatakit.briefcase.model.RemoteFormDefinition;
+import org.opendatakit.briefcase.pull.aggregate.Cursor;
+import org.opendatakit.briefcase.pull.aggregate.PullFromAggregate;
+import org.opendatakit.briefcase.reused.BriefcaseException;
+import org.opendatakit.briefcase.reused.Optionals;
+import org.opendatakit.briefcase.reused.http.CommonsHttp;
+import org.opendatakit.briefcase.reused.http.Credentials;
+import org.opendatakit.briefcase.reused.http.Http;
+import org.opendatakit.briefcase.reused.http.RequestBuilder;
+import org.opendatakit.briefcase.reused.http.response.Response;
+import org.opendatakit.briefcase.reused.job.JobsRunner;
+import org.opendatakit.briefcase.reused.transfer.AggregateServer;
+import org.opendatakit.briefcase.transfer.TransferForms;
+import org.opendatakit.briefcase.ui.pull.PullPanel;
+import org.opendatakit.briefcase.util.FormCache;
+import org.opendatakit.common.cli.Operation;
+import org.opendatakit.common.cli.Param;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PullFormFromCentral {
+  private static final Logger log = LoggerFactory.getLogger(PullFormFromCentral.class);
+  public static final Param<Void> DEPRECATED_PULL_AGGREGATE = Param.flag("pa", "pull_aggregate", "(Deprecated. Use -plla instead)");
+  public static final Param<Void> PULL_AGGREGATE = Param.flag("plla", "pull_aggregate", "Pull form from an Aggregate instance");
+  public static final Param<Void> DEPRECATED_PULL_IN_PARALLEL = Param.flag("pp", "parallel_pull", "(Deprecated. Use -mhc instead)");
+  private static final Param<Void> RESUME_LAST_PULL = Param.flag("sfl", "start_from_last", "Start pull from last submission pulled");
+  private static final Param<LocalDate> START_FROM_DATE = Param.arg("sfd", "start_from_date", "Start pull from date", LocalDate::parse);
+  private static final Param<Void> INCLUDE_INCOMPLETE = Param.flag("ii", "include_incomplete", "Include incomplete submissions");
+
+  public static Operation PULL_FORM_FROM_AGGREGATE = Operation.of(
+      PULL_AGGREGATE,
+      args -> pullFormFromAggregate(
+          args.get(STORAGE_DIR),
+          args.getOptional(FORM_ID),
+          args.get(ODK_USERNAME),
+          args.get(ODK_PASSWORD),
+          args.get(AGGREGATE_SERVER),
+          args.has(RESUME_LAST_PULL),
+          args.getOptional(START_FROM_DATE),
+          args.has(INCLUDE_INCOMPLETE),
+          args.getOptional(MAX_HTTP_CONNECTIONS)
+      ),
+      Arrays.asList(STORAGE_DIR, ODK_USERNAME, ODK_PASSWORD, AGGREGATE_SERVER),
+      Arrays.asList(RESUME_LAST_PULL, INCLUDE_INCOMPLETE, FORM_ID, START_FROM_DATE, MAX_HTTP_CONNECTIONS)
+  );
+
+  public static void pullFormFromAggregate(String storageDir, Optional<String> formId, String username, String password, String server, boolean resumeLastPull, Optional<LocalDate> startFromDate, boolean includeIncomplete, Optional<Integer> maybeMaxHttpConnections) {
+    CliEventsCompanion.attach(log);
+    Path briefcaseDir = Common.getOrCreateBriefcaseDir(storageDir);
+    FormCache formCache = FormCache.from(briefcaseDir);
+    formCache.update();
+    BriefcasePreferences appPreferences = BriefcasePreferences.appScoped();
+    appPreferences.setStorageDir(briefcaseDir);
+    BriefcasePreferences tabPreferences = BriefcasePreferences.forClass(PullPanel.class);
+
+    int maxHttpConnections = Optionals.race(
+        maybeMaxHttpConnections,
+        appPreferences.getMaxHttpConnections()
+    ).orElse(DEFAULT_HTTP_CONNECTIONS);
+    Http http = appPreferences.getHttpProxy()
+        .map(host -> CommonsHttp.of(maxHttpConnections, host))
+        .orElseGet(() -> CommonsHttp.of(maxHttpConnections));
+
+    AggregateServer aggregateServer = AggregateServer.authenticated(RequestBuilder.url(server), new Credentials(username, password));
+
+    Response<List<RemoteFormDefinition>> response = http.execute(aggregateServer.getFormListRequest());
+    if (!response.isSuccess()) {
+      System.err.println(response.isRedirection()
+          ? "Error connecting to Aggregate: Redirection detected"
+          : response.isUnauthorized()
+          ? "Error connecting to Aggregate: Wrong credentials"
+          : response.isNotFound()
+          ? "Error connecting to Aggregate: Aggregate not found"
+          : "Error connecting to Aggregate");
+      return;
+    }
+
+    List<FormStatus> filteredForms = response.orElseThrow(BriefcaseException::new)
+        .stream()
+        .filter(f -> formId.map(id -> f.getFormId().equals(id)).orElse(true))
+        .map(FormStatus::new)
+        .collect(toList());
+
+    if (formId.isPresent() && filteredForms.isEmpty())
+      throw new BriefcaseException("Form " + formId.get() + " not found");
+
+    TransferForms forms = TransferForms.empty();
+    forms.load(filteredForms);
+    forms.selectAll();
+
+    PullFromAggregate pullOp = new PullFromAggregate(http, aggregateServer, briefcaseDir, appPreferences, includeIncomplete, PullFormFromCentral::onEvent);
+    JobsRunner.launchAsync(
+        forms.map(form -> pullOp.pull(form, resolveCursor(
+            resumeLastPull,
+            startFromDate,
+            appPreferences,
+            tabPreferences,
+            form
+        ))),
+        PullFormFromCentral::onError
+    ).waitForCompletion();
+    System.out.println();
+    System.out.println("All operations completed");
+    System.out.println();
+  }
+
+  private static Optional<Cursor> resolveCursor(boolean resumeLastPull, Optional<LocalDate> startFromDate, BriefcasePreferences appPreferences, BriefcasePreferences localPreferences, FormStatus form) {
+    return Optionals.race(
+        startFromDate.map(Cursor::of),
+        resumeLastPull
+            ? Optionals.race(Cursor.readPrefs(form, appPreferences), Cursor.readPrefs(form, localPreferences))
+            : Optional.empty()
+    );
+  }
+
+  private static void onEvent(FormStatusEvent event) {
+    System.out.println(event.getStatus().getFormName() + " - " + event.getStatusString());
+    // The PullFromAggregateTracker already logs normal events
+  }
+
+  private static void onError(Throwable e) {
+    System.err.println("Error pulling a form: " + e.getMessage() + " (see the logs for more info)");
+    log.error("Error pulling a form", e);
+  }
+
+}

--- a/src/org/opendatakit/briefcase/operations/PullFormFromCentral.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromCentral.java
@@ -16,12 +16,14 @@
 package org.opendatakit.briefcase.operations;
 
 import static java.util.stream.Collectors.toList;
+import static org.opendatakit.briefcase.operations.Common.CREDENTIALS_EMAIL;
+import static org.opendatakit.briefcase.operations.Common.CREDENTIALS_PASSWORD;
 import static org.opendatakit.briefcase.operations.Common.FORM_ID;
 import static org.opendatakit.briefcase.operations.Common.MAX_HTTP_CONNECTIONS;
+import static org.opendatakit.briefcase.operations.Common.SERVER_URL;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 import static org.opendatakit.briefcase.reused.http.Http.DEFAULT_HTTP_CONNECTIONS;
 
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -36,7 +38,6 @@ import org.opendatakit.briefcase.reused.Optionals;
 import org.opendatakit.briefcase.reused.http.CommonsHttp;
 import org.opendatakit.briefcase.reused.http.Credentials;
 import org.opendatakit.briefcase.reused.http.Http;
-import org.opendatakit.briefcase.reused.http.RequestBuilder;
 import org.opendatakit.briefcase.reused.http.response.Response;
 import org.opendatakit.briefcase.reused.job.JobsRunner;
 import org.opendatakit.briefcase.reused.transfer.CentralServer;
@@ -51,16 +52,13 @@ import org.slf4j.LoggerFactory;
 public class PullFormFromCentral {
   private static final Logger log = LoggerFactory.getLogger(PullFormFromCentral.class);
   private static final Param<Void> PULL_FROM_CENTRAL = Param.flag("pllc", "pull_central", "Pull form from a Central server");
-  private static final Param<URL> SERVER_URL = Param.arg("U", "url", "Central url", RequestBuilder::url);
-  private static final Param<Integer> PROJECT_ID = Param.arg("pid", "project_id", "Central Project ID number", Integer::parseInt);
-  private static final Param<String> EMAIL = Param.arg("E", "email", "Central user account email");
-  private static final Param<String> PASSWORD = Param.arg("p", "password", "Central user account password");
+  private static final Param<Integer> PROJECT_ID = Param.arg("pid", "project_id", "ODK Project ID number", Integer::parseInt);
 
 
   public static Operation OPERATION = Operation.of(
       PULL_FROM_CENTRAL,
       PullFormFromCentral::pullFormFromAggregate,
-      Arrays.asList(STORAGE_DIR, SERVER_URL, PROJECT_ID, EMAIL, PASSWORD),
+      Arrays.asList(STORAGE_DIR, SERVER_URL, PROJECT_ID, CREDENTIALS_EMAIL, CREDENTIALS_PASSWORD),
       Arrays.asList(FORM_ID, MAX_HTTP_CONNECTIONS)
   );
 
@@ -80,7 +78,7 @@ public class PullFormFromCentral {
         .map(host -> CommonsHttp.of(maxHttpConnections, host))
         .orElseGet(() -> CommonsHttp.of(maxHttpConnections));
 
-    CentralServer server = CentralServer.of(args.get(SERVER_URL), args.get(PROJECT_ID), new Credentials(args.get(EMAIL), args.get(PASSWORD)));
+    CentralServer server = CentralServer.of(args.get(SERVER_URL), args.get(PROJECT_ID), new Credentials(args.get(CREDENTIALS_EMAIL), args.get(CREDENTIALS_PASSWORD)));
 
     String token = http.execute(server.getSessionTokenRequest())
         .orElseThrow(() -> new BriefcaseException("Can't authenticate with ODK Central"));

--- a/src/org/opendatakit/briefcase/operations/PullFormFromCentral.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromCentral.java
@@ -57,12 +57,12 @@ public class PullFormFromCentral {
 
   public static Operation OPERATION = Operation.of(
       PULL_FROM_CENTRAL,
-      PullFormFromCentral::pullFormFromAggregate,
+      PullFormFromCentral::pullFromCentral,
       Arrays.asList(STORAGE_DIR, SERVER_URL, PROJECT_ID, CREDENTIALS_EMAIL, CREDENTIALS_PASSWORD),
       Arrays.asList(FORM_ID, MAX_HTTP_CONNECTIONS)
   );
 
-  private static void pullFormFromAggregate(Args args) {
+  private static void pullFromCentral(Args args) {
     CliEventsCompanion.attach(log);
     Path briefcaseDir = Common.getOrCreateBriefcaseDir(args.get(STORAGE_DIR));
     FormCache formCache = FormCache.from(briefcaseDir);
@@ -86,12 +86,12 @@ public class PullFormFromCentral {
     Response<List<RemoteFormDefinition>> response = http.execute(server.getFormsListRequest(token));
     if (!response.isSuccess()) {
       System.err.println(response.isRedirection()
-          ? "Error connecting to Aggregate: Redirection detected"
+          ? "Error connecting to Central: Redirection detected"
           : response.isUnauthorized()
-          ? "Error connecting to Aggregate: Wrong credentials"
+          ? "Error connecting to Central: Wrong credentials"
           : response.isNotFound()
-          ? "Error connecting to Aggregate: Aggregate not found"
-          : "Error connecting to Aggregate");
+          ? "Error connecting to Central: Central not found"
+          : "Error connecting to Central");
       return;
     }
 
@@ -122,7 +122,7 @@ public class PullFormFromCentral {
 
   private static void onEvent(FormStatusEvent event) {
     System.out.println(event.getStatus().getFormName() + " - " + event.getStatusString());
-    // The PullFromAggregateTracker already logs normal events
+    // The tracker already logs normal events
   }
 
   private static void onError(Throwable e) {

--- a/src/org/opendatakit/briefcase/operations/PullFormFromCentral.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromCentral.java
@@ -20,6 +20,7 @@ import static org.opendatakit.briefcase.operations.Common.CREDENTIALS_EMAIL;
 import static org.opendatakit.briefcase.operations.Common.CREDENTIALS_PASSWORD;
 import static org.opendatakit.briefcase.operations.Common.FORM_ID;
 import static org.opendatakit.briefcase.operations.Common.MAX_HTTP_CONNECTIONS;
+import static org.opendatakit.briefcase.operations.Common.PROJECT_ID;
 import static org.opendatakit.briefcase.operations.Common.SERVER_URL;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 import static org.opendatakit.briefcase.reused.http.Http.DEFAULT_HTTP_CONNECTIONS;
@@ -52,7 +53,6 @@ import org.slf4j.LoggerFactory;
 public class PullFormFromCentral {
   private static final Logger log = LoggerFactory.getLogger(PullFormFromCentral.class);
   private static final Param<Void> PULL_FROM_CENTRAL = Param.flag("pllc", "pull_central", "Pull form from a Central server");
-  private static final Param<Integer> PROJECT_ID = Param.arg("pid", "project_id", "ODK Project ID number", Integer::parseInt);
 
 
   public static Operation OPERATION = Operation.of(

--- a/src/org/opendatakit/briefcase/operations/PushFormToCentral.java
+++ b/src/org/opendatakit/briefcase/operations/PushFormToCentral.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.opendatakit.briefcase.operations;
+
+import static org.opendatakit.briefcase.operations.Common.CREDENTIALS_PASSWORD;
+import static org.opendatakit.briefcase.operations.Common.CREDENTIALS_USERNAME;
+import static org.opendatakit.briefcase.operations.Common.FORM_ID;
+import static org.opendatakit.briefcase.operations.Common.MAX_HTTP_CONNECTIONS;
+import static org.opendatakit.briefcase.operations.Common.SERVER_URL;
+import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
+import static org.opendatakit.briefcase.reused.http.Http.DEFAULT_HTTP_CONNECTIONS;
+
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Optional;
+import org.opendatakit.briefcase.model.BriefcasePreferences;
+import org.opendatakit.briefcase.model.FormStatus;
+import org.opendatakit.briefcase.model.FormStatusEvent;
+import org.opendatakit.briefcase.push.aggregate.PushToAggregate;
+import org.opendatakit.briefcase.reused.BriefcaseException;
+import org.opendatakit.briefcase.reused.Optionals;
+import org.opendatakit.briefcase.reused.http.CommonsHttp;
+import org.opendatakit.briefcase.reused.http.Credentials;
+import org.opendatakit.briefcase.reused.http.Http;
+import org.opendatakit.briefcase.reused.http.response.Response;
+import org.opendatakit.briefcase.reused.job.JobsRunner;
+import org.opendatakit.briefcase.reused.transfer.AggregateServer;
+import org.opendatakit.briefcase.transfer.TransferForms;
+import org.opendatakit.briefcase.util.FormCache;
+import org.opendatakit.common.cli.Operation;
+import org.opendatakit.common.cli.Param;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PushFormToCentral {
+  private static final Logger log = LoggerFactory.getLogger(PushFormToCentral.class);
+  private static final Param<Void> PUSH_AGGREGATE = Param.flag("psha", "push_aggregate", "Push form to an Aggregate instance");
+  private static final Param<Void> FORCE_SEND_BLANK = Param.flag("fsb", "force_send_blank", "Force sending the blank form to the Aggregate instance");
+
+  public static Operation OPERATION = Operation.of(
+      PUSH_AGGREGATE,
+      args -> pushFormToAggregate(
+          args.get(STORAGE_DIR),
+          args.get(FORM_ID),
+          args.get(CREDENTIALS_USERNAME),
+          args.get(CREDENTIALS_PASSWORD),
+          args.get(SERVER_URL),
+          args.has(FORCE_SEND_BLANK),
+          args.getOptional(MAX_HTTP_CONNECTIONS)
+      ),
+      Arrays.asList(STORAGE_DIR, FORM_ID, CREDENTIALS_USERNAME, CREDENTIALS_PASSWORD, SERVER_URL),
+      Arrays.asList(FORCE_SEND_BLANK, MAX_HTTP_CONNECTIONS)
+  );
+
+  private static void pushFormToAggregate(String storageDir, String formid, String username, String password, URL server, boolean forceSendBlank, Optional<Integer> maybeMaxConnections) {
+    CliEventsCompanion.attach(log);
+    Path briefcaseDir = Common.getOrCreateBriefcaseDir(storageDir);
+    FormCache formCache = FormCache.from(briefcaseDir);
+    formCache.update();
+    BriefcasePreferences appPreferences = BriefcasePreferences.appScoped();
+
+    int maxHttpConnections = Optionals.race(
+        maybeMaxConnections,
+        appPreferences.getMaxHttpConnections()
+    ).orElse(DEFAULT_HTTP_CONNECTIONS);
+    Http http = appPreferences.getHttpProxy()
+        .map(host -> CommonsHttp.of(maxHttpConnections, host))
+        .orElseGet(() -> CommonsHttp.of(maxHttpConnections));
+
+    AggregateServer aggregateServer = AggregateServer.authenticated(server, new Credentials(username, password));
+
+    Response response = http.execute(aggregateServer.getPushFormPreflightRequest());
+    if (!response.isSuccess()) {
+      System.err.println(response.isRedirection()
+          ? "Error connecting to Aggregate: Redirection detected"
+          : response.isUnauthorized()
+          ? "Error connecting to Aggregate: Wrong credentials"
+          : response.isNotFound()
+          ? "Error connecting to Aggregate: Aggregate not found"
+          : "Error connecting to Aggregate");
+      return;
+    }
+    Optional<FormStatus> maybeFormStatus = formCache.getForms().stream()
+        .filter(form -> form.getFormId().equals(formid))
+        .map(FormStatus::new)
+        .findFirst();
+
+    FormStatus form = maybeFormStatus.orElseThrow(() -> new BriefcaseException("Form " + formid + " not found"));
+    TransferForms forms = TransferForms.of(form);
+    forms.selectAll();
+
+    PushToAggregate pushOp = new PushToAggregate(http, aggregateServer, briefcaseDir, forceSendBlank, PushFormToCentral::onEvent);
+    JobsRunner.launchAsync(forms.map(pushOp::push), PushFormToCentral::onError).waitForCompletion();
+    System.out.println();
+    System.out.println("All operations completed");
+    System.out.println();
+  }
+
+  private static void onEvent(FormStatusEvent event) {
+    System.out.println(event.getStatus().getFormName() + " - " + event.getStatusString());
+    // The PullTracker already logs normal events
+  }
+
+  private static void onError(Throwable e) {
+    System.err.println("Error pushing a form: " + e.getMessage() + " (see the logs for more info)");
+    log.error("Error pushing a form", e);
+  }
+
+}

--- a/src/org/opendatakit/briefcase/operations/PushFormToCentral.java
+++ b/src/org/opendatakit/briefcase/operations/PushFormToCentral.java
@@ -17,7 +17,6 @@ package org.opendatakit.briefcase.operations;
 
 import static org.opendatakit.briefcase.operations.Common.CREDENTIALS_EMAIL;
 import static org.opendatakit.briefcase.operations.Common.CREDENTIALS_PASSWORD;
-import static org.opendatakit.briefcase.operations.Common.CREDENTIALS_USERNAME;
 import static org.opendatakit.briefcase.operations.Common.FORM_ID;
 import static org.opendatakit.briefcase.operations.Common.MAX_HTTP_CONNECTIONS;
 import static org.opendatakit.briefcase.operations.Common.PROJECT_ID;
@@ -32,7 +31,6 @@ import java.util.Optional;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.FormStatusEvent;
-import org.opendatakit.briefcase.push.aggregate.PushToAggregate;
 import org.opendatakit.briefcase.push.central.PushToCentral;
 import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.reused.Optionals;

--- a/src/org/opendatakit/briefcase/operations/PushFormToCentral.java
+++ b/src/org/opendatakit/briefcase/operations/PushFormToCentral.java
@@ -15,32 +15,35 @@
  */
 package org.opendatakit.briefcase.operations;
 
+import static org.opendatakit.briefcase.operations.Common.CREDENTIALS_EMAIL;
 import static org.opendatakit.briefcase.operations.Common.CREDENTIALS_PASSWORD;
 import static org.opendatakit.briefcase.operations.Common.CREDENTIALS_USERNAME;
 import static org.opendatakit.briefcase.operations.Common.FORM_ID;
 import static org.opendatakit.briefcase.operations.Common.MAX_HTTP_CONNECTIONS;
+import static org.opendatakit.briefcase.operations.Common.PROJECT_ID;
 import static org.opendatakit.briefcase.operations.Common.SERVER_URL;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 import static org.opendatakit.briefcase.reused.http.Http.DEFAULT_HTTP_CONNECTIONS;
 
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.FormStatusEvent;
 import org.opendatakit.briefcase.push.aggregate.PushToAggregate;
+import org.opendatakit.briefcase.push.central.PushToCentral;
 import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.reused.Optionals;
 import org.opendatakit.briefcase.reused.http.CommonsHttp;
 import org.opendatakit.briefcase.reused.http.Credentials;
 import org.opendatakit.briefcase.reused.http.Http;
-import org.opendatakit.briefcase.reused.http.response.Response;
 import org.opendatakit.briefcase.reused.job.JobsRunner;
-import org.opendatakit.briefcase.reused.transfer.AggregateServer;
+import org.opendatakit.briefcase.reused.transfer.CentralServer;
 import org.opendatakit.briefcase.transfer.TransferForms;
 import org.opendatakit.briefcase.util.FormCache;
+import org.opendatakit.common.cli.Args;
 import org.opendatakit.common.cli.Operation;
 import org.opendatakit.common.cli.Param;
 import org.slf4j.Logger;
@@ -48,62 +51,46 @@ import org.slf4j.LoggerFactory;
 
 public class PushFormToCentral {
   private static final Logger log = LoggerFactory.getLogger(PushFormToCentral.class);
-  private static final Param<Void> PUSH_AGGREGATE = Param.flag("psha", "push_aggregate", "Push form to an Aggregate instance");
-  private static final Param<Void> FORCE_SEND_BLANK = Param.flag("fsb", "force_send_blank", "Force sending the blank form to the Aggregate instance");
+  private static final Param<Void> PUSH_TO_CENTRAL = Param.flag("pshc", "push_central", "Push form to a Central server");
 
   public static Operation OPERATION = Operation.of(
-      PUSH_AGGREGATE,
-      args -> pushFormToAggregate(
-          args.get(STORAGE_DIR),
-          args.get(FORM_ID),
-          args.get(CREDENTIALS_USERNAME),
-          args.get(CREDENTIALS_PASSWORD),
-          args.get(SERVER_URL),
-          args.has(FORCE_SEND_BLANK),
-          args.getOptional(MAX_HTTP_CONNECTIONS)
-      ),
-      Arrays.asList(STORAGE_DIR, FORM_ID, CREDENTIALS_USERNAME, CREDENTIALS_PASSWORD, SERVER_URL),
-      Arrays.asList(FORCE_SEND_BLANK, MAX_HTTP_CONNECTIONS)
+      PUSH_TO_CENTRAL,
+      PushFormToCentral::pushToCentral,
+      Arrays.asList(STORAGE_DIR, FORM_ID, PROJECT_ID, CREDENTIALS_EMAIL, CREDENTIALS_PASSWORD, SERVER_URL),
+      Collections.singletonList(MAX_HTTP_CONNECTIONS)
   );
 
-  private static void pushFormToAggregate(String storageDir, String formid, String username, String password, URL server, boolean forceSendBlank, Optional<Integer> maybeMaxConnections) {
+  private static void pushToCentral(Args args) {
     CliEventsCompanion.attach(log);
-    Path briefcaseDir = Common.getOrCreateBriefcaseDir(storageDir);
+    Path briefcaseDir = Common.getOrCreateBriefcaseDir(args.get(STORAGE_DIR));
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();
     BriefcasePreferences appPreferences = BriefcasePreferences.appScoped();
 
     int maxHttpConnections = Optionals.race(
-        maybeMaxConnections,
+        args.getOptional(MAX_HTTP_CONNECTIONS),
         appPreferences.getMaxHttpConnections()
     ).orElse(DEFAULT_HTTP_CONNECTIONS);
     Http http = appPreferences.getHttpProxy()
         .map(host -> CommonsHttp.of(maxHttpConnections, host))
         .orElseGet(() -> CommonsHttp.of(maxHttpConnections));
 
-    AggregateServer aggregateServer = AggregateServer.authenticated(server, new Credentials(username, password));
+    CentralServer server = CentralServer.of(args.get(SERVER_URL), args.get(PROJECT_ID), new Credentials(args.get(CREDENTIALS_EMAIL), args.get(CREDENTIALS_PASSWORD)));
 
-    Response response = http.execute(aggregateServer.getPushFormPreflightRequest());
-    if (!response.isSuccess()) {
-      System.err.println(response.isRedirection()
-          ? "Error connecting to Aggregate: Redirection detected"
-          : response.isUnauthorized()
-          ? "Error connecting to Aggregate: Wrong credentials"
-          : response.isNotFound()
-          ? "Error connecting to Aggregate: Aggregate not found"
-          : "Error connecting to Aggregate");
-      return;
-    }
+    String token = http.execute(server.getSessionTokenRequest())
+        .orElseThrow(() -> new BriefcaseException("Can't authenticate with ODK Central"));
+
+    String formId = args.get(FORM_ID);
     Optional<FormStatus> maybeFormStatus = formCache.getForms().stream()
-        .filter(form -> form.getFormId().equals(formid))
+        .filter(form -> form.getFormId().equals(formId))
         .map(FormStatus::new)
         .findFirst();
 
-    FormStatus form = maybeFormStatus.orElseThrow(() -> new BriefcaseException("Form " + formid + " not found"));
+    FormStatus form = maybeFormStatus.orElseThrow(() -> new BriefcaseException("Form " + formId + " not found"));
     TransferForms forms = TransferForms.of(form);
     forms.selectAll();
 
-    PushToAggregate pushOp = new PushToAggregate(http, aggregateServer, briefcaseDir, forceSendBlank, PushFormToCentral::onEvent);
+    PushToCentral pushOp = new PushToCentral(http, server, briefcaseDir, token, PushFormToCentral::onEvent);
     JobsRunner.launchAsync(forms.map(pushOp::push), PushFormToCentral::onError).waitForCompletion();
     System.out.println();
     System.out.println("All operations completed");

--- a/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
+++ b/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
@@ -34,6 +34,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.opendatakit.briefcase.reused.BriefcaseException;
+import org.opendatakit.briefcase.reused.http.RequestBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -307,7 +308,7 @@ public class BriefcaseCLI {
         throw new BriefcaseException("You need to provide a form ID (legacy CLI)");
 
       if (odkDir == null && server != null)
-        pullFormFromAggregate(storageDir, Optional.ofNullable(formid), username, password, server, false, Optional.empty(), false, Optional.of(1));
+        pullFormFromAggregate(storageDir, Optional.ofNullable(formid), username, password, RequestBuilder.url(server), false, Optional.empty(), false, Optional.of(1));
 
       if (exportPath != null)
         export(


### PR DESCRIPTION
Closes #763

This PR adds new pull from Central and push to Central CLI operations.
This PR deprecates `-url --aggregate_url` (see below)

#### What has been done to verify that this works as intended?
Run both CLI operations using the `all-widgets` form and the Central sandbox at https://sandbox.central.opendatakit.org

#### Why is this the best possible solution? Were any other approaches considered?
This PR replicates the same things we already are doing for Aggregate server.

Instead of having shared args for things like the server's url and credentials, I considered having a separate set of args, but it felt bloated and not very reasonable overall.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

To be able to share args for the server's url and credentials, I had to review the language on their shortcode, longcode, and descriptions, and I found an irreconcilable issue with the `-url --aggregate_url` argument. I had to either change the longcode to `--server_url` or deprecate it and create a new arg. I opted for the latter, which means that users won't be able to continue using `-url` and will be prompted to use the new `-U` CLI arg.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Yes! https://github.com/opendatakit/docs/issues/1069