### PR TITLE
Issue #806 Metadata files should have relative paths

### DIFF
--- a/src/org/opendatakit/briefcase/export/ExportForms.java
+++ b/src/org/opendatakit/briefcase/export/ExportForms.java
@@ -34,11 +34,11 @@ import org.opendatakit.briefcase.model.FormStatus;
 public class ExportForms {
   private static final String EXPORT_DATE_PREFIX = "export_date_";
   private static final String CUSTOM_CONF_PREFIX = "custom_";
-  private final List<FormStatus> forms;
-  private ExportConfiguration defaultConfiguration;
   private final Map<String, ExportConfiguration> customConfigurations;
   private final Map<String, LocalDateTime> lastExportDateTimes;
   private final List<BiConsumer<String, LocalDateTime>> onSuccessfulExportCallbacks = new ArrayList<>();
+  private ExportConfiguration defaultConfiguration;
+  private List<FormStatus> forms;
   private Map<String, FormStatus> formsIndex = new HashMap<>();
 
   public ExportForms(List<FormStatus> forms, ExportConfiguration defaultConfiguration, Map<String, ExportConfiguration> configurations, Map<String, LocalDateTime> lastExportDateTimes) {
@@ -84,11 +84,7 @@ public class ExportForms {
   }
 
   public void merge(List<FormStatus> incomingForms) {
-    List<String> incomingFormIds = incomingForms.stream().map(ExportForms::getFormId).collect(toList());
-    List<FormStatus> formsToAdd = incomingForms.stream().filter(form -> !formsIndex.containsKey(getFormId(form))).collect(toList());
-    List<FormStatus> formsToRemove = formsIndex.values().stream().filter(form -> !incomingFormIds.contains(getFormId(form))).collect(toList());
-    forms.addAll(formsToAdd);
-    forms.removeAll(formsToRemove);
+    forms = new ArrayList<>(incomingForms);
     rebuildIndex();
   }
 

--- a/src/org/opendatakit/briefcase/export/ExportToCsv.java
+++ b/src/org/opendatakit/briefcase/export/ExportToCsv.java
@@ -126,7 +126,7 @@ public class ExportToCsv {
         .orElse(CsvLines.empty())
         .getLastLine()
         .ifPresent(line -> {
-          formMetadataPort.execute(updateLastExportedSubmission(formMetadata.getKey(), line.getInstanceId(), line.getSubmissionDate(), OffsetDateTime.now(), formStatus.getFormDir(briefcaseDir)));
+          formMetadataPort.execute(updateLastExportedSubmission(formMetadata.getKey(), line.getInstanceId(), line.getSubmissionDate(), OffsetDateTime.now(), briefcaseDir, formStatus.getFormDir(briefcaseDir)));
         });
 
     ExportOutcome exportOutcome = exportTracker.computeOutcome();

--- a/src/org/opendatakit/briefcase/model/form/FileSystemFormMetadataAdapter.java
+++ b/src/org/opendatakit/briefcase/model/form/FileSystemFormMetadataAdapter.java
@@ -2,6 +2,7 @@ package org.opendatakit.briefcase.model.form;
 
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.walk;
 import static org.opendatakit.briefcase.reused.UncheckedFiles.write;
@@ -13,6 +14,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -55,19 +57,21 @@ public class FileSystemFormMetadataAdapter implements FormMetadataPort {
     Stream<Path> formFiles = candidateFormFiles.filter(path -> isAForm(XmlElement.from(path)));
 
     // Parse existing metadata.json files or build new FormMetadata from form files
-    Stream<FormMetadata> metadataFiles = formFiles.map(formFile -> {
+    // At this point, we collect the stream to avoid problems coming
+    // from actually writing files in the same folders we're reading from
+    List<FormMetadata> metadataFiles = formFiles.map(formFile -> {
       Path formDir = formFile.getParent();
       Path metadataFile = formDir.resolve("metadata.json");
-      FormMetadata formMetadata = Files.exists(metadataFile) ? deserialize(metadataFile) : FormMetadata.from(formFile);
+      FormMetadata formMetadata = Files.exists(metadataFile) ? deserialize(storageRoot, metadataFile) : FormMetadata.from(storageRoot, formFile);
       if (!formMetadata.getCursor().isEmpty())
         return formMetadata;
       // Try to recover any missing cursor from the legacy Java prefs system
       return LegacyPrefs.readCursor(formMetadata.getKey().getId())
           .map(formMetadata::withCursor)
           .orElse(formMetadata);
-    });
+    }).collect(toList());
 
-    Map<FormKey, FormMetadata> forms = metadataFiles
+    Map<FormKey, FormMetadata> forms = metadataFiles.stream()
         .peek(this::persist) // Write updated metadata.json files
         .collect(toMap(FormMetadata::getKey, metadata -> metadata));
 
@@ -116,9 +120,8 @@ public class FileSystemFormMetadataAdapter implements FormMetadataPort {
   }
 
   // region Path <-> JSON <-> FormMetadata serialization
-  private static FormMetadata deserialize(Path metadataFile) {
-    JsonNode root = uncheckedReadTree(metadataFile);
-    return FormMetadata.from(root);
+  private static FormMetadata deserialize(Path storageRoot, Path metadataFile) {
+    return FormMetadata.from(storageRoot, uncheckedReadTree(metadataFile));
   }
 
   private static Path serialize(FormMetadata metaData) {
@@ -142,7 +145,7 @@ public class FileSystemFormMetadataAdapter implements FormMetadataPort {
   }
 
   private static Path getMetadataFile(FormMetadata metaData) {
-    return metaData.getStorageDirectory().resolve("metadata.json");
+    return metaData.getFormDir().resolve("metadata.json");
   }
   // endregion
 }

--- a/src/org/opendatakit/briefcase/model/form/FileSystemFormMetadataAdapter.java
+++ b/src/org/opendatakit/briefcase/model/form/FileSystemFormMetadataAdapter.java
@@ -24,7 +24,6 @@ import java.util.stream.Stream;
 import org.opendatakit.briefcase.export.XmlElement;
 import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.reused.LegacyPrefs;
-import org.opendatakit.briefcase.reused.UncheckedFiles;
 
 public class FileSystemFormMetadataAdapter implements FormMetadataPort {
   private static final ObjectMapper MAPPER = new ObjectMapper().findAndRegisterModules();
@@ -88,11 +87,6 @@ public class FileSystemFormMetadataAdapter implements FormMetadataPort {
 
   @Override
   public void flush() {
-    store.values()
-        .stream()
-        .map(FileSystemFormMetadataAdapter::getMetadataFile)
-        .filter(Files::exists)
-        .forEach(UncheckedFiles::delete);
     store.clear();
   }
 

--- a/src/org/opendatakit/briefcase/model/form/FormMetadataCommands.java
+++ b/src/org/opendatakit/briefcase/model/form/FormMetadataCommands.java
@@ -7,12 +7,12 @@ import java.util.function.Consumer;
 import org.opendatakit.briefcase.pull.aggregate.Cursor;
 
 public class FormMetadataCommands {
-  public static Consumer<FormMetadataPort> updateAsPulled(FormKey key, Cursor cursor, Path storageDirectory) {
+  public static Consumer<FormMetadataPort> updateAsPulled(FormKey key, Cursor cursor, Path storageRoot, Path formDir) {
     return port -> {
       Optional<FormMetadata> fetch = port
           .fetch(key);
       FormMetadata formMetadata = fetch
-          .orElseGet(() -> FormMetadata.of(key, storageDirectory));
+          .orElseGet(() -> FormMetadata.of(key, storageRoot, formDir));
       FormMetadata formMetadata1 = formMetadata
           .withHasBeenPulled(true)
           .withCursor(cursor);
@@ -20,17 +20,17 @@ public class FormMetadataCommands {
     };
   }
 
-  public static Consumer<FormMetadataPort> updateAsPulled(FormKey key, Path storageDirectory) {
+  public static Consumer<FormMetadataPort> updateAsPulled(FormKey key, Path storageRoot, Path formDir) {
     return port -> port.persist(port
         .fetch(key)
-        .orElseGet(() -> FormMetadata.of(key, storageDirectory))
+        .orElseGet(() -> FormMetadata.of(key, storageRoot, formDir))
         .withHasBeenPulled(true));
   }
 
-  public static Consumer<FormMetadataPort> updateLastExportedSubmission(FormKey key, String instanceId, OffsetDateTime submissionDate, OffsetDateTime exportDateTime, Path storageDirectory) {
+  public static Consumer<FormMetadataPort> updateLastExportedSubmission(FormKey key, String instanceId, OffsetDateTime submissionDate, OffsetDateTime exportDateTime, Path storageRoot, Path formDir) {
     return port -> port.persist(port
         .fetch(key)
-        .orElseGet(() -> FormMetadata.of(key, storageDirectory))
+        .orElseGet(() -> FormMetadata.of(key, storageRoot, formDir))
         .withLastExportedSubmission(instanceId, submissionDate, exportDateTime));
   }
 

--- a/src/org/opendatakit/briefcase/pull/aggregate/PullFromAggregate.java
+++ b/src/org/opendatakit/briefcase/pull/aggregate/PullFromAggregate.java
@@ -152,7 +152,7 @@ public class PullFromAggregate {
           tracker.trackEnd();
           Cursor newCursor = getLastCursor(instanceIdBatches).orElse(Cursor.empty());
 
-          formMetadataPort.execute(updateAsPulled(key, newCursor, form.getFormDir(briefcaseDir)));
+          formMetadataPort.execute(updateAsPulled(key, newCursor, briefcaseDir, form.getFormDir(briefcaseDir)));
 
           EventBus.publish(PullEvent.Success.of(form, server));
         });

--- a/src/org/opendatakit/briefcase/pull/central/PullFromCentral.java
+++ b/src/org/opendatakit/briefcase/pull/central/PullFromCentral.java
@@ -112,7 +112,7 @@ public class PullFromCentral {
               });
           tracker.trackEnd();
 
-          formMetadataPort.execute(updateAsPulled(key, form.getFormDir(briefcaseDir)));
+          formMetadataPort.execute(updateAsPulled(key, briefcaseDir, form.getFormDir(briefcaseDir)));
           EventBus.publish(PullEvent.Success.of(form, server));
         }));
   }

--- a/src/org/opendatakit/briefcase/ui/settings/SettingsPanel.java
+++ b/src/org/opendatakit/briefcase/ui/settings/SettingsPanel.java
@@ -53,13 +53,14 @@ public class SettingsPanel {
     form.onStorageLocation(path -> {
       Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(path);
       UncheckedFiles.createBriefcaseDir(briefcaseDir);
+      formCache.unsetLocation();
       formCache.setLocation(briefcaseDir);
       formCache.update();
       appPreferences.setStorageDir(path);
+      formMetadataPort.flush();
       formMetadataPort.syncWithFilesAt(briefcaseDir);
     }, () -> {
       formCache.unsetLocation();
-      formCache.update();
       appPreferences.unsetStorageDir();
       formMetadataPort.flush();
     });

--- a/src/org/opendatakit/briefcase/util/FormCache.java
+++ b/src/org/opendatakit/briefcase/util/FormCache.java
@@ -86,6 +86,7 @@ public class FormCache {
   }
 
   public void unsetLocation() {
+    cacheFile.ifPresent(UncheckedFiles::delete);
     briefcaseDir = Optional.empty();
     cacheFile = Optional.empty();
     hashByPath = new HashMap<>();

--- a/test/java/org/opendatakit/briefcase/export/ExportToCsvScenario.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportToCsvScenario.java
@@ -169,6 +169,7 @@ class ExportToCsvScenario {
     FormKey formKey = FormKey.of(formDef.getFormName(), formDef.getFormId());
     FormMetadata formMetadata = new FormMetadata(
         formKey,
+        briefcaseDir,
         formDef.getFormDir().resolve(stripIllegalChars(formDef.getFormName()) + ".xml"),
         true,
         Cursor.empty(),

--- a/test/java/org/opendatakit/briefcase/model/form/FormMetadataCommandsTest.java
+++ b/test/java/org/opendatakit/briefcase/model/form/FormMetadataCommandsTest.java
@@ -24,28 +24,29 @@ import org.opendatakit.briefcase.pull.aggregate.Cursor;
 
 public class FormMetadataCommandsTest {
 
-  private static final Path storageDirectory = Paths.get("/some/path/to/the/form");
+  private static final Path storageRoot = Paths.get("/some/path");
+  private static final Path formDir = storageRoot.resolve("forms/Some form");
   private FormKey key;
   private FormMetadataPort formMetadataPort;
 
   @Before
   public void setUp() {
     key = FormKey.of("Some form", "some-form");
-    FormMetadata formMetadata = new FormMetadata(key, storageDirectory, false, Cursor.empty(), Optional.empty());
+    FormMetadata formMetadata = new FormMetadata(key, storageRoot, formDir, false, Cursor.empty(), Optional.empty());
     formMetadataPort = new InMemoryFormMetadataAdapter();
     formMetadataPort.persist(formMetadata);
   }
 
   @Test
   public void updates_a_form_as_having_been_pulled() {
-    formMetadataPort.execute(updateAsPulled(key, storageDirectory));
+    formMetadataPort.execute(updateAsPulled(key, storageRoot, formDir));
     assertThat(formMetadataPort.fetch(key).get().hasBeenPulled(), is(true));
   }
 
   @Test
   public void updates_a_form_as_having_been_pulled_adding_the_last_cursor_used_to_pull_it() {
     Cursor cursor = Cursor.from("some cursor data");
-    formMetadataPort.execute(updateAsPulled(key, cursor, storageDirectory));
+    formMetadataPort.execute(updateAsPulled(key, cursor, storageRoot, formDir));
     FormMetadata formMetadata = formMetadataPort.fetch(key).get();
     assertThat(formMetadata.hasBeenPulled(), is(true));
     assertThat(formMetadata.getCursor(), is(cursor));
@@ -56,7 +57,7 @@ public class FormMetadataCommandsTest {
     OffsetDateTime expectedSubmissionDate = OffsetDateTime.parse("2019-01-01T00:00:00.000Z");
     String expectedInstanceId = "some uuid";
     OffsetDateTime expectedExportDate = OffsetDateTime.parse("2019-02-01T00:00:00.000Z");
-    formMetadataPort.execute(updateLastExportedSubmission(key, expectedInstanceId, expectedSubmissionDate, expectedExportDate, storageDirectory));
+    formMetadataPort.execute(updateLastExportedSubmission(key, expectedInstanceId, expectedSubmissionDate, expectedExportDate, storageRoot, formDir));
     FormMetadata formMetadata = formMetadataPort.fetch(key).get();
     assertThat(formMetadata.getLastExportedSubmission(), isPresent());
     // Indirectly assert that the submission metadata is OK by serializing into
@@ -86,6 +87,6 @@ public class FormMetadataCommandsTest {
   private FormMetadata buildFormMetadata(int number) {
     Paths.get("/some/path/forms/" + stripIllegalChars("Form #" + number));
     FormKey key = FormKey.of("Form #" + number, "form-" + number);
-    return new FormMetadata(key, storageDirectory, true, Cursor.from("some cursor data"), Optional.empty());
+    return new FormMetadata(key, storageRoot, formDir, true, Cursor.from("some cursor data"), Optional.empty());
   }
 }

--- a/test/java/org/opendatakit/briefcase/model/form/FormMetadataQueriesTest.java
+++ b/test/java/org/opendatakit/briefcase/model/form/FormMetadataQueriesTest.java
@@ -14,15 +14,16 @@ public class FormMetadataQueriesTest {
   @Test
   public void queries_the_last_cursor_of_a_form() {
     FormKey key = FormKey.of("Some form", "some-form");
-    Path storageDirectory = Paths.get("/some/path/to/the/form");
-    FormMetadata formMetadata = new FormMetadata(key, storageDirectory, false, Cursor.empty(), Optional.empty());
+    Path storageRoot = Paths.get("/some/path");
+    Path formDir = storageRoot.resolve("forms/Some form");
+    FormMetadata formMetadata = new FormMetadata(key, storageRoot, formDir, false, Cursor.empty(), Optional.empty());
     FormMetadataPort formMetadataPort = new InMemoryFormMetadataAdapter();
     formMetadataPort.persist(formMetadata);
 
     assertThat(formMetadataPort.query(lastCursorOf(key)), isPresentAndIs(Cursor.empty()));
 
     Cursor cursor = Cursor.from("some cursor");
-    formMetadataPort.execute(FormMetadataCommands.updateAsPulled(key, cursor, storageDirectory));
+    formMetadataPort.execute(FormMetadataCommands.updateAsPulled(key, cursor, storageRoot, formDir));
 
     assertThat(formMetadataPort.query(lastCursorOf(key)), isPresentAndIs(cursor));
   }

--- a/test/java/org/opendatakit/briefcase/model/form/FormMetadataTest.java
+++ b/test/java/org/opendatakit/briefcase/model/form/FormMetadataTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.OffsetDateTime;
 import java.util.Optional;
@@ -17,23 +18,20 @@ public class FormMetadataTest {
 
   @Test
   public void can_be_serialized_and_deserialized_into_and_from_JSON() {
+    Path storageRoot = Paths.get("/some/path");
     Stream.of(
         FormKey.of("Some form", "some-form"),
         FormKey.of("Some form", "some-form", "some numeric version")
     ).flatMap(key -> Stream.of(
-        new FormMetadata(key, Paths.get("/some/path"), true, Cursor.empty(), Optional.empty()),
-        new FormMetadata(key, Paths.get("/some/path"), false, Cursor.empty(), Optional.empty()),
-        new FormMetadata(key, Paths.get("/some/path"), true, Cursor.from("some cursor"), Optional.empty()),
-        new FormMetadata(key, Paths.get("/some/path"), false, Cursor.from("some cursor"), Optional.empty()),
-        new FormMetadata(key, Paths.get("/some/path"), true, Cursor.empty(), Optional.of(new SubmissionExportMetadata("some instance ID", SOME_DATE_TIME, SOME_DATE_TIME))),
-        new FormMetadata(key, Paths.get("/some/path"), false, Cursor.empty(), Optional.of(new SubmissionExportMetadata("some instance ID", SOME_DATE_TIME, SOME_DATE_TIME))),
-        new FormMetadata(key, Paths.get("/some/path"), true, Cursor.from("some cursor"), Optional.of(new SubmissionExportMetadata("some instance ID", SOME_DATE_TIME, SOME_DATE_TIME))),
-        new FormMetadata(key, Paths.get("/some/path"), false, Cursor.from("some cursor"), Optional.of(new SubmissionExportMetadata("some instance ID", SOME_DATE_TIME, SOME_DATE_TIME)))
-    )).forEach(formMetadata -> assertThat(FormMetadata.from(formMetadata.asJson(MAPPER)), is(formMetadata)));
+        new FormMetadata(key, storageRoot, Paths.get("forms/Some form"), true, Cursor.empty(), Optional.empty()),
+        new FormMetadata(key, storageRoot, Paths.get("forms/Some form"), false, Cursor.empty(), Optional.empty()),
+        new FormMetadata(key, storageRoot, Paths.get("forms/Some form"), true, Cursor.from("some cursor"), Optional.empty()),
+        new FormMetadata(key, storageRoot, Paths.get("forms/Some form"), false, Cursor.from("some cursor"), Optional.empty()),
+        new FormMetadata(key, storageRoot, Paths.get("forms/Some form"), true, Cursor.empty(), Optional.of(new SubmissionExportMetadata("some instance ID", SOME_DATE_TIME, SOME_DATE_TIME))),
+        new FormMetadata(key, storageRoot, Paths.get("forms/Some form"), false, Cursor.empty(), Optional.of(new SubmissionExportMetadata("some instance ID", SOME_DATE_TIME, SOME_DATE_TIME))),
+        new FormMetadata(key, storageRoot, Paths.get("forms/Some form"), true, Cursor.from("some cursor"), Optional.of(new SubmissionExportMetadata("some instance ID", SOME_DATE_TIME, SOME_DATE_TIME))),
+        new FormMetadata(key, storageRoot, Paths.get("forms/Some form"), false, Cursor.from("some cursor"), Optional.of(new SubmissionExportMetadata("some instance ID", SOME_DATE_TIME, SOME_DATE_TIME)))
+    )).forEach(formMetadata -> assertThat(FormMetadata.from(storageRoot, formMetadata.asJson(MAPPER)), is(formMetadata)));
   }
 
-  @Test
-  public void has_a_default_factory_from_form_keys() {
-
-  }
 }


### PR DESCRIPTION
Closes #806

#### What has been done to verify that this works as intended?
Fixed and run the automated tests
Manually pulled forms, changed the sd location, and exported them

#### Why is this the best possible solution? Were any other approaches considered?
This is the smallest change I could come up to be able to store relative paths while providing absolute paths to downstream code.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No risks here, just a fixed bug :)

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.