### PR TITLE
Fix #786 - Show error message when invalid project id is used for Central

### DIFF
--- a/src/org/opendatakit/briefcase/reused/transfer/CentralServer.java
+++ b/src/org/opendatakit/briefcase/reused/transfer/CentralServer.java
@@ -28,10 +28,8 @@ import java.util.Optional;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.RemoteFormDefinition;
-import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.reused.OptionalProduct;
 import org.opendatakit.briefcase.reused.http.Credentials;
-import org.opendatakit.briefcase.reused.http.Http;
 import org.opendatakit.briefcase.reused.http.Request;
 import org.opendatakit.briefcase.reused.http.RequestBuilder;
 

--- a/src/org/opendatakit/briefcase/reused/transfer/CentralServer.java
+++ b/src/org/opendatakit/briefcase/reused/transfer/CentralServer.java
@@ -28,8 +28,10 @@ import java.util.Optional;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.RemoteFormDefinition;
+import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.reused.OptionalProduct;
 import org.opendatakit.briefcase.reused.http.Credentials;
+import org.opendatakit.briefcase.reused.http.Http;
 import org.opendatakit.briefcase.reused.http.Request;
 import org.opendatakit.briefcase.reused.http.RequestBuilder;
 
@@ -77,6 +79,18 @@ public class CentralServer implements RemoteServer {
         .withHeader("Content-Type", "application/json")
         .withBody(buildSessionPayload(credentials))
         .withResponseMapper(json -> !((String) json.get("token")).isEmpty())
+        .build();
+  }
+
+  public Request<String> getProjectTestRequest(Http http) {
+    String token = http.execute(getSessionTokenRequest())
+        .orElseThrow(() -> new BriefcaseException("Can't authenticate with ODK Central"));
+
+    return RequestBuilder.get(baseUrl)
+        .asText()
+        .withPath("/v1/projects/" + projectId)
+        .withHeader("Authorization", "Bearer " + token)
+        .withResponseMapper(json -> json)
         .build();
   }
 

--- a/src/org/opendatakit/briefcase/reused/transfer/CentralServer.java
+++ b/src/org/opendatakit/briefcase/reused/transfer/CentralServer.java
@@ -72,20 +72,7 @@ public class CentralServer implements RemoteServer {
     return index == -1 ? url : url.substring(0, index);
   }
 
