### PR TITLE
Replace Java 11 API calls with Java 8 alternative calls

### DIFF
--- a/src/org/opendatakit/briefcase/pull/aggregate/OpaqueCursor.java
+++ b/src/org/opendatakit/briefcase/pull/aggregate/OpaqueCursor.java
@@ -23,7 +23,7 @@ public class OpaqueCursor implements Cursor {
 
   @Override
   public boolean isEmpty() {
-    return Optional.ofNullable(value).isEmpty();
+    return !Optional.ofNullable(value).isPresent();
   }
 
   @Override

--- a/test/java/org/opendatakit/briefcase/model/form/FormMetadataCommandsTest.java
+++ b/test/java/org/opendatakit/briefcase/model/form/FormMetadataCommandsTest.java
@@ -21,6 +21,7 @@ import java.util.stream.IntStream;
 import org.junit.Before;
 import org.junit.Test;
 import org.opendatakit.briefcase.pull.aggregate.Cursor;
+import org.opendatakit.briefcase.reused.BriefcaseException;
 
 public class FormMetadataCommandsTest {
 
@@ -79,7 +80,7 @@ public class FormMetadataCommandsTest {
         .stream()
         .map(FormMetadata::getKey)
         .forEach(key -> {
-          FormMetadata actualFormMetadata = formMetadataPort.fetch(key).orElseThrow();
+          FormMetadata actualFormMetadata = formMetadataPort.fetch(key).orElseThrow(BriefcaseException::new);
           assertThat(actualFormMetadata.getCursor().isEmpty(), is(true));
         });
   }


### PR DESCRIPTION
Closes #826 

#### What has been done to verify that this works as intended?
Compile the project and run the tests

#### Why is this the best possible solution? Were any other approaches considered?
The proposed alternative versions feel straightforward. No other approaches considered.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This shouldn't change Briefcase behavior at all.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.