### PR TITLE
Issue 777 Latest Central rejects multiple simultaneous auth methods

### DIFF
--- a/src/org/opendatakit/briefcase/reused/http/CommonsHttp.java
+++ b/src/org/opendatakit/briefcase/reused/http/CommonsHttp.java
@@ -16,7 +16,7 @@
 
 package org.opendatakit.briefcase.reused.http;
 
-import static org.apache.http.client.config.CookieSpecs.STANDARD;
+import static org.apache.http.client.config.CookieSpecs.IGNORE_COOKIES;
 import static org.apache.http.client.config.RequestConfig.custom;
 import static org.opendatakit.briefcase.reused.http.RequestMethod.POST;
 
@@ -71,7 +71,8 @@ public class CommonsHttp implements Http {
             .setConnectionRequestTimeout(0)
             .setSocketTimeout(0)
             .setConnectTimeout(0)
-            .setCookieSpec(STANDARD).build());
+            .setCookieSpec(IGNORE_COOKIES)
+            .build());
   }
 
   @Override


### PR DESCRIPTION
Closes #777

#### What has been done to verify that this works as intended?
Manually test against bleeding edge Central server at antinod.es

#### Why is this the best possible solution? Were any other approaches considered?
Central (latest) will reject requests arriving with auth tokens and session cookies. Since we don't really need cookies for anything, this is a quick fix for this issue while we decide what to do about auth in Central

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
There's the risk of undocumented dependency on cookies by aggregate-compatible servers that we don't know about. If any of these servers rely upon cookies that were being sent, pull/push operations could fail due to this change. Testing in known servers (Ona, Kobo...) would be required to ensure we're breaking anything.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.