### PR TITLE
Issue 831 ignore failing forms on startup

### DIFF
--- a/src/org/opendatakit/briefcase/model/form/FileSystemFormMetadataAdapter.java
+++ b/src/org/opendatakit/briefcase/model/form/FileSystemFormMetadataAdapter.java
@@ -86,7 +86,7 @@ public class FileSystemFormMetadataAdapter implements FormMetadataPort {
     try {
       root = XmlElement.from(path);
     } catch (BriefcaseException e) {
-      log.error("Couldn't parse form at {}", path);
+      log.error("Couldn't parse form at {}", path, e);
       return false;
     }
     return root.getName().equals("html")

--- a/src/org/opendatakit/briefcase/model/form/FileSystemFormMetadataAdapter.java
+++ b/src/org/opendatakit/briefcase/model/form/FileSystemFormMetadataAdapter.java
@@ -24,8 +24,11 @@ import java.util.stream.Stream;
 import org.opendatakit.briefcase.export.XmlElement;
 import org.opendatakit.briefcase.reused.BriefcaseException;
 import org.opendatakit.briefcase.reused.LegacyPrefs;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FileSystemFormMetadataAdapter implements FormMetadataPort {
+  private static final Logger log = LoggerFactory.getLogger(FileSystemFormMetadataAdapter.class);
   private static final ObjectMapper MAPPER = new ObjectMapper().findAndRegisterModules();
   private final Map<FormKey, FormMetadata> store = new ConcurrentHashMap<>();
 
@@ -79,7 +82,13 @@ public class FileSystemFormMetadataAdapter implements FormMetadataPort {
   }
 
   private boolean isAForm(Path path) {
-    XmlElement foo = XmlElement.from(path);
+    XmlElement foo;
+    try {
+      foo = XmlElement.from(path);
+    } catch (BriefcaseException e) {
+      log.error("Couldn't parse form at {}", path);
+      return false;
+    }
     return foo.getName().equals("html")
         && foo.findElements("head", "title").size() == 1
         && foo.findElements("head", "model", "instance").size() >= 1

--- a/src/org/opendatakit/briefcase/model/form/FileSystemFormMetadataAdapter.java
+++ b/src/org/opendatakit/briefcase/model/form/FileSystemFormMetadataAdapter.java
@@ -79,10 +79,11 @@ public class FileSystemFormMetadataAdapter implements FormMetadataPort {
   }
 
   private boolean isAForm(Path path, XmlElement root) {
-    return root.getName().equals("html")
-        && root.findElements("head", "title").size() == 1
-        && root.findElements("head", "model", "instance").size() >= 1
-        && root.findElements("body").size() == 1;
+    XmlElement foo = root;
+    return foo.getName().equals("html")
+        && foo.findElements("head", "title").size() == 1
+        && foo.findElements("head", "model", "instance").size() >= 1
+        && foo.findElements("body").size() == 1;
   }
 
   @Override

--- a/src/org/opendatakit/briefcase/model/form/FileSystemFormMetadataAdapter.java
+++ b/src/org/opendatakit/briefcase/model/form/FileSystemFormMetadataAdapter.java
@@ -53,7 +53,7 @@ public class FileSystemFormMetadataAdapter implements FormMetadataPort {
 
     // select XML files that look like forms by parsing them
     // and looking for key parts that all forms must have
-    Stream<Path> formFiles = candidateFormFiles.filter(path -> isAForm(path, XmlElement.from(path)));
+    Stream<Path> formFiles = candidateFormFiles.filter(path -> isAForm(path));
 
     // Parse existing metadata.json files or build new FormMetadata from form files
     // At this point, we collect the stream to avoid problems coming
@@ -78,7 +78,7 @@ public class FileSystemFormMetadataAdapter implements FormMetadataPort {
     return this;
   }
 
-  private boolean isAForm(Path path, XmlElement root) {
+  private boolean isAForm(Path path) {
     XmlElement foo = XmlElement.from(path);
     return foo.getName().equals("html")
         && foo.findElements("head", "title").size() == 1

--- a/src/org/opendatakit/briefcase/model/form/FileSystemFormMetadataAdapter.java
+++ b/src/org/opendatakit/briefcase/model/form/FileSystemFormMetadataAdapter.java
@@ -82,17 +82,17 @@ public class FileSystemFormMetadataAdapter implements FormMetadataPort {
   }
 
   private boolean isAForm(Path path) {
-    XmlElement foo;
+    XmlElement root;
     try {
-      foo = XmlElement.from(path);
+      root = XmlElement.from(path);
     } catch (BriefcaseException e) {
       log.error("Couldn't parse form at {}", path);
       return false;
     }
-    return foo.getName().equals("html")
-        && foo.findElements("head", "title").size() == 1
-        && foo.findElements("head", "model", "instance").size() >= 1
-        && foo.findElements("body").size() == 1;
+    return root.getName().equals("html")
+        && root.findElements("head", "title").size() == 1
+        && root.findElements("head", "model", "instance").size() >= 1
+        && root.findElements("body").size() == 1;
   }
 
   @Override

--- a/src/org/opendatakit/briefcase/model/form/FileSystemFormMetadataAdapter.java
+++ b/src/org/opendatakit/briefcase/model/form/FileSystemFormMetadataAdapter.java
@@ -79,7 +79,7 @@ public class FileSystemFormMetadataAdapter implements FormMetadataPort {
   }
 
   private boolean isAForm(Path path, XmlElement root) {
-    XmlElement foo = root;
+    XmlElement foo = XmlElement.from(path);
     return foo.getName().equals("html")
         && foo.findElements("head", "title").size() == 1
         && foo.findElements("head", "model", "instance").size() >= 1

--- a/src/org/opendatakit/briefcase/model/form/FileSystemFormMetadataAdapter.java
+++ b/src/org/opendatakit/briefcase/model/form/FileSystemFormMetadataAdapter.java
@@ -53,7 +53,7 @@ public class FileSystemFormMetadataAdapter implements FormMetadataPort {
 
     // select XML files that look like forms by parsing them
     // and looking for key parts that all forms must have
-    Stream<Path> formFiles = candidateFormFiles.filter(path -> isAForm(XmlElement.from(path)));
+    Stream<Path> formFiles = candidateFormFiles.filter(path -> isAForm(path, XmlElement.from(path)));
 
     // Parse existing metadata.json files or build new FormMetadata from form files
     // At this point, we collect the stream to avoid problems coming
@@ -78,7 +78,7 @@ public class FileSystemFormMetadataAdapter implements FormMetadataPort {
     return this;
   }
 
-  private boolean isAForm(XmlElement root) {
+  private boolean isAForm(Path path, XmlElement root) {
     return root.getName().equals("html")
         && root.findElements("head", "title").size() == 1
         && root.findElements("head", "model", "instance").size() >= 1

--- a/src/org/opendatakit/briefcase/model/form/FileSystemFormMetadataAdapter.java
+++ b/src/org/opendatakit/briefcase/model/form/FileSystemFormMetadataAdapter.java
@@ -53,7 +53,7 @@ public class FileSystemFormMetadataAdapter implements FormMetadataPort {
 
     // select XML files that look like forms by parsing them
     // and looking for key parts that all forms must have
-    Stream<Path> formFiles = candidateFormFiles.filter(path -> isAForm(path));
+    Stream<Path> formFiles = candidateFormFiles.filter(this::isAForm);
 
     // Parse existing metadata.json files or build new FormMetadata from form files
     // At this point, we collect the stream to avoid problems coming


### PR DESCRIPTION
Closes #831

#### What has been done to verify that this works as intended?
- Run automated tests
- Manually copied the form attached to #831 and verified that Briefcase can be launched

#### Why is this the best possible solution? Were any other approaches considered?
This is a straightforward change to ignore forms that can't be parsed while sync'ing files from the storage directory.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should solve the issue. Users should expect a new log message "Couldn't parse form at /foo/ODK Briefcase Storage/forms/bar/bar.xml" each time Briefcase isn't able to sync a form for parsing reasons. The full stacktrace would include the causing error. In this case, having replaced the last `>` with a `?` character:

```
2019-11-19 15:25:57,597 [main] ERROR o.o.b.m.f.FileSystemFormMetadataAdapter - Couldn't parse form at /tmp/cocotero/ODK Briefcase Storage/forms/fieldListSimpleTest/fieldListSimpleTest.xml
org.opendatakit.briefcase.reused.BriefcaseException: org.xmlpull.v1.XmlPullParserException: expected: '>' actual: '?' (position:END_TAG </h:html>@1:1553 in java.io.InputStreamReader@5bf8fa12) 
	at org.opendatakit.briefcase.export.XmlElement.from(XmlElement.java:94)
	at org.opendatakit.briefcase.model.form.FileSystemFormMetadataAdapter.isAForm(FileSystemFormMetadataAdapter.java:87)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:176)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at org.opendatakit.briefcase.model.form.FileSystemFormMetadataAdapter.syncWithFilesAt(FileSystemFormMetadataAdapter.java:74)
	at java.base/java.util.Optional.ifPresent(Optional.java:183)
	at org.opendatakit.briefcase.ui.MainBriefcaseWindow.<init>(MainBriefcaseWindow.java:115)
	at org.opendatakit.briefcase.ui.MainBriefcaseWindow.launchGUI(MainBriefcaseWindow.java:94)
	at org.opendatakit.briefcase.Launcher.lambda$main$0(Launcher.java:78)
	at org.opendatakit.common.cli.Cli.lambda$run$5(Cli.java:136)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at org.opendatakit.common.cli.Cli.run(Cli.java:136)
	at org.opendatakit.briefcase.Launcher.main(Launcher.java:90)
Caused by: org.xmlpull.v1.XmlPullParserException: expected: '>' actual: '?' (position:END_TAG </h:html>@1:1553 in java.io.InputStreamReader@5bf8fa12) 
	at org.kxml2.io.KXmlParser.exception(Unknown Source)
	at org.kxml2.io.KXmlParser.error(Unknown Source)
	at org.kxml2.io.KXmlParser.read(Unknown Source)
	at org.kxml2.io.KXmlParser.parseEndTag(Unknown Source)
	at org.kxml2.io.KXmlParser.nextImpl(Unknown Source)
	at org.kxml2.io.KXmlParser.nextToken(Unknown Source)
	at org.kxml2.kdom.Element.parse(Unknown Source)
	at org.kxml2.kdom.Node.parse(Unknown Source)
	at org.kxml2.kdom.Element.parse(Unknown Source)
	at org.kxml2.kdom.Node.parse(Unknown Source)
	at org.kxml2.kdom.Document.parse(Unknown Source)
	at org.opendatakit.briefcase.export.XmlElement.from(XmlElement.java:91)
	... 20 common frames omitted
```

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
