### PR TITLE
Fix #755 - Set appropriate colour of view form details button.

### DIFF
--- a/src/org/opendatakit/briefcase/ui/reused/UI.java
+++ b/src/org/opendatakit/briefcase/ui/reused/UI.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.briefcase.ui.reused;
 
+import static java.awt.Color.DARK_GRAY;
 import static java.awt.Color.GRAY;
 import static java.awt.Color.LIGHT_GRAY;
 import static javax.swing.JOptionPane.ERROR_MESSAGE;
@@ -55,7 +56,7 @@ public class UI {
     button.setToolTipText("View this form's status history");
     button.setMargin(new Insets(0, 0, 0, 0));
 
-    button.setForeground(LIGHT_GRAY);
+    button.setForeground(form.getStatusHistory().isEmpty() ? LIGHT_GRAY : DARK_GRAY);
     button.addActionListener(__ -> {
       if (!form.getStatusHistory().isEmpty())
         showDialog(getFrameForComponent(button), form.getFormDefinition(), form.getStatusHistory());


### PR DESCRIPTION
Closes #755 

#### What has been done to verify that this works as intended?
Tested manually:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/22395998/62720736-42948a80-ba28-11e9-96b1-89ae2c69274f.gif)

#### Why is this the best possible solution? Were any other approaches considered?
This is the best solution because it doesn't alter the backend logic of the system.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No risks. Slight UI misinformation is corrected.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No