### PR TITLE
Issue #789 Catch NPE while populating dynamic choices

### DIFF
--- a/src/org/opendatakit/briefcase/export/FormDefinition.java
+++ b/src/org/opendatakit/briefcase/export/FormDefinition.java
@@ -163,7 +163,11 @@ public class FormDefinition {
             // Populate choices of any control using a secondary
             // instance that is not external
             if (secondaryInstance != null && !(secondaryInstance instanceof ExternalDataInstance))
-              formDef.populateDynamicChoices(itemsetBinding, (TreeReference) control.getBind().getReference());
+              try {
+                formDef.populateDynamicChoices(itemsetBinding, (TreeReference) control.getBind().getReference());
+              } catch (NullPointerException e) {
+                // Ignore (see https://github.com/opendatakit/briefcase/issues/789)
+              }
           }
         })
         .collect(toMap(FormDefinition::controlFqn, e -> e));

--- a/test/java/org/opendatakit/briefcase/export/ExportToCsvExplodeChoiceListWithRelativePredicateInRepeatTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportToCsvExplodeChoiceListWithRelativePredicateInRepeatTest.java
@@ -1,0 +1,26 @@
+package org.opendatakit.briefcase.export;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ExportToCsvExplodeChoiceListWithRelativePredicateInRepeatTest {
+  private ExportToCsvScenario scenario;
+
+  @Before
+  public void setUp() {
+    scenario = ExportToCsvScenario.setUp("choice-lists-predicate-relative-repeat");
+  }
+
+  @After
+  public void tearDown() {
+    scenario.tearDown();
+  }
+
+  @Test
+  public void exports_forms_with_all_data_types() {
+    scenario.runExportExplodedChoiceLists();
+    scenario.assertSameContent();
+    scenario.assertSameContentRepeats("", "group");
+  }
+}

--- a/test/resources/org/opendatakit/briefcase/export/choice-lists-predicate-relative-repeat-group.csv.expected
+++ b/test/resources/org/opendatakit/briefcase/export/choice-lists-predicate-relative-repeat-group.csv.expected
@@ -1,0 +1,2 @@
+category,item,PARENT_KEY,KEY,SET-OF-group
+1,1,uuid:a21ca0ad-db7e-4ef5-b7ea-d73dd4a42bf0,uuid:a21ca0ad-db7e-4ef5-b7ea-d73dd4a42bf0/group[1],uuid:a21ca0ad-db7e-4ef5-b7ea-d73dd4a42bf0/group

--- a/test/resources/org/opendatakit/briefcase/export/choice-lists-predicate-relative-repeat-submission.xml
+++ b/test/resources/org/opendatakit/briefcase/export/choice-lists-predicate-relative-repeat-submission.xml
@@ -1,0 +1,9 @@
+<data id="choice-lists-predicate-relative-repeat" instanceID="uuid:a21ca0ad-db7e-4ef5-b7ea-d73dd4a42bf0" submissionDate="2019-03-17T10:14:18.820Z" isComplete="true" markedAsCompleteDate="2019-03-17T10:14:18.820Z" xmlns="http://opendatakit.org/submissions">
+  <group>
+    <category>1</category>
+    <item>1</item>
+  </group>
+  <n0:meta xmlns:n0="http://openrosa.org/xforms">
+    <n0:instanceID>uuid:a21ca0ad-db7e-4ef5-b7ea-d73dd4a42bf0</n0:instanceID>
+  </n0:meta>
+</data>

--- a/test/resources/org/opendatakit/briefcase/export/choice-lists-predicate-relative-repeat.csv.expected
+++ b/test/resources/org/opendatakit/briefcase/export/choice-lists-predicate-relative-repeat.csv.expected
@@ -1,0 +1,2 @@
+SubmissionDate,SET-OF-group,meta-instanceID,KEY
+"Mar 17, 2019 10:14:18 AM",uuid:a21ca0ad-db7e-4ef5-b7ea-d73dd4a42bf0/group,uuid:a21ca0ad-db7e-4ef5-b7ea-d73dd4a42bf0,uuid:a21ca0ad-db7e-4ef5-b7ea-d73dd4a42bf0

--- a/test/resources/org/opendatakit/briefcase/export/choice-lists-predicate-relative-repeat.xml
+++ b/test/resources/org/opendatakit/briefcase/export/choice-lists-predicate-relative-repeat.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa">
+  <h:head>
+    <h:title>Populate dynamic choices in repeat groups with relative paths</h:title>
+    <model>
+      <instance>
+        <data id="choice-lists-predicate-relative-repeat">
+          <group jr:template="">
+            <category/>
+            <item/>
+          </group>
+          <meta>
+            <instanceID/>
+          </meta>
+        </data>
+      </instance>
+      <instance id="items">
+        <root>
+          <item>
+            <name>1</name>
+            <category>1</category>
+          </item>
+          <item>
+            <name>2</name>
+            <category>1</category>
+          </item>
+          <item>
+            <name>3</name>
+            <category>1</category>
+          </item>
+          <item>
+            <name>4</name>
+            <category>1</category>
+          </item>
+          <item>
+            <name>5</name>
+            <category>2</category>
+          </item>
+          <item>
+            <name>6</name>
+            <category>2</category>
+          </item>
+          <item>
+            <name>7</name>
+            <category>2</category>
+          </item>
+          <item>
+            <name>8</name>
+            <category>3</category>
+          </item>
+          <item>
+            <name>9</name>
+            <category>3</category>
+          </item>
+          <item>
+            <name>10</name>
+            <category>3</category>
+          </item>
+        </root>
+      </instance>
+      <bind nodeset="/data/group/category" required="true()" type="select1"/>
+      <bind nodeset="/data/group/item" required="true()" type="select1"/>
+      <bind nodeset="/data/meta/instanceID" jr:preload="uid" readonly="true()" type="string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <group ref="/data/group">
+      <label>Repeat group</label>
+      <repeat nodeset="/data/group">
+        <select1 ref="/data/group/category">
+          <label>Category</label>
+          <item>
+            <label>1</label>
+            <value>1</value>
+          </item>
+          <item>
+            <label>2</label>
+            <value>2</value>
+          </item>
+          <item>
+            <label>3</label>
+            <value>3</value>
+          </item>
+        </select1>
+        <select1 ref="/data/group/item">
+          <label>Item</label>
+          <itemset nodeset="instance('items')/root/item[category= current()/../category ]">
+            <value ref="name"/>
+            <label ref="name"/>
+          </itemset>
+        </select1>
+      </repeat>
+    </group>
+  </h:body>
+</h:html>


### PR DESCRIPTION
Closes #789

#### What has been done to verify that this works as intended?
- Added an automated regression test
- Manually exported the form attached in the issue and verified that it exports correctly when combined with the "split select multiples" feature.

Test this PR with [briefcase_pr_790.zip](https://github.com/opendatakit/briefcase/files/3515126/briefcase_pr_790.zip)

#### Why is this the best possible solution? Were any other approaches considered?
This is what feels safest from the three options described in #789 (maybe there are more options?). It's a straightforward change to prevent an NPE.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
There's the risk of masking other sources of NPEs by the added try/catch block.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.
