### PR TITLE
Issue #799 Fix getting form name for form keys

### DIFF
--- a/src/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -230,7 +230,7 @@ public class BaseFormParserForJavaRosa implements Serializable {
   /**
    * The XForm definition in XML
    */
-  protected final String xml;
+  public final String xml;
 
   // original bindings from parse-time for later comparison
   private transient final List<Element> bindElements = new ArrayList<>();

--- a/test/java/org/opendatakit/briefcase/model/form/FormKeyTest.java
+++ b/test/java/org/opendatakit/briefcase/model/form/FormKeyTest.java
@@ -17,13 +17,13 @@ import org.opendatakit.briefcase.util.BadFormDefinition;
 public class FormKeyTest {
   @Test
   public void regression_wrong_form_name_when_creating_keys_from_briefcase_form_defs() throws BadFormDefinition, URISyntaxException, IOException {
-    String sanitizedName = stripIllegalChars("this-title-has-dashes");
+    String sanitizedName = stripIllegalChars("this-title-has-dashes/and/slashes");
     Path briefcaseFolder = Files.createTempDirectory("briefcase");
     Path formFile = briefcaseFolder.resolve("forms").resolve(sanitizedName).resolve(sanitizedName + ".xml");
-    Path sourceFormFile = getPath("title-with-dashes-form.xml");
+    Path sourceFormFile = getPath("form-with-special-chars.xml");
     Files.createDirectories(formFile.getParent());
     Files.copy(sourceFormFile, formFile);
-    FormKey key1 = FormKey.of("this-title-has-dashes", "this-id-has-dashes");
+    FormKey key1 = FormKey.of("this-title-has-dashes/and/slashes", "this-id-has-dashes/and/slashes");
     FormKey key2 = FormKey.from(new FormStatus(BriefcaseFormDefinition.resolveAgainstBriefcaseDefn(formFile.toFile(), false, briefcaseFolder.toFile())));
     assertThat(key1, is(key2));
   }

--- a/test/java/org/opendatakit/briefcase/model/form/FormKeyTest.java
+++ b/test/java/org/opendatakit/briefcase/model/form/FormKeyTest.java
@@ -1,0 +1,30 @@
+package org.opendatakit.briefcase.model.form;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.opendatakit.briefcase.ui.pull.FormInstallerTest.getPath;
+import static org.opendatakit.briefcase.util.StringUtils.stripIllegalChars;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Test;
+import org.opendatakit.briefcase.model.BriefcaseFormDefinition;
+import org.opendatakit.briefcase.model.FormStatus;
+import org.opendatakit.briefcase.util.BadFormDefinition;
+
+public class FormKeyTest {
+  @Test
+  public void regression_wrong_form_name_when_creating_keys_from_briefcase_form_defs() throws BadFormDefinition, URISyntaxException, IOException {
+    String sanitizedName = stripIllegalChars("this-title-has-dashes");
+    Path briefcaseFolder = Files.createTempDirectory("briefcase");
+    Path formFile = briefcaseFolder.resolve("forms").resolve(sanitizedName).resolve(sanitizedName + ".xml");
+    Path sourceFormFile = getPath("title-with-dashes-form.xml");
+    Files.createDirectories(formFile.getParent());
+    Files.copy(sourceFormFile, formFile);
+    FormKey key1 = FormKey.of("this-title-has-dashes", "this-id-has-dashes");
+    FormKey key2 = FormKey.from(new FormStatus(BriefcaseFormDefinition.resolveAgainstBriefcaseDefn(formFile.toFile(), false, briefcaseFolder.toFile())));
+    assertThat(key1, is(key2));
+  }
+}

--- a/test/java/org/opendatakit/briefcase/ui/pull/FormInstallerTest.java
+++ b/test/java/org/opendatakit/briefcase/ui/pull/FormInstallerTest.java
@@ -209,7 +209,7 @@ public class FormInstallerTest {
     return new FormStatus(new OdkCollectFormDefinition(formPath.toFile()));
   }
 
-  private static Path getPath(String fileName) throws URISyntaxException {
+  public static Path getPath(String fileName) throws URISyntaxException {
     return Paths.get(FormInstallerTest.class.getClassLoader().getResource(fileName).toURI());
   }
 

--- a/test/resources/form-with-special-chars.xml
+++ b/test/resources/form-with-special-chars.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
   <h:head>
-    <h:title>this-title-has-dashes</h:title>
+    <h:title>this-title-has-dashes/and/slashes</h:title>
     <model>
       <instance>
-        <data id="this-id-has-dashes">
+        <data id="this-id-has-dashes/and/slashes">
           <some-field/>
           <meta>
             <instanceID/>

--- a/test/resources/title-with-dashes-form.xml
+++ b/test/resources/title-with-dashes-form.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+  <h:head>
+    <h:title>this-title-has-dashes</h:title>
+    <model>
+      <instance>
+        <data id="this-id-has-dashes">
+          <some-field/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </data>
+      </instance>
+      <bind nodeset="/data/some-field" type="string"/>
+      <bind calculate="concat('uuid:', uuid())" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/data/some-field">
+      <label>Some field</label>
+    </input>
+  </h:body>
+</h:html>


### PR DESCRIPTION
Closes #799

#### What has been done to verify that this works as intended?
Added an automated regression test
 
#### Why is this the best possible solution? Were any other approaches considered?
This is not an optimal solution because it involves reparsing form definitions to get their names, but changing the underlying JavaRosaParserWrapper is much riskier because more code depends on that.

Also, this change will become irrelevant once we have v2.0, so it feels like we wont' be running into much problems anyway.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
There should be no changes in behavior due to this change.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.