### PR TITLE
Issue #780 Parsing JSON Central responses fails when unexpected fields arrive

### DIFF
--- a/src/org/opendatakit/briefcase/reused/http/CommonsHttp.java
+++ b/src/org/opendatakit/briefcase/reused/http/CommonsHttp.java
@@ -16,7 +16,7 @@
 
 package org.opendatakit.briefcase.reused.http;
 
-import static org.apache.http.client.config.CookieSpecs.STANDARD;
+import static org.apache.http.client.config.CookieSpecs.IGNORE_COOKIES;
 import static org.apache.http.client.config.RequestConfig.custom;
 import static org.opendatakit.briefcase.reused.http.RequestMethod.POST;
 
@@ -71,7 +71,8 @@ public class CommonsHttp implements Http {
             .setConnectionRequestTimeout(0)
             .setSocketTimeout(0)
             .setConnectTimeout(0)
-            .setCookieSpec(STANDARD).build());
+            .setCookieSpec(IGNORE_COOKIES)
+            .build());
   }
 
   @Override

--- a/src/org/opendatakit/briefcase/reused/transfer/CentralAttachment.java
+++ b/src/org/opendatakit/briefcase/reused/transfer/CentralAttachment.java
@@ -21,13 +21,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
-@JsonIgnoreProperties({"type"})
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class CentralAttachment {
   private final String name;
   private final boolean exists;
 
   @JsonCreator
-
   public CentralAttachment(@JsonProperty("name") String name, @JsonProperty("exists") boolean exists) {
     this.name = name;
     this.exists = exists;


### PR DESCRIPTION
Closes #780

#### What has been done to verify that this works as intended?
Manully verified using the UI and the instructions in the issue

#### Why is this the best possible solution? Were any other approaches considered?
Super narrow fix to ignore unknown/undeclared/unused props in incoming JSONs from Central

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Pretty safe change behavior-wise.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.