### PR TITLE
Issue 812 GUI fails to load after CLI used 

### DIFF
--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -87,7 +87,6 @@ public class PullFormFromAggregate {
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();
     BriefcasePreferences appPreferences = BriefcasePreferences.appScoped();
-    appPreferences.setStorageDir(briefcaseDir);
     FormMetadataPort formMetadataPort = FileSystemFormMetadataAdapter.at(briefcaseDir);
 
     int maxHttpConnections = Optionals.race(

--- a/src/org/opendatakit/briefcase/operations/PullFormFromCentral.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromCentral.java
@@ -70,7 +70,6 @@ public class PullFormFromCentral {
     FormCache formCache = FormCache.from(briefcaseDir);
     formCache.update();
     BriefcasePreferences appPreferences = BriefcasePreferences.appScoped();
-    appPreferences.setStorageDir(briefcaseDir);
     FormMetadataPort formMetadataPort = FileSystemFormMetadataAdapter.at(briefcaseDir);
 
     int maxHttpConnections = Optionals.race(


### PR DESCRIPTION
Closes #812

In this PR
- [ ] Pending to reproduce and fix the original issue reported in #812
- [x] Avoid losing prefs by runnnig a CLI op

#### What has been done to verify that this works as intended?
Testing of this PR involves this steps:
- Run the `-c` CLI op to clear all preferences
- Ensure the GUI environment is set and configured by running the GUI once and setting an sd
- Run a pull from Central CLI op
- Run the GUI again

In master, you are asked to set an sd for a second time, which shouldn't happen.

#### Why is this the best possible solution? Were any other approaches considered?
This is a super narrow fix. No other approaches were considered.

Somehow, setting the sd in the pull CLI ops was losing prefs for the GUI, and users were asked to set it again in the next GUI launch.

Also, setting the sd in CLI ops is not required (downstream code gets the briefcaseDir directly), so it's a safe change to do.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I tried to track uses of `BriefcasePreferences.getStorageDir()` in downstream code that would require the call to `BriefcasePreferences.setStorageDir()` I've removed and I found none. I could have missed something, though.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.
