### PR TITLE
Provide fallback cursor implementation

### DIFF
--- a/src/org/opendatakit/briefcase/pull/aggregate/Cursor.java
+++ b/src/org/opendatakit/briefcase/pull/aggregate/Cursor.java
@@ -81,7 +81,8 @@ public interface Cursor<T extends Cursor> extends Comparable<T> {
   static Cursor from(String value) {
     return firstNonFailing(
         () -> AggregateCursor.from(value),
-        () -> OnaCursor.from(value)
+        () -> OnaCursor.from(value),
+        () -> OpaqueCursor.from(value)
     ).orElseThrow(() -> new BriefcaseException("Unknown cursor format"));
   }
 
@@ -99,8 +100,10 @@ public interface Cursor<T extends Cursor> extends Comparable<T> {
 
 
   enum Type {
+
     AGGREGATE("aggregate", AggregateCursor::from),
-    ONA("ona", OnaCursor::from);
+    ONA("ona", OnaCursor::from),
+    OPAQUE("opaque", OpaqueCursor::from);
 
     private final String name;
     private final Function<String, Cursor> factory;
@@ -115,6 +118,8 @@ public interface Cursor<T extends Cursor> extends Comparable<T> {
         return AGGREGATE;
       if (type.equals("ona"))
         return ONA;
+      if (type.equals("opaque"))
+        return OPAQUE;
       throw new BriefcaseException("Unknown cursor type " + type);
     }
 

--- a/src/org/opendatakit/briefcase/pull/aggregate/Cursor.java
+++ b/src/org/opendatakit/briefcase/pull/aggregate/Cursor.java
@@ -118,9 +118,7 @@ public interface Cursor<T extends Cursor> extends Comparable<T> {
         return AGGREGATE;
       if (type.equals("ona"))
         return ONA;
-      if (type.equals("opaque"))
-        return OPAQUE;
-      throw new BriefcaseException("Unknown cursor type " + type);
+      return OPAQUE;
     }
 
     public Cursor create(String rawValue) {

--- a/src/org/opendatakit/briefcase/pull/aggregate/OpaqueCursor.java
+++ b/src/org/opendatakit/briefcase/pull/aggregate/OpaqueCursor.java
@@ -1,0 +1,40 @@
+package org.opendatakit.briefcase.pull.aggregate;
+
+import java.util.Optional;
+import org.opendatakit.briefcase.model.BriefcasePreferences;
+import org.opendatakit.briefcase.model.FormStatus;
+
+public class OpaqueCursor implements Cursor<OpaqueCursor> {
+
+  private final String value;
+
+  private OpaqueCursor(String value) {
+    this.value = value;
+  }
+
+  public static Cursor from(String rawValue) {
+    return new OpaqueCursor(Optional.ofNullable(rawValue).orElse(""));
+  }
+
+  @Override
+  public String getValue() {
+    return Optional.ofNullable(value).map(Object::toString).orElse("");
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return !Optional.ofNullable(value).isPresent();
+  }
+
+  @Override
+  public void storePrefs(FormStatus form, BriefcasePreferences prefs) {
+    prefs.put(form.getFormId() + LAST_CURSOR_PREFERENCE_KEY_SUFFIX, getValue());
+    prefs.put(form.getFormId() + LAST_CURSOR_TYPE_PREFERENCE_KEY_SUFFIX, Type.OPAQUE.getName());
+  }
+
+  @Override
+  public int compareTo(OpaqueCursor o) {
+    return Optional.ofNullable(value).orElse("")
+        .compareTo(Optional.ofNullable(o.value).orElse(""));
+  }
+}

--- a/test/java/org/opendatakit/briefcase/pull/aggregate/AggregateCursorTest.java
+++ b/test/java/org/opendatakit/briefcase/pull/aggregate/AggregateCursorTest.java
@@ -29,7 +29,7 @@ import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.InMemoryPreferences;
 
-public class OpenRosaCursorTest {
+public class AggregateCursorTest {
 
   @Test
   @SuppressWarnings("unchecked")

--- a/test/java/org/opendatakit/briefcase/pull/aggregate/CursorHelpers.java
+++ b/test/java/org/opendatakit/briefcase/pull/aggregate/CursorHelpers.java
@@ -1,0 +1,20 @@
+package org.opendatakit.briefcase.pull.aggregate;
+
+import java.util.UUID;
+
+class CursorHelpers {
+  static String buildCursorXml(String lastUpdate) {
+    return buildCursorXml(lastUpdate, UUID.randomUUID().toString());
+  }
+
+  static String buildCursorXml(String lastUpdate, String lastId) {
+    return "" +
+        "<cursor xmlns=\"http://www.opendatakit.org/cursor\">\n" +
+        "<attributeName>_LAST_UPDATE_DATE</attributeName>\n" +
+        "<attributeValue>" + lastUpdate + "</attributeValue>\n" +
+        "<uriLastReturnedValue>" + lastId + "</uriLastReturnedValue>\n" +
+        "<isForwardCursor>true</isForwardCursor>\n" +
+        "</cursor>" +
+        "";
+  }
+}

--- a/test/java/org/opendatakit/briefcase/pull/aggregate/CursorTest.java
+++ b/test/java/org/opendatakit/briefcase/pull/aggregate/CursorTest.java
@@ -1,0 +1,21 @@
+package org.opendatakit.briefcase.pull.aggregate;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.opendatakit.briefcase.pull.aggregate.CursorHelpers.buildCursorXml;
+
+import org.junit.Test;
+
+public class CursorTest {
+  @Test
+  public void knows_how_to_build_cursor_objects_from_a_range_of_specific_formats() {
+    assertThat(Cursor.from(buildCursorXml("2019-01-01T00:00:00.000Z")), is(instanceOf(AggregateCursor.class)));
+    assertThat(Cursor.from("12345"), is(instanceOf(OnaCursor.class)));
+  }
+
+  @Test
+  public void falls_back_to_an_opaque_cursor_implementation() {
+    assertThat(Cursor.from("some opaque cursor"), is(instanceOf(OpaqueCursor.class)));
+  }
+}

--- a/test/java/org/opendatakit/briefcase/pull/aggregate/OpenRosaCursorTest.java
+++ b/test/java/org/opendatakit/briefcase/pull/aggregate/OpenRosaCursorTest.java
@@ -21,9 +21,9 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
 import static org.opendatakit.briefcase.model.FormStatusBuilder.buildFormStatus;
+import static org.opendatakit.briefcase.pull.aggregate.CursorHelpers.buildCursorXml;
 
 import java.util.Optional;
-import java.util.UUID;
 import org.junit.Test;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
@@ -31,22 +31,8 @@ import org.opendatakit.briefcase.model.InMemoryPreferences;
 
 public class OpenRosaCursorTest {
 
-  public static String buildCursorXml(String lastUpdate) {
-    return buildCursorXml(lastUpdate, UUID.randomUUID().toString());
-  }
-
-  public static String buildCursorXml(String lastUpdate, String lastId) {
-    return "" +
-        "<cursor xmlns=\"http://www.opendatakit.org/cursor\">\n" +
-        "<attributeName>_LAST_UPDATE_DATE</attributeName>\n" +
-        "<attributeValue>" + lastUpdate + "</attributeValue>\n" +
-        "<uriLastReturnedValue>" + lastId + "</uriLastReturnedValue>\n" +
-        "<isForwardCursor>true</isForwardCursor>\n" +
-        "</cursor>" +
-        "";
-  }
-
   @Test
+  @SuppressWarnings("unchecked")
   public void fixes_dates_while_parsing_cursors() {
     assertThat(
         Cursor.from(buildCursorXml("2010-01-01T00:00:00.000+0800")),


### PR DESCRIPTION
Closes #768 

#### What has been done to verify that this works as intended?
Since we can't test every aggregate compatible server, I've added automated tests covering the fallback option.

#### Why is this the best possible solution? Were any other approaches considered?
This is what should have been shipped in v1.16 in the first place. An opaque cursor implementation as a fallback for non-aggregate server is the most reasonable way to maintain compatibility with non aggregate servers.

Code with the solution was cherry picked from https://github.com/cims-bioko/briefcase/commit/91ca88ac274a3c8e52222127c69c9119c8a64d96 (thanks, @batkinson!)

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Users using non-aggregate servers should be able to pull forms from their servers after this PR gets merged.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.
