### PR TITLE
Issue 824 relative paths in cli

### DIFF
--- a/src/org/opendatakit/briefcase/operations/Common.java
+++ b/src/org/opendatakit/briefcase/operations/Common.java
@@ -25,18 +25,18 @@ import org.opendatakit.briefcase.reused.http.RequestBuilder;
 import org.opendatakit.common.cli.Param;
 
 public class Common {
-  static final Param<String> STORAGE_DIR = Param.arg("sd", "storage_directory", "Briefcase storage directory");
+  public static final Param<String> DEPRECATED_AGGREGATE_SERVER = Param.arg("url", "aggregate_url", "Aggregate server URL");
+  public static final Param<URL> SERVER_URL = Param.arg("U", "odk_url", "ODK Server URL", RequestBuilder::url);
+  public static final Param<Integer> MAX_HTTP_CONNECTIONS = Param.arg("mhc", "max_http_connections", "Maximum simultaneous HTTP connections (defaults to 8)", Integer::parseInt);
+  static final Param<Path> STORAGE_DIR = Param.arg("sd", "storage_directory", "Briefcase storage directory", Paths::get);
   static final Param<String> FORM_ID = Param.arg("id", "form_id", "Form ID");
   static final Param<Integer> PROJECT_ID = Param.arg("pid", "project_id", "ODK Project ID number", Integer::parseInt);
   static final Param<String> CREDENTIALS_USERNAME = Param.arg("u", "odk_username", "ODK Username");
   static final Param<String> CREDENTIALS_EMAIL = Param.arg("E", "odk_email", "ODK Email");
   static final Param<String> CREDENTIALS_PASSWORD = Param.arg("p", "odk_password", "ODK Password");
-  public static final Param<String> DEPRECATED_AGGREGATE_SERVER = Param.arg("url", "aggregate_url", "Aggregate server URL");
-  public static final Param<URL> SERVER_URL = Param.arg("U", "odk_url", "ODK Server URL", RequestBuilder::url);
-  public static final Param<Integer> MAX_HTTP_CONNECTIONS = Param.arg("mhc", "max_http_connections", "Maximum simultaneous HTTP connections (defaults to 8)", Integer::parseInt);
 
-  static Path getOrCreateBriefcaseDir(String storageDir) {
-    Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(Paths.get(storageDir));
+  static Path getOrCreateBriefcaseDir(Path storageDir) {
+    Path briefcaseDir = BriefcasePreferences.buildBriefcaseDir(storageDir);
     if (!Files.exists(briefcaseDir)) {
       System.err.println("The directory " + briefcaseDir.toString() + " doesn't exist. Creating it");
       UncheckedFiles.createBriefcaseDir(briefcaseDir);

--- a/src/org/opendatakit/briefcase/operations/Common.java
+++ b/src/org/opendatakit/briefcase/operations/Common.java
@@ -48,7 +48,7 @@ public class Common {
    * Returns an absolute path to the given string path, using the user.dir property
    * to resolve input relative paths if necessary
    */
-  private static Path absolutePath(String path) {
+  static Path absolutePath(String path) {
     Path storageDir = Paths.get(path);
     return storageDir.isAbsolute()
         ? storageDir

--- a/src/org/opendatakit/briefcase/operations/Common.java
+++ b/src/org/opendatakit/briefcase/operations/Common.java
@@ -28,12 +28,7 @@ public class Common {
   public static final Param<String> DEPRECATED_AGGREGATE_SERVER = Param.arg("url", "aggregate_url", "Aggregate server URL");
   public static final Param<URL> SERVER_URL = Param.arg("U", "odk_url", "ODK Server URL", RequestBuilder::url);
   public static final Param<Integer> MAX_HTTP_CONNECTIONS = Param.arg("mhc", "max_http_connections", "Maximum simultaneous HTTP connections (defaults to 8)", Integer::parseInt);
-  static final Param<Path> STORAGE_DIR = Param.arg("sd", "storage_directory", "Briefcase storage directory", path -> {
-    Path storageDir = Paths.get(path);
-    return storageDir.isAbsolute()
-        ? storageDir
-        : Paths.get(System.getProperty("user.dir")).resolve(storageDir);
-  });
+  static final Param<Path> STORAGE_DIR = Param.arg("sd", "storage_directory", "Briefcase storage directory", Common::absolutePath);
   static final Param<String> FORM_ID = Param.arg("id", "form_id", "Form ID");
   static final Param<Integer> PROJECT_ID = Param.arg("pid", "project_id", "ODK Project ID number", Integer::parseInt);
   static final Param<String> CREDENTIALS_USERNAME = Param.arg("u", "odk_username", "ODK Username");
@@ -47,5 +42,16 @@ public class Common {
       UncheckedFiles.createBriefcaseDir(briefcaseDir);
     }
     return briefcaseDir;
+  }
+
+  /**
+   * Returns an absolute path to the given string path, using the user.dir property
+   * to resolve input relative paths if necessary
+   */
+  private static Path absolutePath(String path) {
+    Path storageDir = Paths.get(path);
+    return storageDir.isAbsolute()
+        ? storageDir
+        : Paths.get(System.getProperty("user.dir")).resolve(storageDir);
   }
 }

--- a/src/org/opendatakit/briefcase/operations/Common.java
+++ b/src/org/opendatakit/briefcase/operations/Common.java
@@ -28,7 +28,12 @@ public class Common {
   public static final Param<String> DEPRECATED_AGGREGATE_SERVER = Param.arg("url", "aggregate_url", "Aggregate server URL");
   public static final Param<URL> SERVER_URL = Param.arg("U", "odk_url", "ODK Server URL", RequestBuilder::url);
   public static final Param<Integer> MAX_HTTP_CONNECTIONS = Param.arg("mhc", "max_http_connections", "Maximum simultaneous HTTP connections (defaults to 8)", Integer::parseInt);
-  static final Param<Path> STORAGE_DIR = Param.arg("sd", "storage_directory", "Briefcase storage directory", Paths::get);
+  static final Param<Path> STORAGE_DIR = Param.arg("sd", "storage_directory", "Briefcase storage directory", path -> {
+    Path storageDir = Paths.get(path);
+    return storageDir.isAbsolute()
+        ? storageDir
+        : Paths.get(System.getProperty("user.dir")).resolve(storageDir);
+  });
   static final Param<String> FORM_ID = Param.arg("id", "form_id", "Form ID");
   static final Param<Integer> PROJECT_ID = Param.arg("pid", "project_id", "ODK Project ID number", Integer::parseInt);
   static final Param<String> CREDENTIALS_USERNAME = Param.arg("u", "odk_username", "ODK Username");

--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -96,7 +96,7 @@ public class Export {
       Arrays.asList(PEM_FILE, EXCLUDE_MEDIA, OVERWRITE, START, END, PULL_BEFORE, SPLIT_SELECT_MULTIPLES, INCLUDE_GEOJSON_EXPORT, REMOVE_GROUP_NAMES, SMART_APPEND)
   );
 
-  public static void export(String storageDir, String formid, Path exportDir, String baseFilename, boolean exportMedia, boolean overwriteFiles, boolean pullBefore, Optional<LocalDate> startDate, Optional<LocalDate> endDate, Optional<Path> maybePemFile, boolean splitSelectMultiples, boolean includeGeoJsonExport, boolean removeGroupNames, boolean smartAppend) {
+  public static void export(Path storageDir, String formid, Path exportDir, String baseFilename, boolean exportMedia, boolean overwriteFiles, boolean pullBefore, Optional<LocalDate> startDate, Optional<LocalDate> endDate, Optional<Path> maybePemFile, boolean splitSelectMultiples, boolean includeGeoJsonExport, boolean removeGroupNames, boolean smartAppend) {
     CliEventsCompanion.attach(log);
     Path briefcaseDir = Common.getOrCreateBriefcaseDir(storageDir);
     FormCache formCache = FormCache.from(briefcaseDir);

--- a/src/org/opendatakit/briefcase/operations/Export.java
+++ b/src/org/opendatakit/briefcase/operations/Export.java
@@ -24,7 +24,6 @@ import static org.opendatakit.briefcase.reused.UncheckedFiles.createDirectories;
 import static org.opendatakit.briefcase.reused.http.Http.DEFAULT_HTTP_CONNECTIONS;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -61,13 +60,13 @@ import org.slf4j.LoggerFactory;
 public class Export {
   private static final Logger log = LoggerFactory.getLogger(Export.class);
   private static final Param<Void> EXPORT = Param.flag("e", "export", "Export a form");
-  private static final Param<Path> EXPORT_DIR = Param.arg("ed", "export_directory", "Export directory", Paths::get);
+  private static final Param<Path> EXPORT_DIR = Param.arg("ed", "export_directory", "Export directory", Common::absolutePath);
   private static final Param<String> FILE = Param.arg("f", "export_filename", "Filename for export operation");
   private static final Param<LocalDate> START = Param.localDate("start", "export_start_date", "Export start date (inclusive)");
   private static final Param<LocalDate> END = Param.localDate("end", "export_end_date", "Export end date (inclusive)");
   private static final Param<Void> EXCLUDE_MEDIA = Param.flag("em", "exclude_media_export", "Exclude media in export");
   private static final Param<Void> OVERWRITE = Param.flag("oc", "overwrite_csv_export", "Overwrite files during export");
-  private static final Param<Path> PEM_FILE = Param.arg("pf", "pem_file", "PEM file for form decryption", Paths::get);
+  private static final Param<Path> PEM_FILE = Param.arg("pf", "pem_file", "PEM file for form decryption", Common::absolutePath);
   private static final Param<Void> PULL_BEFORE = Param.flag("pb", "pull_before", "Pull before export");
   private static final Param<Void> SPLIT_SELECT_MULTIPLES = Param.flag("ssm", "split_select_multiples", "Split select multiple fields");
   private static final Param<Void> INCLUDE_GEOJSON_EXPORT = Param.flag("ig", "include_geojson", "Include a GeoJSON file with spatial data");

--- a/src/org/opendatakit/briefcase/operations/ImportFromODK.java
+++ b/src/org/opendatakit/briefcase/operations/ImportFromODK.java
@@ -20,7 +20,6 @@ import static org.opendatakit.briefcase.operations.Common.FORM_ID;
 import static org.opendatakit.briefcase.operations.Common.STORAGE_DIR;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Optional;
 import org.opendatakit.briefcase.model.FormStatus;
@@ -37,7 +36,7 @@ import org.slf4j.LoggerFactory;
 public class ImportFromODK {
   private static final Logger log = LoggerFactory.getLogger(ImportFromODK.class);
   private static final Param<Void> IMPORT = Param.flag("pc", "pull_collect", "Pull from Collect");
-  private static final Param<Path> ODK_DIR = Param.arg("od", "odk_directory", "ODK directory", Paths::get);
+  private static final Param<Path> ODK_DIR = Param.arg("od", "odk_directory", "ODK directory", Common::absolutePath);
 
   public static final Operation IMPORT_FROM_ODK = Operation.of(
       IMPORT,

--- a/src/org/opendatakit/briefcase/operations/ImportFromODK.java
+++ b/src/org/opendatakit/briefcase/operations/ImportFromODK.java
@@ -50,7 +50,7 @@ public class ImportFromODK {
       Arrays.asList(FORM_ID)
   );
 
-  public static void importODK(String storageDir, Path odkDir, Optional<String> formId) {
+  public static void importODK(Path storageDir, Path odkDir, Optional<String> formId) {
     CliEventsCompanion.attach(log);
     Path briefcaseDir = Common.getOrCreateBriefcaseDir(storageDir);
     FormCache formCache = FormCache.from(briefcaseDir);

--- a/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PullFormFromAggregate.java
@@ -81,7 +81,7 @@ public class PullFormFromAggregate {
       Arrays.asList(RESUME_LAST_PULL, INCLUDE_INCOMPLETE, FORM_ID, START_FROM_DATE, MAX_HTTP_CONNECTIONS)
   );
 
-  public static void pullFormFromAggregate(String storageDir, Optional<String> formId, String username, String password, URL server, boolean resumeLastPull, Optional<LocalDate> startFromDate, boolean includeIncomplete, Optional<Integer> maybeMaxHttpConnections) {
+  public static void pullFormFromAggregate(Path storageDir, Optional<String> formId, String username, String password, URL server, boolean resumeLastPull, Optional<LocalDate> startFromDate, boolean includeIncomplete, Optional<Integer> maybeMaxHttpConnections) {
     CliEventsCompanion.attach(log);
     Path briefcaseDir = Common.getOrCreateBriefcaseDir(storageDir);
     FormCache formCache = FormCache.from(briefcaseDir);

--- a/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
+++ b/src/org/opendatakit/briefcase/operations/PushFormToAggregate.java
@@ -68,7 +68,7 @@ public class PushFormToAggregate {
       Arrays.asList(FORCE_SEND_BLANK, MAX_HTTP_CONNECTIONS, FORM_ID)
   );
 
-  private static void pushFormToAggregate(String storageDir, Optional<String> formid, String username, String password, URL server, boolean forceSendBlank, Optional<Integer> maybeMaxConnections) {
+  private static void pushFormToAggregate(Path storageDir, Optional<String> formid, String username, String password, URL server, boolean forceSendBlank, Optional<Integer> maybeMaxConnections) {
     CliEventsCompanion.attach(log);
     Path briefcaseDir = Common.getOrCreateBriefcaseDir(storageDir);
     FormCache formCache = FormCache.from(briefcaseDir);

--- a/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
+++ b/src/org/opendatakit/briefcase/ui/BriefcaseCLI.java
@@ -21,6 +21,7 @@ import static org.opendatakit.briefcase.operations.Export.export;
 import static org.opendatakit.briefcase.operations.ImportFromODK.importODK;
 import static org.opendatakit.briefcase.operations.PullFormFromAggregate.pullFormFromAggregate;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -289,7 +290,7 @@ public class BriefcaseCLI {
     String password = cli.getOptionValue(ODK_PASSWORD);
     String server = cli.getOptionValue(AGGREGATE_URL);
     String formid = cli.getOptionValue(FORM_ID);
-    String storageDir = cli.getOptionValue(STORAGE_DIRECTORY);
+    Path storageDir = Paths.get(cli.getOptionValue(STORAGE_DIRECTORY));
     String fileName = cli.getOptionValue(EXPORT_FILENAME);
     String exportPath = cli.getOptionValue(EXPORT_DIRECTORY);
     String startDateString = cli.getOptionValue(EXPORT_START_DATE);


### PR DESCRIPTION
Closes #824

Test it with this JAR: [briefcase_p833.zip](https://github.com/opendatakit/briefcase/files/3863090/briefcase_p833.zip)

#### What has been done to verify that this works as intended?
- Run the automated tests
- Manually pulled forms from the sandbox using the CLI and providing relative paths in the `-sd` arg

#### Why is this the best possible solution? Were any other approaches considered?
Intercepting the value users provide as the storage directory while parsing CLI args feels like the smallest possible change and probably the safest place to do it.

Another approach would be to patch the particular place where the error was being produced, but that wouldn't get us rid of other similar undiscovered problems in other parts of the codebase.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The change will allow users to provide relative paths in the CLI. It shouldn't have unexpected behavior changes for users double-clicking the JAR file or manually launching the GUI from the shell, since the GUI always works with absolute paths.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.