### PR TITLE
Issue #801 Restore cookies to interact with Aggregate

### DIFF
--- a/src/org/opendatakit/briefcase/reused/http/Request.java
+++ b/src/org/opendatakit/briefcase/reused/http/Request.java
@@ -46,8 +46,9 @@ public class Request<T> {
   final Map<String, String> headers;
   private final Optional<InputStream> body;
   final List<MultipartMessage> multipartMessages;
+  private final boolean ignoreCookies;
 
-  Request(RequestMethod method, URL url, Optional<Credentials> credentials, Function<InputStream, T> responseMapper, Map<String, String> headers, Optional<InputStream> body, List<MultipartMessage> multipartMessages) {
+  Request(RequestMethod method, URL url, Optional<Credentials> credentials, Function<InputStream, T> responseMapper, Map<String, String> headers, Optional<InputStream> body, List<MultipartMessage> multipartMessages, boolean ignoreCookies) {
     this.method = method;
     this.url = url;
     this.credentials = credentials;
@@ -55,6 +56,7 @@ public class Request<T> {
     this.headers = headers;
     this.body = body;
     this.multipartMessages = multipartMessages;
+    this.ignoreCookies = ignoreCookies;
   }
 
   public T map(InputStream responseBody) {
@@ -91,7 +93,7 @@ public class Request<T> {
    * Returns a RequestBuilder that would produce this instance when built.
    */
   public RequestBuilder<T> builder() {
-    return new RequestBuilder<>(method, url, responseMapper, credentials, headers, body, multipartMessages);
+    return new RequestBuilder<>(method, url, responseMapper, credentials, headers, body, multipartMessages, ignoreCookies);
   }
 
   @Override
@@ -120,5 +122,9 @@ public class Request<T> {
 
   public InputStream getBody() {
     return body.orElseThrow(BriefcaseException::new);
+  }
+
+  public boolean ignoreCookies() {
+    return ignoreCookies;
   }
 }

--- a/src/org/opendatakit/briefcase/reused/transfer/CentralServer.java
+++ b/src/org/opendatakit/briefcase/reused/transfer/CentralServer.java
@@ -73,6 +73,7 @@ public class CentralServer implements RemoteServer {
   public Request<String> getProjectTestRequest(String token) {
     return RequestBuilder.get(baseUrl)
         .asText()
+        .withIgnoreCookies()
         .withPath("/v1/projects/" + projectId)
         .withHeader("Authorization", "Bearer " + token)
         .withResponseMapper(json -> json)
@@ -82,6 +83,7 @@ public class CentralServer implements RemoteServer {
   public Request<String> getSessionTokenRequest() {
     return RequestBuilder.post(baseUrl)
         .asJsonMap()
+        .withIgnoreCookies()
         .withPath("/v1/sessions")
         .withHeader("Content-Type", "application/json")
         .withBody(buildSessionPayload(credentials))
@@ -99,6 +101,7 @@ public class CentralServer implements RemoteServer {
 
   public Request<Void> getDownloadFormRequest(String formId, Path target, String token) {
     return RequestBuilder.get(baseUrl)
+        .withIgnoreCookies()
         .withPath("/v1/projects/" + projectId + "/forms/" + formId + ".xml")
         .withHeader("Authorization", "Bearer " + token)
         .downloadTo(target)
@@ -108,6 +111,7 @@ public class CentralServer implements RemoteServer {
   public Request<List<CentralAttachment>> getFormAttachmentListRequest(String formId, String token) {
     return RequestBuilder.get(baseUrl)
         .asJsonList(CentralAttachment.class)
+        .withIgnoreCookies()
         .withPath("/v1/projects/" + projectId + "/forms/" + formId + "/attachments")
         .withHeader("Authorization", "Bearer " + token)
         .build();
@@ -115,6 +119,7 @@ public class CentralServer implements RemoteServer {
 
   public Request<Void> getDownloadFormAttachmentRequest(String formId, CentralAttachment attachment, Path target, String token) {
     return RequestBuilder.get(baseUrl)
+        .withIgnoreCookies()
         .withPath("/v1/projects/" + projectId + "/forms/" + formId + "/attachments/" + attachment.getName())
         .withHeader("Authorization", "Bearer " + token)
         .downloadTo(target)
@@ -124,6 +129,7 @@ public class CentralServer implements RemoteServer {
   public Request<List<String>> getInstanceIdListRequest(String formId, String token) {
     return RequestBuilder.get(baseUrl)
         .asJsonList()
+        .withIgnoreCookies()
         .withPath("/v1/projects/" + projectId + "/forms/" + formId + "/submissions")
         .withHeader("Authorization", "Bearer " + token)
         .withResponseMapper(json -> json.stream().map(o -> (String) o.get("instanceId")).collect(toList()))
@@ -132,6 +138,7 @@ public class CentralServer implements RemoteServer {
 
   public Request<Void> getDownloadSubmissionRequest(String formId, String instanceId, Path target, String token) {
     return RequestBuilder.get(baseUrl)
+        .withIgnoreCookies()
         .withPath("/v1/projects/" + projectId + "/forms/" + formId + "/submissions/" + instanceId + ".xml")
         .withHeader("Authorization", "Bearer " + token)
         .downloadTo(target)
@@ -140,6 +147,7 @@ public class CentralServer implements RemoteServer {
 
   public Request<List<CentralAttachment>> getSubmissionAttachmentListRequest(String formId, String instanceId, String token) {
     return RequestBuilder.get(baseUrl)
+        .withIgnoreCookies()
         .asJsonList(CentralAttachment.class)
         .withPath("/v1/projects/" + projectId + "/forms/" + formId + "/submissions/" + instanceId + "/attachments")
         .withHeader("Authorization", "Bearer " + token)
@@ -148,6 +156,7 @@ public class CentralServer implements RemoteServer {
 
   public Request<Void> getDownloadSubmissionAttachmentRequest(String formId, String instanceId, CentralAttachment attachment, Path target, String token) {
     return RequestBuilder.get(baseUrl)
+        .withIgnoreCookies()
         .withPath("/v1/projects/" + projectId + "/forms/" + formId + "/submissions/" + instanceId + "/attachments/" + attachment.getName())
         .withHeader("Authorization", "Bearer " + token)
         .downloadTo(target)
@@ -163,6 +172,7 @@ public class CentralServer implements RemoteServer {
   public Request<Map<String, Object>> getPushFormRequest(Path formFile, String token) {
     return RequestBuilder.post(baseUrl)
         .asJsonMap()
+        .withIgnoreCookies()
         .withPath("/v1/projects/" + projectId + "/forms")
         .withHeader("Authorization", "Bearer " + token)
         .withHeader("Content-Type", "application/xml")
@@ -173,6 +183,7 @@ public class CentralServer implements RemoteServer {
   public Request<Map<String, Object>> getPushFormAttachmentRequest(String formId, Path attachment, String token) {
     return RequestBuilder.post(baseUrl)
         .asJsonMap()
+        .withIgnoreCookies()
         .withPath("/v1/projects/" + projectId + "/forms/" + formId + "/attachments/" + attachment.getFileName().toString())
         .withHeader("Authorization", "Bearer " + token)
         .withHeader("Content-Type", "*/*")
@@ -183,6 +194,7 @@ public class CentralServer implements RemoteServer {
   public Request<Map<String, Object>> getPushSubmissionRequest(String token, String formId, Path submission) {
     return RequestBuilder.post(baseUrl)
         .asJsonMap()
+        .withIgnoreCookies()
         .withPath("/v1/projects/" + projectId + "/forms/" + formId + "/submissions")
         .withHeader("Authorization", "Bearer " + token)
         .withHeader("Content-Type", "application/xml")
@@ -193,6 +205,7 @@ public class CentralServer implements RemoteServer {
   public Request<Map<String, Object>> getPushSubmissionAttachmentRequest(String token, String formId, String instanceId, Path attachment) {
     return RequestBuilder.post(baseUrl)
         .asJsonMap()
+        .withIgnoreCookies()
         .withPath("/v1/projects/" + projectId + "/forms/" + formId + "/submissions/" + instanceId + "/attachments/" + attachment.getFileName().toString())
         .withHeader("Authorization", "Bearer " + token)
         .withHeader("Content-Type", "*/*")
@@ -203,6 +216,7 @@ public class CentralServer implements RemoteServer {
   public Request<List<RemoteFormDefinition>> getFormsListRequest(String token) {
     return RequestBuilder.get(baseUrl)
         .asJsonList()
+        .withIgnoreCookies()
         .withPath("/v1/projects/" + projectId + "/forms")
         .withHeader("Authorization", "Bearer " + token)
         .withResponseMapper(list -> list.stream()


### PR DESCRIPTION
Closes #801

#### What has been done to verify that this works as intended?
Tested to push to Aggregate v2 (sandbox), Aggregate v1.17 in GAE, and Central (sandbox)

When pushing to Aggregate, I made sure to disable anonymous credentials to force Briefcase to use credentials and authenticate into the server.

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

In v1.16.3 we changed the cookie spec to IGNORE_COOKIES to work around an issue with multiple auth methods sent to Central servers. Doing so broke auth with Aggregate servers.

Since the cookie spec is set at an HTTP client level inside the executor, we can't create it each time we need to send a request because that would prevent requests to the same host to reuse connections. Having two executors (one with cookies, one without) is not an option either because it would leak too much of the internal workings.

Due to this, now we let the Request object tell the HTTP adapter when it needs to use cookies or not. Instead of ignoring cookies, we clear the cookie store before sending the request, which is not the same concept but achieves the same effect.


#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.