### PR TITLE
Issue 796 support custom functions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     exclude group: 'commons-logging'
   }
   compile group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
-  compile(group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.15.1') {
+  compile(group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.16.0') {
     exclude group: 'org.slf4j'
   }
   compile group: 'org.hsqldb', name: 'hsqldb', version: '2.4.0'

--- a/src/org/opendatakit/briefcase/export/ExportConfiguration.java
+++ b/src/org/opendatakit/briefcase/export/ExportConfiguration.java
@@ -80,7 +80,7 @@ public class ExportConfiguration {
   private final OverridableBoolean removeGroupNames;
   private final OverridableBoolean smartAppend;
 
-  private ExportConfiguration(Optional<String> exportFileName, Optional<Path> exportDir, Optional<Path> pemFile, DateRange dateRange, OverridableBoolean pullBefore, OverridableBoolean overwriteFiles, OverridableBoolean exportMedia, OverridableBoolean splitSelectMultiples, OverridableBoolean includeGeoJsonExport, OverridableBoolean removeGroupNames, OverridableBoolean smartAppend) {
+  public ExportConfiguration(Optional<String> exportFileName, Optional<Path> exportDir, Optional<Path> pemFile, DateRange dateRange, OverridableBoolean pullBefore, OverridableBoolean overwriteFiles, OverridableBoolean exportMedia, OverridableBoolean splitSelectMultiples, OverridableBoolean includeGeoJsonExport, OverridableBoolean removeGroupNames, OverridableBoolean smartAppend) {
     this.exportFileName = exportFileName;
     this.exportDir = exportDir;
     this.pemFile = pemFile;

--- a/src/org/opendatakit/briefcase/export/FormDefinition.java
+++ b/src/org/opendatakit/briefcase/export/FormDefinition.java
@@ -37,8 +37,6 @@ import org.javarosa.core.model.IDataReference;
 import org.javarosa.core.model.IFormElement;
 import org.javarosa.core.model.ItemsetBinding;
 import org.javarosa.core.model.QuestionDef;
-import org.javarosa.core.model.condition.EvaluationContext;
-import org.javarosa.core.model.condition.IFunctionHandler;
 import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.InstanceInitializationFactory;
@@ -53,32 +51,6 @@ import org.opendatakit.briefcase.reused.BriefcaseException;
  * This class holds all the relevant information about the form being exported.
  */
 public class FormDefinition {
-  private static final IFunctionHandler DUMMY_PULLDATA_HANDLER = new IFunctionHandler() {
-    @Override
-    public String getName() {
-      return "pulldata";
-    }
-
-    @Override
-    public List<Class[]> getPrototypes() {
-      return Collections.emptyList();
-    }
-
-    @Override
-    public boolean rawArgs() {
-      return true;
-    }
-
-    @Override
-    public boolean realTime() {
-      return false;
-    }
-
-    @Override
-    public Object eval(Object[] args, EvaluationContext ec) {
-      return "";
-    }
-  };
   private final String id;
   private final String name;
   private final Path formFile;
@@ -144,7 +116,7 @@ public class FormDefinition {
   }
 
   private static Map<String, QuestionDef> getFormControls(FormDef formDef) {
-    formDef.getEvaluationContext().addFunctionHandler(DUMMY_PULLDATA_HANDLER);
+    formDef.getEvaluationContext().addFallbackFunctionHandler((name, args, ec) -> "");
     formDef.initialize(false, new InstanceInitializationFactory());
     return formDef.getChildren()
         .stream()

--- a/test/java/org/opendatakit/briefcase/CustomFunctionTest.java
+++ b/test/java/org/opendatakit/briefcase/CustomFunctionTest.java
@@ -1,26 +1,15 @@
 package org.opendatakit.briefcase;
 
-import static org.opendatakit.briefcase.reused.UncheckedFiles.createDirectories;
-import static org.opendatakit.briefcase.reused.UncheckedFiles.createTempDirectory;
+import static org.junit.Assert.assertThat;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.toURI;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
+import org.hamcrest.Matchers;
 import org.junit.Test;
-import org.opendatakit.briefcase.export.DateRange;
-import org.opendatakit.briefcase.export.ExportConfiguration;
-import org.opendatakit.briefcase.export.ExportToCsv;
 import org.opendatakit.briefcase.export.FormDefinition;
-import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
-import org.opendatakit.briefcase.model.FormStatus;
-import org.opendatakit.briefcase.model.form.FormMetadata;
-import org.opendatakit.briefcase.model.form.InMemoryFormMetadataAdapter;
 import org.opendatakit.briefcase.pull.aggregate.PullFromAggregateIntegrationTest;
-import org.opendatakit.briefcase.reused.OverridableBoolean;
-import org.opendatakit.briefcase.util.BadFormDefinition;
 
 public class CustomFunctionTest {
   private static Path getPath(String fileName) {
@@ -31,37 +20,9 @@ public class CustomFunctionTest {
 
   @Test
   public void name() {
-    FormDefinition.from(getPath("custom-function-form.xml"));
-  }
-
-  @Test
-  public void full_regression_test() throws IOException, BadFormDefinition {
-    Path exportDir = createTempDirectory("briefcase-test-export-dir-");
-    Path sourceFormFile = getPath("custom-function-form.xml");
-    Path briefcaseDir = createTempDirectory("briefcase-test-storage-dir-");
-    Path formFile = briefcaseDir.resolve("Custom function form").resolve("Custom function form.xml");
-    createDirectories(formFile.getParent());
-    Files.copy(sourceFormFile, formFile);
-
-    FormMetadata formMetadata = FormMetadata.from(formFile);
-    InMemoryFormMetadataAdapter formMetadataPort = new InMemoryFormMetadataAdapter();
-    formMetadataPort.persist(formMetadata);
-    BriefcaseFormDefinition localFormDef = BriefcaseFormDefinition.resolveAgainstBriefcaseDefn(formFile.toFile(), false, briefcaseDir.toFile());
-    FormStatus formStatus = new FormStatus(localFormDef);
-
-    ExportConfiguration configuration = new ExportConfiguration(
-        Optional.<String>empty(),
-        Optional.of(exportDir),
-        Optional.<Path>empty(),
-        DateRange.empty(),
-        OverridableBoolean.FALSE,
-        OverridableBoolean.TRUE,
-        OverridableBoolean.TRUE,
-        OverridableBoolean.FALSE,
-        OverridableBoolean.FALSE,
-        OverridableBoolean.FALSE,
-        OverridableBoolean.FALSE
-    );
-    ExportToCsv.export(formMetadataPort, formMetadata, formStatus, FormDefinition.from(localFormDef), briefcaseDir, configuration);
+    FormDefinition formDefinition = FormDefinition.from(getPath("custom-function-form.xml"));
+    // Assert anything about the form definition object
+    // What's important is that we can get the form def object without errors
+    assertThat(formDefinition.getFormId(), Matchers.is("custom-function-form"));
   }
 }

--- a/test/java/org/opendatakit/briefcase/CustomFunctionTest.java
+++ b/test/java/org/opendatakit/briefcase/CustomFunctionTest.java
@@ -1,0 +1,67 @@
+package org.opendatakit.briefcase;
+
+import static org.opendatakit.briefcase.reused.UncheckedFiles.createDirectories;
+import static org.opendatakit.briefcase.reused.UncheckedFiles.createTempDirectory;
+import static org.opendatakit.briefcase.reused.UncheckedFiles.toURI;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import org.junit.Test;
+import org.opendatakit.briefcase.export.DateRange;
+import org.opendatakit.briefcase.export.ExportConfiguration;
+import org.opendatakit.briefcase.export.ExportToCsv;
+import org.opendatakit.briefcase.export.FormDefinition;
+import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
+import org.opendatakit.briefcase.model.FormStatus;
+import org.opendatakit.briefcase.model.form.FormMetadata;
+import org.opendatakit.briefcase.model.form.InMemoryFormMetadataAdapter;
+import org.opendatakit.briefcase.pull.aggregate.PullFromAggregateIntegrationTest;
+import org.opendatakit.briefcase.reused.OverridableBoolean;
+import org.opendatakit.briefcase.util.BadFormDefinition;
+
+public class CustomFunctionTest {
+  private static Path getPath(String fileName) {
+    return Optional.ofNullable(PullFromAggregateIntegrationTest.class.getClassLoader().getResource("org/opendatakit/briefcase/" + fileName))
+        .map(url -> Paths.get(toURI(url)))
+        .orElseThrow(RuntimeException::new);
+  }
+
+  @Test
+  public void name() {
+    FormDefinition.from(getPath("custom-function-form.xml"));
+  }
+
+  @Test
+  public void full_regression_test() throws IOException, BadFormDefinition {
+    Path exportDir = createTempDirectory("briefcase-test-export-dir-");
+    Path sourceFormFile = getPath("custom-function-form.xml");
+    Path briefcaseDir = createTempDirectory("briefcase-test-storage-dir-");
+    Path formFile = briefcaseDir.resolve("Custom function form").resolve("Custom function form.xml");
+    createDirectories(formFile.getParent());
+    Files.copy(sourceFormFile, formFile);
+
+    FormMetadata formMetadata = FormMetadata.from(formFile);
+    InMemoryFormMetadataAdapter formMetadataPort = new InMemoryFormMetadataAdapter();
+    formMetadataPort.persist(formMetadata);
+    BriefcaseFormDefinition localFormDef = BriefcaseFormDefinition.resolveAgainstBriefcaseDefn(formFile.toFile(), false, briefcaseDir.toFile());
+    FormStatus formStatus = new FormStatus(localFormDef);
+
+    ExportConfiguration configuration = new ExportConfiguration(
+        Optional.<String>empty(),
+        Optional.of(exportDir),
+        Optional.<Path>empty(),
+        DateRange.empty(),
+        OverridableBoolean.FALSE,
+        OverridableBoolean.TRUE,
+        OverridableBoolean.TRUE,
+        OverridableBoolean.FALSE,
+        OverridableBoolean.FALSE,
+        OverridableBoolean.FALSE,
+        OverridableBoolean.FALSE
+    );
+    ExportToCsv.export(formMetadataPort, formMetadata, formStatus, FormDefinition.from(localFormDef), briefcaseDir, configuration);
+  }
+}

--- a/test/resources/org/opendatakit/briefcase/custom-function-form.xml
+++ b/test/resources/org/opendatakit/briefcase/custom-function-form.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+  <h:head>
+    <h:title>Custom function form</h:title>
+    <model>
+      <instance>
+        <data id="custom-function-form">
+          <some-field/>
+          <some-field-trimmed/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </data>
+      </instance>
+      <bind nodeset="/data/some-field" type="string"/>
+      <bind nodeset="/data/some-field-trimmed" type="string" calculate="trim(/data/some-field)"/>
+      <bind calculate="concat('uuid:', uuid())" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/data/some-field">
+      <label>Some field</label>
+    </input>
+  </h:body>
+</h:html>


### PR DESCRIPTION
Closes #796 

Use this form to test the PR: [custom-function-form.txt](https://github.com/opendatakit/briefcase/files/3604685/custom-function-form.txt)

#### What has been done to verify that this works as intended?
Added an automated regression test

#### Why is this the best possible solution? Were any other approaches considered?
A brute force approach that used actual exception messages was considered to provide a quick&dirty solution that didn't require changes in JR, but we ultimately thought it was better to add a method in JR to provide fallback function handlers that would prevent the error from #796.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should be a narrow change that only prevents the issue from #796

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.