### PR TITLE
775: Push all forms to Aggregate if a form ID is not provided

### DIFF
--- a/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
@@ -55,18 +55,18 @@ public class PushFormToAggregate {
       PUSH_AGGREGATE,
       args -> pushFormToAggregate(
           args.get(STORAGE_DIR),
-          args.get(FORM_ID),
+          args.getOptional(FORM_ID),
           args.get(ODK_USERNAME),
           args.get(ODK_PASSWORD),
           args.get(AGGREGATE_SERVER),
           args.has(FORCE_SEND_BLANK),
           args.getOptional(MAX_HTTP_CONNECTIONS)
       ),
-      Arrays.asList(STORAGE_DIR, FORM_ID, ODK_USERNAME, ODK_PASSWORD, AGGREGATE_SERVER),
-      Arrays.asList(FORCE_SEND_BLANK, MAX_HTTP_CONNECTIONS)
+      Arrays.asList(STORAGE_DIR, ODK_USERNAME, ODK_PASSWORD, AGGREGATE_SERVER),
+      Arrays.asList(FORCE_SEND_BLANK, MAX_HTTP_CONNECTIONS, FORM_ID)
   );
 
-  private static void pushFormToAggregate(String storageDir, String formid, String username, String password, String server, boolean forceSendBlank, Optional<Integer> maybeMaxConnections) {
+  private static void pushFormToAggregate(String storageDir, Optional<String> formid, String username, String password, String server, boolean forceSendBlank, Optional<Integer> maybeMaxConnections) {
     CliEventsCompanion.attach(log);
     Path briefcaseDir = Common.getOrCreateBriefcaseDir(storageDir);
     FormCache formCache = FormCache.from(briefcaseDir);

--- a/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
@@ -96,14 +96,14 @@ public class PushFormToAggregate {
           : "Error connecting to Aggregate");
       return;
     }
-    Optional<FormStatus> maybeFormStatus = formCache.getForms().stream()
-        .filter(form -> form.getFormId().equals(formid))
-        .map(FormStatus::new)
-        .findFirst();
 
     List<FormStatus> statuses;
     if (formid.isPresent()) {
-      FormStatus status = maybeFormStatus.orElseThrow(() -> new BriefcaseException("Form " + formid + " not found"));
+      FormStatus status = formCache.getForms().stream()
+          .filter(form -> form.getFormId().equals(formid))
+          .map(FormStatus::new)
+          .findFirst()
+          .orElseThrow(() -> new BriefcaseException("Form " + formid + " not found"));
       statuses = Arrays.asList(status);
     } else {
       statuses = formCache.getForms().stream()

--- a/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
@@ -99,11 +99,12 @@ public class PushFormToAggregate {
 
     List<FormStatus> statuses;
     if (formid.isPresent()) {
+      String requestedFormId = formid.get();
       FormStatus status = formCache.getForms().stream()
-          .filter(form -> form.getFormId().equals(formid))
+          .filter(form -> form.getFormId().equals(requestedFormId))
           .map(FormStatus::new)
           .findFirst()
-          .orElseThrow(() -> new BriefcaseException("Form " + formid + " not found"));
+          .orElseThrow(() -> new BriefcaseException("Form " + requestedFormId + " not found"));
       statuses = Arrays.asList(status);
     } else {
       statuses = formCache.getForms().stream()

--- a/src/org/opendatakit/briefcase/transfer/TransferForms.java
+++ b/src/org/opendatakit/briefcase/transfer/TransferForms.java
@@ -62,8 +62,12 @@ public class TransferForms implements Iterable<FormStatus> {
     return form.getFormDefinition().getFormId();
   }
 
+  public static TransferForms of(List<FormStatus> forms) {
+    return new TransferForms(new ArrayList<>(forms));
+  }
+  
   public static TransferForms of(FormStatus... forms) {
-    return new TransferForms(new ArrayList<>(Arrays.asList(forms)));
+    return of(Arrays.asList(forms));
   }
 
   /**


### PR DESCRIPTION
Closes #775

#### What has been done to verify that this works as intended?

I added a bit of temporary logging code to see which forms were being pushed, and then manually ran a command like this:

```
$ java -jar build/libs/ODK-Briefcase-v1.16.0-1-g91f5f85f-dirty.jar --push_aggregate --aggregate_url https://sandbox.aggregate.opendatakit.org/ --odk_username foo --odk_password bar --storage_directory /tmp
```

All local forms were selected and pushed.

#### Why is this the best possible solution? Were any other approaches considered?

Straightforward change. This is substantially similar to the work done in #727.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The only user-facing change is that the form ID can be omitted, and this will be interpreted as selecting all forms.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.

I don't think so.

#### Notes

This seems to work for Aggregate, but the issue description mentions pushing to Central. Are parameters like `push_central` being added in 1.17? Is there anything else to be done right now?