### PR TITLE
A solution for Bug #798

### DIFF
--- a/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
+++ b/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
@@ -22,7 +22,8 @@ import static org.opendatakit.briefcase.reused.job.Job.run;
 import static org.opendatakit.briefcase.ui.reused.UI.errorMessage;
 
 import java.util.Optional;
-import javax.swing.*;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
 
 import org.bushe.swing.event.EventBus;
 import org.bushe.swing.event.annotation.AnnotationProcessor;

--- a/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
+++ b/src/org/opendatakit/briefcase/ui/pull/PullPanel.java
@@ -22,7 +22,8 @@ import static org.opendatakit.briefcase.reused.job.Job.run;
 import static org.opendatakit.briefcase.ui.reused.UI.errorMessage;
 
 import java.util.Optional;
-import javax.swing.JPanel;
+import javax.swing.*;
+
 import org.bushe.swing.event.EventBus;
 import org.bushe.swing.event.annotation.AnnotationProcessor;
 import org.bushe.swing.event.annotation.EventSubscriber;
@@ -69,6 +70,7 @@ public class PullPanel {
 
     // Register callbacks to view events
     view.onSelect(source -> {
+      view.setWorking();
       this.source = Optional.of(source);
       source.storeSourcePrefs(tabPreferences, getStorePasswordsConsentProperty());
       onSource(view, forms, source);
@@ -125,10 +127,12 @@ public class PullPanel {
     JobsRunner.launchAsync(
         run(__ -> {
           forms.load(source.getFormList());
+          SwingUtilities.invokeLater(view::unsetWorking);
           view.refresh();
           updateActionButtons();
         }),
         cause -> {
+          SwingUtilities.invokeLater(view::unsetWorking);
           log.warn("Unable to load form list from {}", source.getDescription(), cause);
           errorMessage("Error Loading Forms", "Briefcase wasn't able to load forms using the configured source. Try Reload or Reset.");
         }


### PR DESCRIPTION
The bug was caused by the fact that the Source/Target panel has no information that the forms are being loaded from the server. Making a call to setWorking() in the current view makes the buttons in the Source/Target panel to go disabled until the unsetWorking method is call. I think this fixes the bug as the user won be able to click on reset (or reload) during the time the forms are being loaded, and also the user will have good feedback.

Closes #

#### What has been done to verify that this works as intended?

I was able to reproduce the bug before the fix, after the fix i cannot hit the reset button while loading.

#### Why is this the best possible solution? Were any other approaches considered?

It uses the already created method setWorking that is intended for this kind of behavior

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The user won be able to cancel the form loading process, but i think that is ok.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.

I dont think this need to be put explicitly in the documentation as is a minor fix.
