### PR TITLE
Issue #791 Match case when finding xml element

### DIFF
--- a/src/org/opendatakit/briefcase/export/XmlElement.java
+++ b/src/org/opendatakit/briefcase/export/XmlElement.java
@@ -144,7 +144,7 @@ public class XmlElement {
   public List<XmlElement> findElements(String... namesArray) {
 
     if (namesArray.length == 1)
-      return childrenOf().stream().filter(e -> e.getName().equalsIgnoreCase(namesArray[0])).collect(Collectors.toList());
+      return childrenOf().stream().filter(e -> e.getName().equals(namesArray[0])).collect(Collectors.toList());
     // Shift the first element on array
     List<String> names = Arrays.asList(namesArray);
     return findElement(names.get(0))
@@ -250,7 +250,7 @@ public class XmlElement {
   }
 
   private boolean hasName(String name) {
-    return element.getName().equalsIgnoreCase(name);
+    return element.getName().equals(name);
   }
 
   private boolean isFirstLevelGroup() {

--- a/test/java/org/opendatakit/briefcase/export/ExportToCsvCaseSensitivityTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportToCsvCaseSensitivityTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.briefcase.export;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ExportToCsvCaseSensitivityTest {
+  private ExportToCsvScenario scenario;
+
+  @Before
+  public void setUp() {
+    scenario = ExportToCsvScenario.setUp("simple-form-case-sensitivity");
+  }
+
+  @After
+  public void tearDown() {
+    scenario.tearDown();
+  }
+
+  @Test
+  public void exports_forms_with_all_data_types() {
+    scenario.runExport();
+    scenario.assertSameContent();
+  }
+}

--- a/test/resources/org/opendatakit/briefcase/export/simple-form-case-sensitivity-submission.xml
+++ b/test/resources/org/opendatakit/briefcase/export/simple-form-case-sensitivity-submission.xml
@@ -1,0 +1,7 @@
+<data id="simple-form-case-sensitivity" instanceID="uuid:0a1b861f-a5fd-4f49-846a-78dcf06cfc1b" version="2018012404" submissionDate="2018-02-01T11:35:19.178Z" isComplete="true" markedAsCompleteDate="2018-02-01T11:35:19.178Z" xmlns="http://opendatakit.org/submissions">
+  <field>Some value</field>
+  <Field>2019-01-01T00:00:00.000Z</Field>
+  <n0:meta xmlns:n0="http://openrosa.org/xforms">
+    <n0:instanceID>uuid:0a1b861f-a5fd-4f49-846a-78dcf06cfc1b</n0:instanceID>
+  </n0:meta>
+</data>

--- a/test/resources/org/opendatakit/briefcase/export/simple-form-case-sensitivity.csv.expected
+++ b/test/resources/org/opendatakit/briefcase/export/simple-form-case-sensitivity.csv.expected
@@ -1,0 +1,2 @@
+SubmissionDate,field,Field,meta-instanceID,KEY
+"Feb 1, 2018 11:35:19 AM",Some value,"Jan 1, 2019 12:00:00 AM",uuid:0a1b861f-a5fd-4f49-846a-78dcf06cfc1b,uuid:0a1b861f-a5fd-4f49-846a-78dcf06cfc1b

--- a/test/resources/org/opendatakit/briefcase/export/simple-form-case-sensitivity.xml
+++ b/test/resources/org/opendatakit/briefcase/export/simple-form-case-sensitivity.xml
@@ -1,0 +1,27 @@
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+  <h:head>
+    <h:title>Simple form</h:title>
+    <model>
+      <instance>
+        <data id="simple-form-case-sensitivity">
+          <field/>
+          <Field/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </data>
+      </instance>
+      <itext>
+        <translation lang="English">
+        </translation>
+      </itext>
+      <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" calculate="concat('uuid:', uuid())"/>
+      <bind nodeset="/data/field" type="string"/>
+      <bind nodeset="/data/Field" type="dateTime"/>
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/data/field"/>
+    <input ref="/data/Field"/>
+  </h:body>
+</h:html>


### PR DESCRIPTION
Closes #791

#### What has been done to verify that this works as intended?
Added automated regression test
Manually exported the form attached to the issue

Test this PR with [briefcase_pr_792.zip](https://github.com/opendatakit/briefcase/files/3515127/briefcase_pr_792.zip)

#### Why is this the best possible solution? Were any other approaches considered?
Super narrow fix to avoid confusing field mappers when two fields have the same name with case differences.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This shouldn't change any other behavior.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.
