### PR TITLE
Fix #732 - Disable the select all button on Export tab if list is empty

### DIFF
--- a/src/org/opendatakit/briefcase/export/ExportForms.java
+++ b/src/org/opendatakit/briefcase/export/ExportForms.java
@@ -158,7 +158,11 @@ public class ExportForms {
   }
 
   public boolean allSelected() {
-    return forms.stream().allMatch(FormStatus::isSelected);
+    return !forms.isEmpty() && forms.stream().allMatch(FormStatus::isSelected);
+  }
+
+  public boolean isEmpty() {
+    return forms.isEmpty();
   }
 
   public boolean noneSelected() {

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanel.java
@@ -149,6 +149,11 @@ public class ExportPanel {
     } else {
       form.toggleSelectAll();
     }
+
+    if (forms.isEmpty())
+      form.disableSelectAll();
+    else
+      form.enableSelectAll();
   }
 
   public static ExportPanel from(BriefcasePreferences exportPreferences, BriefcasePreferences appPreferences, BriefcasePreferences pullPrefs, Analytics analytics, FormCache formCache, Http http) {

--- a/src/org/opendatakit/briefcase/ui/export/ExportPanelForm.java
+++ b/src/org/opendatakit/briefcase/ui/export/ExportPanelForm.java
@@ -111,6 +111,14 @@ public class ExportPanelForm {
     formsTable.onChange(callback);
   }
 
+  void disableSelectAll() {
+    selectAllButton.setEnabled(false);
+  }
+
+  void enableSelectAll() {
+    selectAllButton.setEnabled(true);
+  }
+
   void toggleClearAll() {
     selectAllButton.setVisible(false);
     clearAllButton.setVisible(true);


### PR DESCRIPTION
Closes #732 

#### What has been done to verify that this works as intended?
Manually tested with empty and filled forms list.

#### Why is this the best possible solution? Were any other approaches considered?
The approach used is similar to how things have been done in `PullPanel`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This fixes a minor UI bug. No risks.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No