-  public Request<Boolean> getCredentialsTestRequest() {
-    return RequestBuilder.post(baseUrl)
-        .asJsonMap()
-        .withPath("/v1/sessions")
-        .withHeader("Content-Type", "application/json")
-        .withBody(buildSessionPayload(credentials))
-        .withResponseMapper(json -> !((String) json.get("token")).isEmpty())
-        .build();
-  }
-
-  public Request<String> getProjectTestRequest(Http http) {
-    String token = http.execute(getSessionTokenRequest())
-        .orElseThrow(() -> new BriefcaseException("Can't authenticate with ODK Central"));
-
+  public Request<String> getProjectTestRequest(String token) {
     return RequestBuilder.get(baseUrl)
         .asText()
         .withPath("/v1/projects/" + projectId)

--- a/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/CentralServerDialog.java
+++ b/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/CentralServerDialog.java
@@ -55,7 +55,7 @@ public class CentralServerDialog {
               form.hideDialog();
             } else
               showErrorMessage(
-                  response.isRedirection() ? "Redirection detected" : response.isUnauthorized() ? "Wrong credentials" : response.isNotFound() ? "Central not found" : "",
+                  response.isRedirection() ? "Redirection detected" : response.isUnauthorized() ? "Wrong credentials" : response.isNotFound() ? "Project ID does not exist." : "",
                   response.isRedirection() ? "Unexpected error" : "Configuration error"
               );
           } catch (InterruptedException ignore) {

--- a/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/CentralServerDialog.java
+++ b/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/CentralServerDialog.java
@@ -53,13 +53,11 @@ public class CentralServerDialog {
             if (response.isSuccess()) {
               triggerConnect(server);
               form.hideDialog();
-            } else {
-              System.out.println(response.getStatusPhrase());
+            } else
               showErrorMessage(
                   response.isRedirection() ? "Redirection detected" : response.isUnauthorized() ? "Wrong credentials" : response.isNotFound() ? "Project ID does not exist" : "",
                   response.isRedirection() ? "Unexpected error" : "Configuration error"
               );
-            }
           } catch (InterruptedException ignore) {
             // Ignore
           } catch (ExecutionException e) {

--- a/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/CentralServerDialog.java
+++ b/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/CentralServerDialog.java
@@ -55,7 +55,7 @@ public class CentralServerDialog {
               form.hideDialog();
             } else
               showErrorMessage(
-                  response.isRedirection() ? "Redirection detected" : response.isUnauthorized() ? "Wrong credentials" : response.isNotFound() ? "Project ID does not exist" : "",
+                  response.isRedirection() ? "Redirection detected" : response.isUnauthorized() ? "Wrong credentials" : response.isNotFound() ? "Central server or project not found" : "",
                   response.isRedirection() ? "Unexpected error" : "Configuration error"
               );
           } catch (InterruptedException ignore) {

--- a/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/CentralServerDialog.java
+++ b/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/CentralServerDialog.java
@@ -53,11 +53,13 @@ public class CentralServerDialog {
             if (response.isSuccess()) {
               triggerConnect(server);
               form.hideDialog();
-            } else
+            } else {
+              System.out.println(response.getStatusPhrase());
               showErrorMessage(
-                  response.isRedirection() ? "Redirection detected" : response.isUnauthorized() ? "Wrong credentials" : response.isNotFound() ? "Project ID does not exist." : "",
+                  response.isRedirection() ? "Redirection detected" : response.isUnauthorized() ? "Wrong credentials" : response.isNotFound() ? "Project ID does not exist" : "",
                   response.isRedirection() ? "Unexpected error" : "Configuration error"
               );
+            }
           } catch (InterruptedException ignore) {
             // Ignore
           } catch (ExecutionException e) {

--- a/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/source/PullSource.java
+++ b/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/source/PullSource.java
@@ -38,12 +38,12 @@ public interface PullSource<T> extends SourceOrTarget<T> {
   static PullSource<CentralServer> central(Http http, Consumer<PullSource> consumer) {
     return new Central(http,
         server -> {
-          Response response = http.execute(server.getCredentialsTestRequest());
+          Response<String> response = http.execute(server.getSessionTokenRequest());
           if (!response.isSuccess()) {
             return response;
           }
 
-          return http.execute(server.getProjectTestRequest(http));
+          return http.execute(server.getProjectTestRequest(response.get()));
         }, consumer);
   }
 

--- a/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/source/PullSource.java
+++ b/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/source/PullSource.java
@@ -23,6 +23,7 @@ import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.form.FormMetadataPort;
 import org.opendatakit.briefcase.reused.http.Http;
+import org.opendatakit.briefcase.reused.http.response.Response;
 import org.opendatakit.briefcase.reused.job.JobsRunner;
 import org.opendatakit.briefcase.reused.transfer.AggregateServer;
 import org.opendatakit.briefcase.reused.transfer.CentralServer;
@@ -35,7 +36,15 @@ public interface PullSource<T> extends SourceOrTarget<T> {
   }
 
   static PullSource<CentralServer> central(Http http, Consumer<PullSource> consumer) {
-    return new Central(http, server -> http.execute(server.getCredentialsTestRequest()), consumer);
+    return new Central(http,
+        server -> {
+          Response response = http.execute(server.getCredentialsTestRequest());
+          if (!response.isSuccess()) {
+            return response;
+          }
+
+          return http.execute(server.getProjectTestRequest(http));
+        }, consumer);
   }
 
   static PullSource<Path> customDir(Consumer<PullSource> consumer) {

--- a/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/target/PushTarget.java
+++ b/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/target/PushTarget.java
@@ -39,12 +39,12 @@ public interface PushTarget<T> extends SourceOrTarget<T> {
 
   static PushTarget<CentralServer> central(Http http, Consumer<PushTarget> consumer) {
     return new Central(http, server -> {
-      Response response = http.execute(server.getCredentialsTestRequest());
+      Response<String> response = http.execute(server.getSessionTokenRequest());
       if (!response.isSuccess()) {
         return response;
       }
 
-      return http.execute(server.getProjectTestRequest(http));
+      return http.execute(server.getProjectTestRequest(response.get()));
     }, consumer);
   }
 

--- a/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/target/PushTarget.java
+++ b/src/org/opendatakit/briefcase/ui/reused/transfer/sourcetarget/target/PushTarget.java
@@ -20,6 +20,7 @@ import java.nio.file.Path;
 import java.util.function.Consumer;
 import org.opendatakit.briefcase.model.BriefcasePreferences;
 import org.opendatakit.briefcase.reused.http.Http;
+import org.opendatakit.briefcase.reused.http.response.Response;
 import org.opendatakit.briefcase.reused.job.JobsRunner;
 import org.opendatakit.briefcase.reused.transfer.AggregateServer;
 import org.opendatakit.briefcase.reused.transfer.CentralServer;
@@ -37,7 +38,14 @@ public interface PushTarget<T> extends SourceOrTarget<T> {
   }
 
   static PushTarget<CentralServer> central(Http http, Consumer<PushTarget> consumer) {
-    return new Central(http, server -> http.execute(server.getCredentialsTestRequest()), consumer);
+    return new Central(http, server -> {
+      Response response = http.execute(server.getCredentialsTestRequest());
+      if (!response.isSuccess()) {
+        return response;
+      }
+
+      return http.execute(server.getProjectTestRequest(http));
+    }, consumer);
   }
 
   void storeTargetPrefs(BriefcasePreferences prefs, boolean storePasswords);


### PR DESCRIPTION
Closes #786 

#### What has been done to verify that this works as intended?
Manually tested with correct and incorrect project IDs as shown below:
https://www.youtube.com/watch?v=Rd0Vuyg1PMg

#### Why is this the best possible solution? Were any other approaches considered?
I have tried to keep it as consistent with the current design as possible. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change will warn the user of an invalid project ID for the Central server at the time of setting up the connection. No risks to the users.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No